### PR TITLE
misc layout fixes

### DIFF
--- a/src/components/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -104,7 +104,7 @@
                 <v-btn
                   text color="primary"
                   :id="`officer-${index}-undo-btn`"
-                  @click="emitUndo(index)"
+                  @click="emitUndo(index); dropdown[index]=false"
                 >
                   <v-icon small>mdi-undo</v-icon>
                   <span>Undo</span>
@@ -125,15 +125,19 @@
               </span>
 
               <!-- More Actions Menu -->
-              <span class="more-actions mr-4">
-                <v-menu offset-y>
+              <span :class="`more-actions-${index}`" class="mr-4">
+                <v-menu
+                  offset-y left nudge-bottom="4"
+                  v-model="dropdown[index]"
+                  :attach="`#list-people-roles .more-actions-${index}`"
+                >
                   <template v-slot:activator="{ on }">
                     <v-btn
                       text small color="primary"
                       class="more-actions-btn"
                       v-on="on"
                     >
-                      <v-icon>mdi-menu-down</v-icon>
+                      <v-icon>{{dropdown[index] ? 'mdi-menu-up' : 'mdi-menu-down'}}</v-icon>
                     </v-btn>
                   </template>
                   <v-list>
@@ -193,6 +197,9 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
 
   /** Headers for the person table. */
   readonly tableHeaders = ['Name', 'Mailing Address', 'Delivery Address', 'Roles']
+
+  /** V-model for dropdown menus. */
+  private dropdown: Array<boolean> = []
 
   /**
    * Checks if specified org/person was added.
@@ -310,6 +317,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
   .actions {
     position: absolute;
     right: 0;
+    margin-top: -0.5rem;
 
     .edit-action {
       border-right: 1px solid $gray1;
@@ -327,7 +335,15 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
 
 .v-list-item {
   min-height: 0;
-  padding: 0 1rem 0 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.v-list-item__subtitle {
+  color: var(--v-primary-base) !important;
+
+  .v-icon {
+    color: var(--v-primary-base) !important;
+  }
 }
 
 .col {
@@ -343,5 +359,11 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
   top: 2px;
   left: 2px;
   color: $BCgovInputError;
+}
+
+// italicize the delivery instructions in the base address component
+::v-deep .address-block__info-row:last-of-type {
+  padding-top: 0.75rem;
+  font-style: italic;
 }
 </style>

--- a/src/components/YourCompany/OfficeAddresses.vue
+++ b/src/components/YourCompany/OfficeAddresses.vue
@@ -37,27 +37,31 @@
           <div v-else>Same as Mailing Address</div>
         </v-flex>
 
-        <v-flex xs1 class="mt-n2" v-if="officeAddressesChanged">
+        <v-flex xs1 v-if="officeAddressesChanged">
           <div class="actions mr-4">
             <span class="edit-action">
               <v-btn
                 text color="primary"
                 id="btn-undo-office-addresses"
-                @click="resetOfficeAddresses()"
+                @click="resetOfficeAddresses(); dropdown=false"
               >
                 <v-icon small>mdi-undo</v-icon>
                 <span>Undo</span>
               </v-btn>
             </span>
             <span class="more-actions">
-              <v-menu offset-y attach=".more-actions">
+              <v-menu
+                offset-y left nudge-bottom="4"
+                v-model="dropdown"
+                attach="#office-addresses .more-actions"
+              >
                 <template v-slot:activator="{ on }">
                   <v-btn
                     text small color="primary"
                     id="btn-more-actions"
                     v-on="on"
                   >
-                    <v-icon>mdi-menu-down</v-icon>
+                    <v-icon>{{dropdown ? 'mdi-menu-up' : 'mdi-menu-down'}}</v-icon>
                   </v-btn>
                 </template>
                 <v-list>
@@ -320,6 +324,9 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
 
   /** Whether to show the editable forms for the addresses (true) or the static display addresses (false). */
   private isEditing: boolean = false
+
+  /** V-model for dropdown menu. */
+  private dropdown: boolean = null
 
   // The 4 addresses that are the current state of the BaseAddress sub-components:
   private mailingAddress = {} as AddressIF
@@ -709,6 +716,7 @@ ul {
 .actions {
   position: absolute;
   right: 0;
+  margin-top: -0.5rem;
 
   .edit-action {
     border-right: 1px solid $gray1;
@@ -721,7 +729,15 @@ ul {
 
 .v-list-item {
   min-height: 0;
-  padding: 0 1rem 0 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.v-list-item__subtitle {
+  color: var(--v-primary-base) !important;
+
+  .v-icon {
+    color: var(--v-primary-base) !important;
+  }
 }
 
 .action-btns {
@@ -739,6 +755,7 @@ ul {
 
 // italicize the delivery instructions in the base address component
 ::v-deep .address-block__info-row:last-of-type {
+  padding-top: 0.75rem;
   font-style: italic;
 }
 </style>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5368

*Description of changes:*

This commit fixes the People & Roles and Office Addresses components. Other components will need to be fixed in future tickets/commits.

- fixed action buttons vertical layout
- toggle more actions menu-down/up icon
- fixed more actions items layout
- fixed more actions items colour
- attached v-menu to prevent "flying in" on undo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).