### PR TITLE
fixed address comparisons and assignments

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>BC Business Registry</title>
     <link rel="icon" href="<%= BASE_URL %>favicon.png">
-    <link rel="preload" href="<%= BASE_URL %>fonts/materialdesignicons-webfont.927457ed.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="<%= BASE_URL %>css/addresscomplete-2.30.min.css">
     <script type="text/javascript" src="<%= BASE_URL %>js/addresscomplete-2.30.min.js" defer></script>
   </head>

--- a/src/components/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/PeopleAndRoles/PeopleAndRoles.vue
@@ -361,7 +361,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
     const original = this.originalParties.find(x => x.officer.id === person.officer.id)
     if (!original) return ActionTypes.ADDED
     // ignore "action" when comparing
-    if (!this.isSame(person, original, 'action')) return ActionTypes.EDITED
+    if (!this.isSame(person, original, ['action'])) return ActionTypes.EDITED
     return null // no action
   }
 

--- a/src/interfaces/stepper-interfaces/YourCompany/address-interface.ts
+++ b/src/interfaces/stepper-interfaces/YourCompany/address-interface.ts
@@ -7,6 +7,7 @@ export interface AddressIF {
   postalCode: string;
   streetAddress: string;
   streetAddressAdditional?: string;
+  addressType?: string
 }
 
 /** Interface to define the joint base addresses. */

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -13,16 +13,14 @@ export default class CommonMixin extends Vue {
   }
 
   /**
-   * Compares two objects while omitting a specified property from the comparison.
-   *
-   * @param addressA the first object to compare
-   * @param addressB the second object to compare
-   * @param prop the property to omit during the comparison
-   *
+   * Compares two objects while omitting specified properties from the comparison.
+   * @param objA the first object to compare
+   * @param objB the second object to compare
+   * @param props an optional array of properties to omit during the comparison
    * @return a boolean indicating a match of objects
    */
-  isSame (objA: {}, objB: {}, prop: string = null): boolean {
-    return isEqual({ ...omit(objA, prop ? [prop] : []) }, { ...omit(objB, prop ? [prop] : []) })
+  isSame (objA: {}, objB: {}, props: string[] = []): boolean {
+    return isEqual({ ...omit(objA, props) }, { ...omit(objB, props) })
   }
 
   /**
@@ -49,12 +47,12 @@ export default class CommonMixin extends Vue {
     return fullName.trimRight()
   }
 
-  /** Return true when in correction filings. */
+  /** Returns true when filing a correction. */
   isCorrection (): boolean {
     return (this.$route.name === RouteNames.CORRECTION)
   }
 
-  /** Return true when in alteration filings. */
+  /** Returns true when filing an alteration. */
   isAlteration (): boolean {
     return (this.$route.name === RouteNames.ALTERATION)
   }

--- a/tests/unit/OfficeAddresses.spec.ts
+++ b/tests/unit/OfficeAddresses.spec.ts
@@ -850,7 +850,12 @@ describe('"same as" checkboxes', () => {
     expect(wrapper.vm.$data.recMailingAddress.addressCity).toBe('addressCity1')
     expect(wrapper.vm.$data.recDeliveryAddress.addressCity).toBe('addressCity1')
 
-    // first need to make records addresses not same as registered addresses
+    // verify that checkbox is checked and that records addresses don't exist
+    expect(wrapper.find('#records-mailing-same-chkbx').attributes('aria-checked')).toBe('true')
+    expect(wrapper.find('#address-records-mailing').exists()).toBe(false)
+    expect(wrapper.find('#address-records-delivery').exists()).toBe(false)
+
+    // first make records office not the same as registered office
     const recordsCheckbox = wrapper.find('#records-mailing-same-chkbx')
     recordsCheckbox.trigger('click')
     await Vue.nextTick()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5420

*Description of changes:*
- closed v-menu on button clicks
- ignore Address Country Description in direct comparisons
- ignore Address Type in mailing/delivery comparisons
- set address types on assignments
- added optional addressType property to interface
- updated isSame() to handle array of omitted props
- updated a unit test
- also removed unneeded font preload

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).