### PR TITLE
more framework updates for proper loading and reloading

### DIFF
--- a/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/AddPeopleAndRoles/ListPeopleAndRoles.vue
@@ -133,7 +133,7 @@ import { OrgPersonIF } from '@/interfaces'
   }
 })
 export default class ListPeopleAndRoles extends Mixins(CommonMixin, EntityFilterMixin) {
-  // Store Properties
+  // Props passed in to this component
   @Prop({ default: () => [] })
   private personList: Array<OrgPersonIF>
 

--- a/src/components/IncorporationAgreement/AgreementType.vue
+++ b/src/components/IncorporationAgreement/AgreementType.vue
@@ -69,22 +69,14 @@ export default class AgreementType extends Vue {
 
   // Global setters
   @Action setIncorporationAgreementStepData!: ActionBindingIF
-  @Action setIgnoreChanges!: ActionBindingIF
+  @Action setHaveChanges!: ActionBindingIF
 
   // Local properties
   private agreementType: string | null = null
 
   // Lifecycle methods
   private created (): void {
-    // temporarily ignore data changes
-    this.setIgnoreChanges(true)
-
     this.agreementType = this.agreementTypeState
-
-    // resume tracking data changes once page has loaded (in next tick)
-    Vue.nextTick(() => {
-      this.setIgnoreChanges(false)
-    })
   }
 
   mounted (): void {
@@ -92,6 +84,9 @@ export default class AgreementType extends Vue {
       valid: !!this.agreementType,
       agreementType: this.agreementType
     })
+
+    // now that all data is loaded, wait for things to stabilize and reset flag
+    Vue.nextTick(() => this.setHaveChanges(false))
   }
 
   private changeAgreementType (): void {

--- a/src/utils/auth-helper.ts
+++ b/src/utils/auth-helper.ts
@@ -18,7 +18,7 @@ function parseToken (token: string): any {
     }).join(''))
     return JSON.parse(base64)
   } catch (err) {
-    throw new Error('Error parsing token - ' + err)
+    throw new Error('Error parsing Keycloak token - ' + err)
   }
 }
 

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Mixins, Vue } from 'vue-property-decorator'
+import { Component, Emit, Mixins, Prop, Vue, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { featureFlags } from '@/utils'
 
@@ -45,8 +45,12 @@ export default class Alteration extends Mixins(LegalApiMixin, FilingTemplateMixi
   @Getter getShareClasses!: ShareClassIF[]
 
   // Global setters
-  @Action setIgnoreChanges!: ActionBindingIF
+  @Action setHaveChanges!: ActionBindingIF
   @Action setEntityType!: ActionBindingIF
+
+  /** Whether App is ready. */
+  @Prop({ default: false })
+  private appReady: boolean
 
   /** The id of the IA filing to alter. */
   // private get filingId (): number {
@@ -58,10 +62,13 @@ export default class Alteration extends Mixins(LegalApiMixin, FilingTemplateMixi
     return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
   }
 
-  /** Called when this component is mounted. */
-  private async mounted (): Promise<void> {
+  /** Called when App is ready and this component can load its data. */
+  @Watch('appReady')
+  private async onAppReady (val: boolean): Promise<void> {
+    // do not proceed if app is not ready
+    if (!val) return
+
     // do not proceed if we are not anthenticated
-    // (this component will be re-mounted after authentication)
     if (!this.isAuthenticated) return
 
     // do not proceed if FF is disabled
@@ -91,9 +98,6 @@ export default class Alteration extends Mixins(LegalApiMixin, FilingTemplateMixi
     //   return
     // }
 
-    // temporarily ignore data changes
-    this.setIgnoreChanges(true)
-
     // try to fetch data
     try {
       // fetch IA to alter
@@ -110,22 +114,27 @@ export default class Alteration extends Mixins(LegalApiMixin, FilingTemplateMixi
         filingTypeCode: FilingCodes.ALTERATION,
         entityType: EntityTypes.BCOMP
       }])
+
+      // tell App that we're finished loading
+      this.emitHaveData()
     } catch (err) {
       console.log(err) // eslint-disable-line no-console
       this.emitFetchError(err)
     }
 
-    // resume tracking data changes once page has loaded (in next tick)
-    Vue.nextTick(() => {
-      this.setIgnoreChanges(false)
-    })
+    // now that all data is loaded, wait for things to stabilize and reset flag
+    Vue.nextTick(() => this.setHaveChanges(false))
   }
 
-  /** Emits Fetch Error event for App to handle. */
+  /** Emits Fetch Error event. */
   @Emit('fetchError')
   private emitFetchError (message: string = ''): void {}
 
-  /** Emits new Filing Data to parent. */
+  /** Emits Have Data event. */
+  @Emit('haveData')
+  private emitHaveData (haveData: Boolean = true): void {}
+
+  /** Emits new Filing Data. */
   @Emit('filingData')
   private emitFilingData (filingData: FilingDataIF[]): void {}
 }

--- a/src/views/DefineCompany.vue
+++ b/src/views/DefineCompany.vue
@@ -112,7 +112,7 @@ export default class DefineCompany extends Mixins(EntityFilterMixin) {
   @Action setFolioNumber!: ActionBindingIF
   @Action setOfficeAddresses!: ActionBindingIF
   @Action setDefineCompanyStepValidity!: ActionBindingIF
-  @Action setIgnoreChanges!: ActionBindingIF
+  @Action setHaveChanges!: ActionBindingIF
 
   // Resources for template
   readonly BenefitCompanyStatementResource = BenefitCompanyStatementResource
@@ -126,18 +126,13 @@ export default class DefineCompany extends Mixins(EntityFilterMixin) {
 
   /** Called when component is created. */
   private created (): void {
-    // temporarily ignore data changes
-    this.setIgnoreChanges(true)
-
     // if no addresses were fetched, set default addresses
     if (!this.getOfficeAddresses.registeredOffice && !this.getOfficeAddresses.recordsOffice) {
       this.setDefaultAddresses()
     }
 
-    // resume tracking data changes once page has loaded (in next tick)
-    Vue.nextTick(() => {
-      this.setIgnoreChanges(false)
-    })
+    // now that all data is loaded, wait for things to stabilize and reset flag
+    Vue.nextTick(() => this.setHaveChanges(false))
   }
 
   /** Sets default addresses in filing. (Will get overwritten by a fetched draft filing if there is one.) */

--- a/src/views/auth/Signin.vue
+++ b/src/views/auth/Signin.vue
@@ -1,22 +1,32 @@
 <template>
-  <sbc-signin @sync-user-profile-ready="onSessionReady()" />
+  <sbc-signin @sync-user-profile-ready="onProfileReady()" />
 </template>
 
 <script lang="ts">
 // Libraries
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Emit, Vue } from 'vue-property-decorator'
 
 // Components
 import SbcSignin from 'sbc-common-components/src/components/SbcSignin.vue'
 
+/**
+ * Operation:
+ * 1. When this component is first loaded (ie, we are not authenticated) then the
+ *    SbcSgnin component will redirect us to log in.
+ * 2. When this component is reloaded (ie, we are now authenticated) then the
+ *    SbcSignin component will emit "sync-user-profile-ready".
+ */
 @Component({
   components: {
     SbcSignin
   }
 })
 export default class Signin extends Vue {
-  /** Called when Keycloak session is ready (ie, the user is authenticated). */
-  private async onSessionReady () {
+  /** Called when user profile is ready (ie, the user is authenticated). */
+  private onProfileReady () {
+    // let App know that data can now be loaded
+    this.emitProfileReady()
+
     if (this.$route.query.redirect) {
       // navigate to the route we originally came from
       this.$router.push(this.$route.query.redirect as string)
@@ -28,6 +38,10 @@ export default class Signin extends Vue {
       window.location.assign(businessesUrl)
     }
   }
+
+  /** Emits Profile Ready event. */
+  @Emit('profileReady')
+  private emitProfileReady (profileReady: boolean = true): void {}
 }
 </script>
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4553

*Description of changes:*
- added appReady to let views know when they can load data
- added profileReady so Signin can let App know when user is authed
- added haveData so views can let App know when to hide spinner
- added haveChanges so views can let App know whether to show Fee Summary
- simplified App create since it can be called without authentication
- created onProfileReady to load one-time app data
- updated initApp to load repeatable app data
- deleted unneeded onRouteChanged (now using events instea of route
change to init app)
- cleared haveChanges after view loading (cleaner than ignoring changes)
- updated views to load data in onAppReady and emit haveData when done
- updated Signin view to emit profileReady when authed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).