### PR TITLE
fixed misc People And Roles bugs

### DIFF
--- a/src/components/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -197,7 +197,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
   @Prop() private currentCompletingParty: OrgPersonIF
 
   /** Headers for the person table. */
-  readonly tableHeaders: Array<string> = ['Name', 'Mailing Address', 'Delivery Address', 'Roles']
+  readonly tableHeaders = ['Name', 'Mailing Address', 'Delivery Address', 'Roles']
 
   /**
    * Checks if specified org/person was added.
@@ -227,16 +227,16 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
   }
 
   /**
-   * Formats the org or person name for display.
-   * @param filing The filing body which contains the name/title.
-   * @returns The formatted org/person name.
+   * Returns the org or person full name for display.
+   * @param orgPerson the org/person object
+   * @returns the formatted name
    */
-  private formatName (filing: any): string {
-    if (filing?.officer?.orgName) {
-      return filing.officer.orgName
+  private formatName (orgPerson: OrgPersonIF): string {
+    if (orgPerson?.officer?.orgName) {
+      return orgPerson.officer.orgName
     }
-    if (filing?.officer) {
-      return `${filing.officer.firstName} ${filing.officer.middleName || ''} ${filing.officer.lastName}`
+    if (orgPerson?.officer) {
+      return this.formatFullName(orgPerson.officer)
     }
     return ''
   }

--- a/src/components/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/PeopleAndRoles/OrgPerson.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="add-edit-org-person">
+
     <confirm-dialog
       ref="reassignCpDialog"
       attach="#add-edit-org-person"
@@ -223,15 +224,15 @@ export default class OrgPerson extends Mixins(CommonMixin) {
   private orgPerson: OrgPersonIF = null
 
   /** Model value for org/person form validity. */
-  private orgPersonFormValid: boolean = true
+  private orgPersonFormValid = true
 
   // Address related properties
   private inProgressMailingAddress: AddressIF = undefined
   private inProgressDeliveryAddress: AddressIF = undefined
-  private inheritMailingAddress: boolean = true
-  private mailingAddressValid: boolean = false
-  private deliveryAddressValid: boolean = false
-  private reassignCompletingParty: boolean = false
+  private inheritMailingAddress = true
+  private mailingAddressValid = false
+  private deliveryAddressValid = false
+  private reassignCompletingParty = false
 
   /** Model value for roles checboxes. */
   private selectedRoles: Array<Roles> = []
@@ -294,16 +295,6 @@ export default class OrgPerson extends Mixins(CommonMixin) {
       isFormValid = (isFormValid && this.deliveryAddressValid)
     }
     return isFormValid
-  }
-
-  /** The formatted, current completing party's name. */
-  private get currentCompletingPartyName (): string {
-    let name = this.currentCompletingParty?.officer.firstName
-    if (this.currentCompletingParty?.officer.middleName) {
-      name += ` ${this.currentCompletingParty.officer.middleName}`
-    }
-    name += ` ${this.currentCompletingParty?.officer.lastName}`
-    return name
   }
 
   /** True if current data object is a person. */
@@ -400,28 +391,28 @@ export default class OrgPerson extends Mixins(CommonMixin) {
   }
 
   /**
-   * Prompts user whether to change the Completing Party.
-   * */
+   * Displays dialog to prompt user whether to change the Completing Party.
+   */
   private confirmReassignPerson () {
     // open confirmation dialog and wait for response
     this.$refs.reassignCpDialog.open(
       'Change Completing Party?',
-      this.reassignPersonErrorMessage(),
+      this.changeCpMessage,
       {
         width: '45rem',
         persistent: true,
         yes: 'Change Completing Party',
-        no: null,
-        cancel: 'Cancel'
+        no: 'Cancel',
+        cancel: null
       }
-    ).then(async (confirm) => {
+    ).then(confirm => {
       if (confirm) {
         // set flag to reassign CP when Done is clicked
         this.reassignCompletingParty = true
+      } else {
+        // remove the role
+        this.selectedRoles = this.selectedRoles.filter(r => r !== Roles.COMPLETING_PARTY)
       }
-    }).catch(() => {
-      // remove the role
-      this.selectedRoles = this.selectedRoles.filter(r => r !== Roles.COMPLETING_PARTY)
     })
   }
 
@@ -477,8 +468,10 @@ export default class OrgPerson extends Mixins(CommonMixin) {
     }
   }
 
-  private reassignPersonErrorMessage (): string {
-    return `The Completing Party role is already assigned to ${this.currentCompletingPartyName}.\n` +
+  /** The Completing Party change message. */
+  private get changeCpMessage (): string {
+    const currentCpName = this.formatFullName(this.currentCompletingParty?.officer)
+    return `The Completing Party role is already assigned to ${currentCpName}.\n` +
       'Selecting "Completing Party" here will change the Completing Party.'
   }
 

--- a/src/components/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/PeopleAndRoles/OrgPerson.vue
@@ -8,10 +8,12 @@
     <ul class="list add-person">
       <li class="add-person-container">
         <div class="meta-container">
+
           <label class="add-org-header" v-if="isPerson">
             <span v-if="isNaN(activeIndex)">Add Person</span>
             <span v-else>Edit Person</span>
           </label>
+
           <label class="add-org-header" v-if="isOrg">
             <span v-if="isNaN(activeIndex)">Add Corporation or Firm</span>
             <span v-else>Edit Corporation or Firm</span>
@@ -75,31 +77,27 @@
                 <label class="sub-header">Roles</label>
                 <v-row class="roles-row my-6">
                   <v-col cols="4" class="mt-0" v-if="isPerson">
-                    <div class="pa-1" :class="{'highlightedRole': isRoleLocked(Roles.COMPLETING_PARTY)}">
+                    <div class="pa-1">
                       <v-checkbox
                         id="cp-checkbox"
                         class="mt-1"
                         v-model="selectedRoles"
                         :value="Roles.COMPLETING_PARTY"
                         :label="Roles.COMPLETING_PARTY"
-                        :disabled="isRoleLocked(Roles.COMPLETING_PARTY)"
                         :rules="roleRules"
                         @change="assignCompletingPartyRole()"
                       />
                     </div>
                   </v-col>
                   <v-col cols="4" class="mt-0">
-                    <div class="pa-1" :class="{ 'highlightedRole': isRoleLocked(Roles.INCORPORATOR) ||
-                      orgPerson.officer.partyType === IncorporatorTypes.CORPORATION }"
-                    >
+                    <div class="pa-1" :class="{ 'highlightedRole': isOrg }">
                       <v-checkbox
                         id="incorp-checkbox"
                         class="mt-1"
                         v-model="selectedRoles"
                         :value="Roles.INCORPORATOR"
                         :label="Roles.INCORPORATOR"
-                        :disabled="isRoleLocked(Roles.INCORPORATOR) ||
-                          orgPerson.officer.partyType === IncorporatorTypes.CORPORATION"
+                        :disabled="isOrg"
                         :rules="roleRules"
                     />
                     </div>
@@ -162,8 +160,7 @@
                   :disabled="isNaN(activeIndex)"
                   @click="emitRemove(activeIndex)">Remove</v-btn>
                 <v-btn id="btn-done" large color="primary" class="ml-auto"
-                  @click="validateOrgPersonForm()"
-                  :disabled="!isFormValid">Done</v-btn>
+                  @click="validateOrgPersonForm()">Done</v-btn>
                 <v-btn id="btn-cancel" large outlined color="primary"
                   @click="resetAddPersonData(true)">Cancel</v-btn>
               </div>
@@ -290,11 +287,11 @@ export default class OrgPerson extends Mixins(CommonMixin) {
     v => (v?.length <= 155) || 'Cannot exceed 155 characters' // maximum character count
   ]
 
-  /* True if the form is valid. */
+  /** True if the form is valid. */
   private get isFormValid (): boolean {
     let isFormValid = (this.orgPersonFormValid && this.mailingAddressValid)
     if (this.isDirector && !this.inheritMailingAddress) {
-      isFormValid = isFormValid && this.deliveryAddressValid
+      isFormValid = (isFormValid && this.deliveryAddressValid)
     }
     return isFormValid
   }
@@ -320,7 +317,7 @@ export default class OrgPerson extends Mixins(CommonMixin) {
   }
 
   /**
-   * Called when component is created to set local properties.
+   * Called when component is created, to set local properties.
    */
   private created (): void {
     // safety check
@@ -365,9 +362,17 @@ export default class OrgPerson extends Mixins(CommonMixin) {
    * Called when user clicks Done button.
    */
   private validateOrgPersonForm (): void {
+    // validate the main form and address form(s)
+    this.$refs.orgPersonForm.validate()
+    this.$refs.mailingAddressNew.$refs.addressForm.validate()
+    if (this.$refs.deliveryAddressNew) {
+      this.$refs.deliveryAddressNew.$refs.addressForm.validate()
+    }
+
+    // only proceed if form is valid
     if (this.isFormValid) {
       const person = this.addPerson()
-      // only process if person has actually changed
+      // only process if org/person has actually changed
       if (this.hasPersonChanged(person)) {
         if (this.reassignCompletingParty) {
           this.emitRemoveCpRole()
@@ -470,10 +475,6 @@ export default class OrgPerson extends Mixins(CommonMixin) {
     if (emitEvent) {
       this.emitReset()
     }
-  }
-
-  private isRoleLocked (role: Roles): boolean {
-    return (this.orgPerson?.roles.some(r => r.roleType === role) && !isNaN(this.activeIndex))
   }
 
   private reassignPersonErrorMessage (): string {

--- a/src/components/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/PeopleAndRoles/PeopleAndRoles.vue
@@ -1,102 +1,119 @@
 <template>
-  <v-card flat id="people-and-roles">
-    <!-- Header -->
-    <div class="header-container">
-      <v-icon color="#38598A">mdi-account-multiple-plus</v-icon>
-      <label class="font-weight-bold pl-2">People and Roles</label>
-    </div>
+  <div id="people-and-roles">
 
-    <!-- Instructional Text -->
-    <div class="role-container pt-6 px-4">
-      This application must include the following:
-      <ul>
-        <li>
-          <v-icon v-if="cpValid" color="blue" class="cp-valid">mdi-check</v-icon>
-          <v-icon v-else color="red" class="cp-invalid">mdi-close</v-icon>
-          <span class="ml-2">The Completing Party</span>
-        </li>
-        <li>
-          <v-icon v-if="incorpValid" color="blue" class="incorp-valid">mdi-check</v-icon>
-          <v-icon v-else color="red" class="incorp-invalid">mdi-close</v-icon>
-          <span class="ml-2">At least one Incorporator</span>
-        </li>
-        <li>
-          <v-icon v-if="dirValid" color="blue" class="dir-valid">mdi-check</v-icon>
-          <v-icon v-else color="red" class="dir-invalid">mdi-close</v-icon>
-          <span class="ml-2">At least one Director</span>
-        </li>
-      </ul>
-    </div>
+    <confirm-dialog
+      ref="changeCpDialog"
+      attach="#people-and-roles"
+    />
 
-    <!-- Add Buttons -->
-    <div class="btn-container py-6 px-4">
-      <v-btn
-        id="btn-add-person"
-        outlined
-        color="primary"
-        :disabled="renderOrgPersonForm"
-        @click="initAdd([], IncorporatorTypes.PERSON)"
-      >
-        <v-icon>mdi-account-plus</v-icon>
-        <span>Add a Person</span>
-      </v-btn>
-      <v-btn
-        id="btn-add-corp"
-        outlined
-        color="primary"
-        class="ml-2"
-        :disabled="renderOrgPersonForm"
-        @click="initAdd([{ roleType: Roles.INCORPORATOR }], IncorporatorTypes.CORPORATION)"
-      >
-        <v-icon>mdi-domain-plus</v-icon>
-        <span>Add a Corporation or Firm</span>
-      </v-btn>
-      <v-btn
-        v-if="!cpValid"
-        id="btn-add-cp"
-        outlined
-        color="primary"
-        class="ml-2"
-        :disabled="renderOrgPersonForm"
-        @click="initAdd([{ roleType: Roles.COMPLETING_PARTY }], IncorporatorTypes.PERSON)"
-      >
-        <v-icon>mdi-account-plus-outline</v-icon>
-        <span>Add the Completing Party</span>
-      </v-btn>
-    </div>
+    <v-card flat>
+      <!-- Header -->
+      <div class="header-container">
+        <v-icon color="#38598A">mdi-account-multiple-plus</v-icon>
+        <label class="font-weight-bold pl-2">People and Roles</label>
+      </div>
 
-    <div class="list-container px-4">
-      <list-people-and-roles
-        :peopleAndRoles="getPeopleAndRoles"
-        :renderOrgPersonForm="renderOrgPersonForm"
-        :currentOrgPerson="currentOrgPerson"
-        :activeIndex="activeIndex"
-        :nextId="nextId"
-        :currentCompletingParty="currentCompletingParty"
-        @initEdit="initEdit($event)"
-        @addEdit="addEdit($event)"
-        @remove="remove($event)"
-        @undo="undo($event)"
-        @reset="reset()"
-        @removeCpRole="removeCpRole()"
-      />
-    </div>
-  </v-card>
+      <!-- Instructional Text -->
+      <div class="role-container pt-6 px-4">
+        This application must include the following:
+        <ul>
+          <li>
+            <v-icon v-if="cpValid" color="blue" class="cp-valid">mdi-check</v-icon>
+            <v-icon v-else color="red" class="cp-invalid">mdi-close</v-icon>
+            <span class="ml-2">The Completing Party</span>
+          </li>
+          <li>
+            <v-icon v-if="incorpValid" color="blue" class="incorp-valid">mdi-check</v-icon>
+            <v-icon v-else color="red" class="incorp-invalid">mdi-close</v-icon>
+            <span class="ml-2">At least one Incorporator</span>
+          </li>
+          <li>
+            <v-icon v-if="dirValid" color="blue" class="dir-valid">mdi-check</v-icon>
+            <v-icon v-else color="red" class="dir-invalid">mdi-close</v-icon>
+            <span class="ml-2">At least one Director</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Add Buttons -->
+      <div class="btn-container py-6 px-4">
+        <v-btn
+          id="btn-add-person"
+          outlined
+          color="primary"
+          :disabled="renderOrgPersonForm"
+          @click="initAdd([], IncorporatorTypes.PERSON)"
+        >
+          <v-icon>mdi-account-plus</v-icon>
+          <span>Add a Person</span>
+        </v-btn>
+        <v-btn
+          id="btn-add-corp"
+          outlined
+          color="primary"
+          class="ml-2"
+          :disabled="renderOrgPersonForm"
+          @click="initAdd([{ roleType: Roles.INCORPORATOR }], IncorporatorTypes.CORPORATION)"
+        >
+          <v-icon>mdi-domain-plus</v-icon>
+          <span>Add a Corporation or Firm</span>
+        </v-btn>
+        <v-btn
+          v-if="!cpValid"
+          id="btn-add-cp"
+          outlined
+          color="primary"
+          class="ml-2"
+          :disabled="renderOrgPersonForm"
+          @click="initAdd([{ roleType: Roles.COMPLETING_PARTY }], IncorporatorTypes.PERSON)"
+        >
+          <v-icon>mdi-account-plus-outline</v-icon>
+          <span>Add the Completing Party</span>
+        </v-btn>
+      </div>
+
+      <div class="list-container px-4">
+        <list-people-and-roles
+          :peopleAndRoles="getPeopleAndRoles"
+          :renderOrgPersonForm="renderOrgPersonForm"
+          :currentOrgPerson="currentOrgPerson"
+          :activeIndex="activeIndex"
+          :nextId="nextId"
+          :currentCompletingParty="currentCompletingParty"
+          @initEdit="initEdit($event)"
+          @addEdit="addEdit($event)"
+          @remove="remove($event)"
+          @undo="undo($event)"
+          @reset="reset()"
+          @removeCpRole="removeCpRole()"
+        />
+      </div>
+    </v-card>
+  </div>
 </template>
 
 <script lang="ts">
 import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { cloneDeep } from 'lodash'
-import { ActionBindingIF, IncorporationFilingIF, OrgPersonIF, RoleIF } from '@/interfaces'
+import { ActionBindingIF, ConfirmDialogType, IncorporationFilingIF, OrgPersonIF, RoleIF } from '@/interfaces'
 import { ActionTypes, IncorporatorTypes, CompareModes, Roles } from '@/enums'
+import { ConfirmDialog } from '@/components/dialogs'
 import { ListPeopleAndRoles } from '.'
 import { CommonMixin } from '@/mixins'
 
 @Component({
-  components: { ListPeopleAndRoles }
+  components: {
+    ConfirmDialog,
+    ListPeopleAndRoles
+  }
 })
 export default class PeopleAndRoles extends Mixins(CommonMixin) {
+  // Refs
+  $refs!: {
+    changeCpDialog: ConfirmDialogType
+  }
+
   // Declarations for template
   readonly Roles = Roles
   readonly IncorporatorTypes = IncorporatorTypes
@@ -137,10 +154,10 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
   }
 
   // Local properties
-  private renderOrgPersonForm: boolean = false
-  private activeIndex: number = NaN
+  private renderOrgPersonForm = false
+  private activeIndex = NaN
   private currentOrgPerson: OrgPersonIF = null
-  private nextId: number = NaN
+  private nextId = NaN
   private currentCompletingParty: OrgPersonIF = null
   private originalCompletingParty: OrgPersonIF = null
 
@@ -164,6 +181,11 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
     return (this.cpValid && this.incorpValid && this.dirValid)
   }
 
+  /** True if there are no orgs/persons with missing roles. */
+  private get noMissingRoles (): boolean {
+    return this.getPeopleAndRoles.every(p => p.roles.length > 0)
+  }
+
   /** True if we have any changes (from original IA). */
   private get hasChanges (): boolean {
     return this.getPeopleAndRoles.some(x => x.action)
@@ -176,6 +198,13 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
     return this.isRoleStaff
       ? this.originalCompletingParty?.officer.email
       : this.getUserEmail
+  }
+
+  /** The Completing Party change message. */
+  private get changeCpMessage (): string {
+    const currentCpName = this.formatFullName(this.currentCompletingParty?.officer)
+    return `The Completing Party role was re-assigned to ${currentCpName}.\n` +
+      'This undo will restore the original Completing Party.'
   }
 
   /**
@@ -251,7 +280,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
    * Undoes changes to the specified org/person.
    * @param index The index of the org/person to undo.
    */
-  private undo (index: number): void {
+  private async undo (index: number): Promise<void> {
     // make a copy so Vue reacts when we set the updated list
     const tempList = cloneDeep(this.getPeopleAndRoles)
 
@@ -269,31 +298,44 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
         // get ID of person to undo
         const id = person?.officer?.id
 
-        // get value of original person from original IA
+        // get copy of original person from original IA
         const parties = this.getOriginalIA?.incorporationApplication?.parties || []
-        const originalPerson = parties.find(x => x.officer.id === id)
+        const thisPerson = cloneDeep(parties.find(x => x.officer.id === id))
 
         // safety check
-        if (!originalPerson) {
+        if (!thisPerson) {
           // eslint-disable-next-line no-console
           console.log('Failed to find original person with id =', id)
           return
         }
 
-        // check if original person had CP role and another person has it now
-        const hadCp = originalPerson.roles.some(role => role.roleType === Roles.COMPLETING_PARTY)
-        // get the Completing Party
-        // (we update this record right in the temp list)
+        // check if original person had CP role
+        const hadCp = thisPerson.roles.some(role => role.roleType === Roles.COMPLETING_PARTY)
+
+        // check if an other person has CP role right now
+        // NB: we will update this record right in the temp list - no need to splice
         const otherPerson = this.getCompletingParty(tempList)
 
-        if (hadCp && otherPerson && (originalPerson.officer.id !== otherPerson.officer.id)) {
-          // remove the other CP and their email
-          otherPerson.roles = otherPerson.roles.filter(r => r.roleType !== Roles.COMPLETING_PARTY)
-          otherPerson.officer.email = null
+        // check if we would restore the original CP
+        if (hadCp && otherPerson && (thisPerson.officer.id !== otherPerson.officer.id)) {
+          // prompt user for confirmation
+          await this.confirmReassignCp().then(confirm => {
+            if (confirm) {
+              // remove the other person's CP role and their email
+              otherPerson.roles = otherPerson.roles.filter(r => r.roleType !== Roles.COMPLETING_PARTY)
+              otherPerson.officer.email = null
+            } else {
+              // remove this person's CP role and their email
+              thisPerson.roles = thisPerson.roles.filter(r => r.roleType !== Roles.COMPLETING_PARTY)
+              thisPerson.officer.email = null
+              // set action (since they lost their CP role)
+              thisPerson.action = ActionTypes.EDITED
+            }
+          })
         }
 
         // splice in the original person
-        tempList.splice(index, 1, originalPerson)
+        tempList.splice(index, 1, thisPerson)
         break
     }
 
@@ -301,7 +343,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
     this.setPeopleAndRoles(tempList)
 
     // update this component's 'valid' and 'changed' flags
-    this.setPeopleAndRolesValid(this.hasValidRoles)
+    this.setPeopleAndRolesValid(this.hasValidRoles && this.noMissingRoles)
     this.setPeopleAndRolesChanged(this.hasChanges)
 
     // reset state properties
@@ -335,7 +377,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
     this.setPeopleAndRoles(tempList)
 
     // update this component's 'valid' and 'changed' flags
-    this.setPeopleAndRolesValid(this.hasValidRoles)
+    this.setPeopleAndRolesValid(this.hasValidRoles && this.noMissingRoles)
     this.setPeopleAndRolesChanged(this.hasChanges)
 
     // reset state properties
@@ -362,7 +404,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
     this.setPeopleAndRoles(tempList)
 
     // update this component's 'valid' and 'changed' flags
-    this.setPeopleAndRolesValid(this.hasValidRoles)
+    this.setPeopleAndRolesValid(this.hasValidRoles && this.noMissingRoles)
     this.setPeopleAndRolesChanged(this.hasChanges)
 
     // reset state properties
@@ -404,6 +446,25 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
   }
 
   /**
+   * Displays dialog to prompt user whether to change the Completing Party.
+   * @returns a promise that is fulfilled/rejected when the user responds
+   */
+  private async confirmReassignCp (): Promise<any> {
+    // open confirmation dialog and wait for response
+    return this.$refs.changeCpDialog.open(
+      'Change Completing Party?',
+      this.changeCpMessage,
+      {
+        width: '45rem',
+        persistent: true,
+        yes: 'Restore original Completing Party',
+        no: 'Cancel',
+        cancel: null
+      }
+    )
+  }
+
+  /**
    * Gets the Completing Party in a specified org/person list.
    * @param list The list to search.
    * @returns The Completing Party if found, otherwise undefined.
@@ -432,7 +493,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
   @Watch('getPeopleAndRoles', { deep: true })
   private onPeopleAndRolesChanged (): void {
     this.currentCompletingParty = this.getCompletingParty(this.getPeopleAndRoles)
-    this.setPeopleAndRolesValid(this.hasValidRoles)
+    this.setPeopleAndRolesValid(this.hasValidRoles && this.noMissingRoles)
   }
 }
 </script>

--- a/src/components/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/PeopleAndRoles/PeopleAndRoles.vue
@@ -211,8 +211,9 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
    * Called when component is mounted.
    */
   private mounted (): void {
-    // initialize component 'changed' flag
-    this.setPeopleAndRolesChanged(false)
+    // initialize this component's 'valid' and 'changed' flags
+    this.setPeopleAndRolesValid(this.hasValidRoles && this.noMissingRoles)
+    this.setPeopleAndRolesChanged(this.hasChanges)
   }
 
   /**
@@ -227,7 +228,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
     // 2. filter in people with specified role
     const orgPersonWithSpecifiedRole = this.getPeopleAndRoles
       .filter(people => people.action !== ActionTypes.REMOVED)
-      .filter(people => people.roles.some(party => party.roleType === roleName))
+      .filter(people => people.roles.some(role => role.roleType === roleName))
 
     if (mode === CompareModes.EXACT) {
       return (orgPersonWithSpecifiedRole.length === count)
@@ -447,7 +448,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
 
   /**
    * Displays dialog to prompt user whether to change the Completing Party.
-   * @returns a promise that is fulfilled/rejected when the user responds
+   * @returns a promise that is resolved when the user responds
    */
   private async confirmReassignCp (): Promise<any> {
     // open confirmation dialog and wait for response

--- a/src/components/dialogs/ConfirmDialog.vue
+++ b/src/components/dialogs/ConfirmDialog.vue
@@ -5,6 +5,7 @@
     :max-width="options.width"
     :style="{ zIndex: options.zIndex }"
     :persistent="options.persistent"
+    :attach="attach"
     @keydown.esc="onClickCancel">
 
     <v-card>
@@ -56,7 +57,7 @@
  *   this.$root.$confirm = this.$refs.confirm.open
  * }
  */
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Prop, Vue } from 'vue-property-decorator'
 
 interface OptionsObject {
   width?: number | string,
@@ -69,6 +70,9 @@ interface OptionsObject {
 
 @Component({})
 export default class ConfirmDialog extends Vue {
+  /** Prop to provide attachment selector. */
+  @Prop() private attach: string
+
   /** Whether the subject dialog is currently displayed. */
   private dialog: boolean = false
 
@@ -106,6 +110,7 @@ export default class ConfirmDialog extends Vue {
     this.title = title
     this.message = message
     this.options = Object.assign(this.options, options)
+
     return new Promise((resolve, reject) => {
       this.resolve = resolve
       this.reject = reject

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -34,4 +34,17 @@ export default class CommonMixin extends Vue {
       if (!this.isJestRunning) window.scrollTo({ top: element.offsetTop, behavior: 'smooth' })
     })
   }
+
+  /**
+   * Returns the full (first-middle-last) name of the subject officer.
+   * @param officer the object to get the names from
+   * @returns the formatted full name string
+   */
+  formatFullName (officer: any): string {
+    let fullName: string = ''
+    if (officer?.firstName) fullName += officer.firstName + ' '
+    if (officer?.middleName) fullName += officer.middleName + ' '
+    if (officer?.lastName) fullName += officer.lastName
+    return fullName.trimRight()
+  }
 }

--- a/tests/unit/ListPeopleAndRoles.spec.ts
+++ b/tests/unit/ListPeopleAndRoles.spec.ts
@@ -78,7 +78,7 @@ const peopleAndRoles = [
       id: 2,
       firstName: 'Lawrence',
       lastName: 'Kavanagh',
-      middleName: 'H',
+      middleName: '',
       orgName: '',
       partyType: 'Person'
     },
@@ -108,7 +108,7 @@ const peopleAndRoles = [
       id: 3,
       firstName: 'Christy',
       lastName: 'Sawyer',
-      middleName: 'Z',
+      middleName: '',
       orgName: '',
       partyType: 'Person'
     },
@@ -219,9 +219,9 @@ describe('List People And Roles component', () => {
     expect(rows.at(0).find('.v-chip').exists()).toBe(false)
     expect(rows.at(1).find('.people-roles-title').text()).toBe('Random Food Distributors')
     expect(rows.at(1).find('.v-chip').text()).toBe('CORRECTED')
-    expect(rows.at(2).find('.people-roles-title').text()).toBe('Lawrence H Kavanagh')
+    expect(rows.at(2).find('.people-roles-title').text()).toBe('Lawrence Kavanagh')
     expect(rows.at(2).find('.v-chip').text()).toBe('ADDED')
-    expect(rows.at(3).find('.people-roles-title').text()).toBe('Christy Z Sawyer')
+    expect(rows.at(3).find('.people-roles-title').text()).toBe('Christy Sawyer')
     expect(rows.at(3).find('.v-chip').text()).toBe('REMOVED')
 
     wrapper.destroy()

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -219,9 +219,9 @@ describe('Org/Person component', () => {
       .toEqual(validPersonData['officer']['lastName'])
 
     // verify role checkboxes
-    expect(wrapper.find(completingPartyChkBoxSelector).attributes('aria-checked')).toBe("true")
-    expect(wrapper.find(incorporatorChkBoxSelector).attributes('aria-checked')).toBe("false")
-    expect(wrapper.find(directorChkBoxSelector).attributes('aria-checked')).toBe("true")
+    expect(wrapper.find(completingPartyChkBoxSelector).attributes('aria-checked')).toBe('true')
+    expect(wrapper.find(incorporatorChkBoxSelector).attributes('aria-checked')).toBe('false')
+    expect(wrapper.find(directorChkBoxSelector).attributes('aria-checked')).toBe('true')
 
     // verify that all role checkboxes are enabled
     expect(wrapper.find(completingPartyChkBoxSelector).attributes('disabled')).toBeUndefined()
@@ -247,11 +247,11 @@ describe('Org/Person component', () => {
 
     // verify role checkboxes
     expect(wrapper.find(completingPartyChkBoxSelector).exists()).toBe(false)
-    expect(wrapper.find(incorporatorChkBoxSelector).attributes('aria-checked')).toBe("true")
+    expect(wrapper.find(incorporatorChkBoxSelector).attributes('aria-checked')).toBe('true')
     expect(wrapper.find(directorChkBoxSelector).exists()).toBe(false)
 
     // verify that role checkbox is disabled (ie, role is locked)
-    expect(wrapper.find(incorporatorChkBoxSelector).attributes('disabled')).toBe("disabled")
+    expect(wrapper.find(incorporatorChkBoxSelector).attributes('disabled')).toBe('disabled')
 
     // verify action buttons
     expect(wrapper.find(doneButtonSelector).attributes('disabled')).toBeUndefined()
@@ -454,7 +454,7 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  // TODO
+  // TODO (move this to PeopleAndRoles.spec.ts)
   // it('Shows popup when undoing an edit would change the Completing Party', async () => {
   //   const wrapper = createComponent(validIncorporator, NaN, 0, validPersonData)
 

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -24,6 +24,8 @@ const middleNameSelector = '#person__middle-name'
 const lastNameSelector = '#person__last-name'
 const orgNameSelector = '#firm-name'
 const completingPartyChkBoxSelector = '#cp-checkbox'
+const incorporatorChkBoxSelector = '#incorp-checkbox'
+const directorChkBoxSelector = '#dir-checkbox'
 const removeButtonSelector = '#btn-remove'
 const doneButtonSelector = '#btn-done'
 const cancelButtonSelector = '#btn-cancel'
@@ -113,11 +115,34 @@ const validOrgData = {
   }
 }
 
+const emptyPerson = {
+  officer: {
+    id: null,
+    firstName: '',
+    lastName: '',
+    middleName: '',
+    orgName: '',
+    partyType: 'Person',
+    email: null
+  },
+  roles: [],
+  mailingAddress: {
+    streetAddress: '',
+    streetAddressAdditional: '',
+    addressCity: '',
+    addressRegion: '',
+    postalCode: '',
+    addressCountry: '',
+    deliveryInstructions: ''
+  },
+  action: null
+}
+
 /**
  * Returns the last event for a given name, to be used for testing event propagation in response to component changes.
- * @param wrapper the wrapper for the component that is being tested.
- * @param name the name of the event that is to be returned.
- * @returns the value of the last named event for the wrapper.
+ * @param wrapper the wrapper for the component that is being tested
+ * @param name the name of the event that is to be returned
+ * @returns the value of the last named event for the wrapper
  */
 function getLastEvent (wrapper: Wrapper<OrgPerson>, name: string): any {
   const eventsList = wrapper.emitted(name)
@@ -180,10 +205,12 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('Displays form data for person', async () => {
+  // NB: edit functions the same as add for a person
+  it('Displays edit form for person', async () => {
     const wrapper = createComponent(validPersonData, 0, null, null)
     await Vue.nextTick()
 
+    // verify person's name
     expect((wrapper.find(firstNameSelector).element as HTMLInputElement).value)
       .toEqual(validPersonData['officer']['firstName'])
     expect((wrapper.find(middleNameSelector).element as HTMLInputElement).value)
@@ -191,6 +218,17 @@ describe('Org/Person component', () => {
     expect((wrapper.find(lastNameSelector).element as HTMLInputElement).value)
       .toEqual(validPersonData['officer']['lastName'])
 
+    // verify role checkboxes
+    expect(wrapper.find(completingPartyChkBoxSelector).attributes('aria-checked')).toBe("true")
+    expect(wrapper.find(incorporatorChkBoxSelector).attributes('aria-checked')).toBe("false")
+    expect(wrapper.find(directorChkBoxSelector).attributes('aria-checked')).toBe("true")
+
+    // verify that all role checkboxes are enabled
+    expect(wrapper.find(completingPartyChkBoxSelector).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(incorporatorChkBoxSelector).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(directorChkBoxSelector).attributes('disabled')).toBeUndefined()
+
+    // verify action buttons
     expect(wrapper.find(doneButtonSelector).attributes('disabled')).toBeUndefined()
     expect(wrapper.find(removeButtonSelector).attributes('disabled')).toBeUndefined()
     expect(wrapper.find(cancelButtonSelector).attributes('disabled')).toBeUndefined()
@@ -198,13 +236,24 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('Displays form data for org', async () => {
+  // NB: add functions the same as edit for an org
+  it('Displays add form for org', async () => {
     const wrapper = createComponent(validOrgData, NaN, 0, null)
     await Vue.nextTick()
 
+    // verify org's name
     expect((wrapper.find(orgNameSelector).element as HTMLInputElement).value)
       .toEqual(validOrgData['officer']['orgName'])
 
+    // verify role checkboxes
+    expect(wrapper.find(completingPartyChkBoxSelector).exists()).toBe(false)
+    expect(wrapper.find(incorporatorChkBoxSelector).attributes('aria-checked')).toBe("true")
+    expect(wrapper.find(directorChkBoxSelector).exists()).toBe(false)
+
+    // verify that role checkbox is disabled (ie, role is locked)
+    expect(wrapper.find(incorporatorChkBoxSelector).attributes('disabled')).toBe("disabled")
+
+    // verify action buttons
     expect(wrapper.find(doneButtonSelector).attributes('disabled')).toBeUndefined()
     expect(wrapper.find(removeButtonSelector).attributes('disabled')).toBeDefined()
     expect(wrapper.find(cancelButtonSelector).attributes('disabled')).toBeUndefined()
@@ -212,7 +261,7 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('Remove button is enabled in edit mode', async () => {
+  it('Enables Remove button in edit mode', async () => {
     const wrapper = createComponent(validOrgData, 0, null, null)
 
     expect(wrapper.find(removeButtonSelector).attributes('disabled')).toBeUndefined()
@@ -220,7 +269,7 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('Remove button is disabled in create mode', async () => {
+  it('Disables Remove button in create mode', async () => {
     const wrapper = createComponent(validOrgData, NaN, 0, null)
 
     expect(wrapper.find(removeButtonSelector).attributes('disabled')).toBeDefined()
@@ -228,7 +277,7 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('Clicking Remove button emits "remove" event', async () => {
+  it('Emits "remove" event when clicking Remove button', async () => {
     const wrapper = createComponent(validOrgData, 0, null, null)
 
     wrapper.find(removeButtonSelector).trigger('click')
@@ -239,7 +288,7 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('Clicking Done button when org not changed emits "reset" event', async () => {
+  it('Emits "reset" event when clicking Done button and org has not changed', async () => {
     const wrapper = createComponent(validOrgData, 0, null, null)
     await Vue.nextTick()
 
@@ -256,7 +305,7 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('Clicking Done button when org changed emits "addEdit" event', async () => {
+  it('Emits "addEdit" event when clicking Done button and org has changed', async () => {
     const wrapper = createComponent(validOrgData, 0, null, null)
     await Vue.nextTick()
 
@@ -277,7 +326,7 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('Clicking Cancel button emits "reset" event', async () => {
+  it('Emits "reset" event when clicking Cancel button', async () => {
     const wrapper = createComponent(validOrgData, 0, null, null)
 
     wrapper.find(cancelButtonSelector).trigger('click')
@@ -405,7 +454,20 @@ describe('Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('Emits "removeCpRole" and "addEdit" events on reassigning completing party', async () => {
+  // TODO
+  // it('Shows popup when undoing an edit would change the Completing Party', async () => {
+  //   const wrapper = createComponent(validIncorporator, NaN, 0, validPersonData)
+
+  //   const checkbox = wrapper.find(completingPartyChkBoxSelector)
+  //   checkbox.setChecked(true)
+  //   await Vue.nextTick()
+
+  //   expect(wrapper.vm.$refs.reassignCpDialog).toBeTruthy()
+
+  //   wrapper.destroy()
+  // })
+
+  it('Emits "removeCpRole" and "addEdit" events on reassigning the Completing Party', async () => {
     const wrapper = createComponent(validIncorporator, NaN, 1, validPersonData)
 
     // add Completing Party role
@@ -431,6 +493,37 @@ describe('Org/Person component', () => {
 
     expect(getLastEvent(wrapper, addEditEvent).roles[0])
       .toStrictEqual({ roleType: 'Completing Party', appointmentDate: '2020-03-30' })
+
+    wrapper.destroy()
+  })
+
+  it('Displays errors and does not submit form when clicking Done button and form is invalid', async () => {
+    const wrapper = createComponent(emptyPerson, NaN, 0, null)
+
+    // verify that Done button is enabled, even for an empty person
+    // then click it
+    const button = wrapper.find(doneButtonSelector)
+    expect(button.attributes('disabled')).toBeUndefined()
+    button.trigger('click')
+    await Vue.nextTick()
+
+    // get a list of validation messages
+    const wrappers = wrapper.findAll('.v-messages__message')
+    const messages: Array<string> = []
+    for (let i = 0; i < wrappers.length; i++) {
+      messages.push(wrappers.at(i).text())
+    }
+
+    // verify some error messages
+    expect(messages.includes('A first name is required'))
+    expect(messages.includes('A last name is required'))
+    expect(messages.includes('A role is required'))
+    expect(messages.includes('This field is required'))
+
+    // verify that no events were emitted
+    expect(wrapper.emitted(removeCpRoleEvent)).toBeUndefined()
+    expect(wrapper.emitted(addEditEvent)).toBeUndefined()
+    expect(wrapper.emitted(resetEvent)).toBeUndefined()
 
     wrapper.destroy()
   })

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -445,27 +445,19 @@ describe('Org/Person component', () => {
   it('Shows popup if there is an existing completing party', async () => {
     const wrapper = createComponent(validIncorporator, NaN, 0, validPersonData)
 
+    // verify that popup is not yet displayed
+    expect(wrapper.find('.confirm-dialog').exists()).toBe(false)
+
+    // check the Completing Party box
     const checkbox = wrapper.find(completingPartyChkBoxSelector)
     checkbox.setChecked(true)
     await Vue.nextTick()
 
-    expect(wrapper.vm.$refs.reassignCpDialog).toBeTruthy()
+    // verify that popup is now displayed
+    expect(wrapper.find('.confirm-dialog').exists()).toBe(true)
 
     wrapper.destroy()
   })
-
-  // TODO (move this to PeopleAndRoles.spec.ts)
-  // it('Shows popup when undoing an edit would change the Completing Party', async () => {
-  //   const wrapper = createComponent(validIncorporator, NaN, 0, validPersonData)
-
-  //   const checkbox = wrapper.find(completingPartyChkBoxSelector)
-  //   checkbox.setChecked(true)
-  //   await Vue.nextTick()
-
-  //   expect(wrapper.vm.$refs.reassignCpDialog).toBeTruthy()
-
-  //   wrapper.destroy()
-  // })
 
   it('Emits "removeCpRole" and "addEdit" events on reassigning the Completing Party', async () => {
     const wrapper = createComponent(validIncorporator, NaN, 1, validPersonData)

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -21,23 +21,22 @@ const vuetify = new Vuetify({})
 const store = getVuexStore()
 
 // Input field selectors to test changes to the DOM elements.
-const btnAddPerson = '#btn-add-person'
-const btnAddCompletingParty = '#btn-add-cp'
-const btnAddCorp = '#btn-add-corp'
 const orgPersonForm = '#org-person-form'
+const btnAddPerson = '#btn-add-person'
+const btnAddCorp = '#btn-add-corp'
+const btnAddCompletingParty = '#btn-add-cp'
 const closeCompletingParty = '.cp-invalid'
-const closeDirector = '.dir-invalid'
 const closeIncorporator = '.incorp-invalid'
+const closeDirector = '.dir-invalid'
 const checkCompletingParty = '.cp-valid'
-const checkDirector = '.dir-valid'
 const checkIncorporator = '.incorp-valid'
+const checkDirector = '.dir-valid'
+
 const completingPartyRole = { roleType: 'Completing Party', appointmentDate: '2020-03-30' }
+const incorporatorRole = { roleType: 'Incorporator', appointmentDate: '2020-03-30' }
+const directorRole = { roleType: 'Director', appointmentDate: '2020-03-30' }
 
-function resetStore (): void {
-  store.state.stateModel.peopleAndRoles.orgPeople = []
-}
-
-function getPersonList (roles = [completingPartyRole]): Array<any> {
+function getPersonList (roles = []): Array<any> {
   return [
     {
       officer: {
@@ -88,65 +87,52 @@ describe('People And Roles component', () => {
   })
 
   it('shows all 3 add buttons when people list is empty', () => {
-    resetStore()
+    store.state.stateModel.peopleAndRoles.orgPeople = []
     const wrapper = wrapperFactory()
     expect(wrapper.find(btnAddPerson).exists()).toBe(true)
-    expect(wrapper.find(btnAddCompletingParty).exists()).toBe(true)
     expect(wrapper.find(btnAddCorp).exists()).toBe(true)
+    expect(wrapper.find(btnAddCompletingParty).exists()).toBe(true)
     wrapper.destroy()
   })
 
-  it('shows Add Person and Add Corporation buttons when people list has a Completing Party', () => {
-    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList()
+  it('shows only Add Person and Add Corporation buttons when people list has a Completing Party', () => {
+    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([completingPartyRole])
     const wrapper = wrapperFactory()
-    expect(wrapper.find(btnAddCorp).exists()).toBe(true)
     expect(wrapper.find(btnAddPerson).exists()).toBe(true)
+    expect(wrapper.find(btnAddCorp).exists()).toBe(true)
+    expect(wrapper.find(btnAddCompletingParty).exists()).toBe(false)
     wrapper.destroy()
-    resetStore()
   })
 
   it('shows Add Completing Party button when people list has no Completing Party', () => {
-    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([
-      { 'roleType': 'Director', 'appointmentDate': '2020-03-30' }
-    ])
+    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([incorporatorRole, directorRole])
     const wrapper = wrapperFactory()
     expect(wrapper.find(btnAddCompletingParty).exists()).toBe(true)
     wrapper.destroy()
-    resetStore()
-  })
-
-  it('does not show Add Completing Party Button when people list has Completing Party', () => {
-    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList()
-    const wrapper = wrapperFactory()
-    expect(wrapper.find(btnAddCompletingParty).exists()).toBe(false)
-    wrapper.destroy()
-    resetStore()
   })
 
   it('sets the data attributes as expected when Add Person button is clicked', async () => {
-    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList()
+    store.state.stateModel.peopleAndRoles.orgPeople = []
     const wrapper = wrapperFactory()
     wrapper.find(btnAddPerson).trigger('click')
     await Vue.nextTick()
     expect(wrapper.vm.$data.renderOrgPersonForm).toBe(true)
-    expect(wrapper.vm.$data.nextId).toBe(1)
+    expect(wrapper.vm.$data.nextId).toBe(0)
     wrapper.destroy()
-    resetStore()
   })
 
   it('sets the data attributes as expected when Add Corporation button is clicked', async () => {
-    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList()
+    store.state.stateModel.peopleAndRoles.orgPeople = []
     const wrapper = wrapperFactory()
     wrapper.find(btnAddCorp).trigger('click')
     await Vue.nextTick()
     expect(wrapper.vm.$data.renderOrgPersonForm).toBe(true)
-    expect(wrapper.vm.$data.nextId).toBe(1)
+    expect(wrapper.vm.$data.nextId).toBe(0)
     wrapper.destroy()
-    resetStore()
   })
 
   it('shows the add person form when Add Person button is clicked', async () => {
-    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList()
+    store.state.stateModel.peopleAndRoles.orgPeople = []
     const wrapper = wrapperFactory()
     wrapper.find(btnAddPerson).trigger('click')
     await Vue.nextTick()
@@ -157,11 +143,10 @@ describe('People And Roles component', () => {
     expect(wrapper.find(orgPersonForm).exists()).toBe(true)
     expect(wrapper.find('.add-org-header').text()).toBe('Add Person')
     wrapper.destroy()
-    resetStore()
   })
 
   it('shows the add corporation form when Add Corporation button is clicked', async () => {
-    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList()
+    store.state.stateModel.peopleAndRoles.orgPeople = []
     const wrapper = wrapperFactory()
     wrapper.find(btnAddCorp).trigger('click')
     await Vue.nextTick()
@@ -172,29 +157,146 @@ describe('People And Roles component', () => {
     expect(wrapper.find(orgPersonForm).exists()).toBe(true)
     expect(wrapper.find('.add-org-header').text()).toBe('Add Corporation or Firm')
     wrapper.destroy()
-    resetStore()
   })
 
   it('shows check icons next to all 3 roles when people list is complete', () => {
     store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([
-      { 'roleType': 'Director', 'appointmentDate': '2020-03-30' },
-      { 'roleType': 'Incorporator', 'appointmentDate': '2020-03-30' },
-      { 'roleType': 'Completing Party', 'appointmentDate': '2020-03-30' }
+      completingPartyRole,
+      incorporatorRole,
+      directorRole
     ])
     const wrapper = wrapperFactory()
     expect(wrapper.find(checkIncorporator).exists()).toBe(true)
     expect(wrapper.find(checkDirector).exists()).toBe(true)
     expect(wrapper.find(checkCompletingParty).exists()).toBe(true)
     wrapper.destroy()
-    resetStore()
   })
 
   it('shows close icons next to all 3 roles when people list is empty', () => {
-    resetStore()
+    store.state.stateModel.peopleAndRoles.orgPeople = []
     const wrapper = wrapperFactory()
     expect(wrapper.find(closeCompletingParty).exists()).toBe(true)
     expect(wrapper.find(closeIncorporator).exists()).toBe(true)
     expect(wrapper.find(closeDirector).exists()).toBe(true)
+    wrapper.destroy()
+  })
+
+  it('sets Valid flag to False when Completing Party role is missing', () => {
+    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([
+      incorporatorRole,
+      directorRole
+    ])
+    const wrapper = wrapperFactory()
+
+    expect(store.state.stateModel.peopleAndRoles.valid).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('sets Valid flag to False when Incorporator role is missing', () => {
+    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([
+      completingPartyRole,
+      directorRole
+    ])
+    const wrapper = wrapperFactory()
+
+    expect(store.state.stateModel.peopleAndRoles.valid).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('sets Valid flag to False when Director role is missing', () => {
+    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([
+      completingPartyRole,
+      incorporatorRole
+    ])
+    const wrapper = wrapperFactory()
+
+    expect(store.state.stateModel.peopleAndRoles.valid).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('sets Valid flag to False when a person has no roles', () => {
+    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([])
+    const wrapper = wrapperFactory()
+
+    // verify warning text
+    expect(wrapper.find('.warning-text').text()).toBe('Missing Role')
+    // verify flag
+    expect(store.state.stateModel.peopleAndRoles.valid).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('sets Valid flag to True when the component is valid', () => {
+    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([
+      completingPartyRole,
+      incorporatorRole,
+      directorRole
+    ])
+    const wrapper = wrapperFactory()
+
+    expect(store.state.stateModel.peopleAndRoles.valid).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('sets Changed flag to False when component has no changes', () => {
+    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([
+      completingPartyRole,
+      incorporatorRole,
+      directorRole
+    ])
+    const wrapper = wrapperFactory()
+
+    expect(store.state.stateModel.peopleAndRoles.changed).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('sets Changed flag to True when component has changes', () => {
+    store.state.stateModel.peopleAndRoles.orgPeople = getPersonList([
+      completingPartyRole,
+      incorporatorRole,
+      directorRole
+    ])
+    store.state.stateModel.peopleAndRoles.orgPeople[0].action = 'edited'
+    const wrapper = wrapperFactory()
+
+    expect(store.state.stateModel.peopleAndRoles.changed).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('shows popup when undoing an edit would change the Completing Party', async () => {
+    // original IA containing original CP:
+    const originalCp = getPersonList([completingPartyRole])[0]
+    originalCp.officer.id = 1
+    originalCp.action = undefined
+    store.state.stateModel.originalIA.incorporationApplication.parties = [originalCp]
+
+    // current orgPeople list containing edited CP and added CP:
+    const editedCp = getPersonList([])[0]
+    editedCp.officer.id = 1
+    editedCp.action = 'edited'
+    const addedCp = getPersonList([completingPartyRole])[0]
+    addedCp.officer.id = 2
+    addedCp.action = 'added'
+    store.state.stateModel.peopleAndRoles.orgPeople = [editedCp, addedCp]
+
+    const wrapper = wrapperFactory()
+
+    // verify that popup is not yet displayed
+    expect(wrapper.find('.confirm-dialog').exists()).toBe(false)
+
+    // click the first person's Undo button
+    wrapper.find('#officer-1-undo-btn').trigger('click')
+    await Vue.nextTick()
+
+    // verify that popup is now displayed
+    expect(wrapper.find('.confirm-dialog').exists()).toBe(true)
+
     wrapper.destroy()
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5191

*Description of changes:*

Commit 1:
- removed locked roles for a person
- always enable Done button
- validate forms when Done is clicked
- updated unit tests

Commit 2:
- created common method to format an officer's full name
- prompt user on Undo for confirmation to revert CP
- added "no missing roles" condition to component validity computation
- misc cleanup

Commit 3:
- added "attach" prop to confirm dialog
- updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).