### PR TITLE
added "scroll to top" to OfficeAddresses

### DIFF
--- a/src/components/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/PeopleAndRoles/PeopleAndRoles.vue
@@ -87,12 +87,13 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { cloneDeep } from 'lodash'
 import { ActionBindingIF, IncorporationFilingIF, OrgPersonIF, RoleIF } from '@/interfaces'
 import { ActionTypes, EntityTypes, IncorporatorTypes, Modes, Roles } from '@/enums'
 import { OrgPerson, ListPeopleAndRoles } from '.'
+import { CommonMixin } from '@/mixins'
 
 @Component({
   components: {
@@ -100,7 +101,7 @@ import { OrgPerson, ListPeopleAndRoles } from '.'
     ListPeopleAndRoles
   }
 })
-export default class PeopleAndRoles extends Vue {
+export default class PeopleAndRoles extends Mixins(CommonMixin) {
   // Declarations for template
   readonly EntityTypes = EntityTypes
   readonly Roles = Roles
@@ -250,8 +251,7 @@ export default class PeopleAndRoles extends Vue {
     this.renderOrgPersonForm = false
 
     // as Vue has updated the visible sections, scroll back to the top of this component
-    const element: any = this.$el
-    Vue.nextTick(() => { window.scrollTo({ top: element.offsetTop, behavior: 'smooth' }) })
+    this.scrollToTop(this.$el)
   }
 
   /**

--- a/src/components/YourCompany/OfficeAddresses.vue
+++ b/src/components/YourCompany/OfficeAddresses.vue
@@ -569,6 +569,9 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
     this.storeAddresses()
 
     this.isEditing = false
+
+    // as Vue has updated the visible sections, scroll back to the top of this component
+    this.scrollToTop(this.$el)
   }
 
   /**
@@ -579,6 +582,9 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
     this.setLocalProperties()
 
     this.isEditing = false
+
+    // as Vue has updated the visible sections, scroll back to the top of this component
+    this.scrollToTop(this.$el)
   }
 
   /**

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -7,15 +7,23 @@ import { omit, isEqual } from 'lodash'
 @Component({})
 export default class CommonMixin extends Vue {
   /**
-   * Compares two objects while omitting specified properties from the comparison.
+   * Compares two objects while omitting a specified property from the comparison.
    *
-   * @param addressA The first object to compare
-   * @param addressB The second object to compare
-   * @param prop The property to omit during the comparison
+   * @param addressA the first object to compare
+   * @param addressB the second object to compare
+   * @param prop the property to omit during the comparison
    *
-   * @return boolean A boolean indicating a match of objects
+   * @return a boolean indicating a match of objects
    */
-  isSame (objA: {}, objB: {}, prop: string | null = null): boolean {
+  isSame (objA: {}, objB: {}, prop: string = null): boolean {
     return isEqual({ ...omit(objA, prop ? [prop] : []) }, { ...omit(objB, prop ? [prop] : []) })
+  }
+
+  /**
+   * Scrolls the window to the top of the specified element.
+   * @param element the element to scroll to the top of
+   */
+  scrollToTop (element: any): void {
+    Vue.nextTick(() => { window.scrollTo({ top: element.offsetTop, behavior: 'smooth' }) })
   }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5076

*Description of changes:*
- scrolled to top after office addresses edit/cancel
- moved method to common mixin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).