### PR TITLE
disable buttons when editing

### DIFF
--- a/src/components/IncorporationAgreement/AgreementType.vue
+++ b/src/components/IncorporationAgreement/AgreementType.vue
@@ -89,6 +89,7 @@ export default class AgreementType extends Vue {
 
   // Global setters
   @Action setIncorporationAgreementStepData!: ActionBindingIF
+  @Action setEditingIncorporationAgreement!: ActionBindingIF
 
   // Local properties
   private agreementType: string = null
@@ -128,6 +129,12 @@ export default class AgreementType extends Vue {
   private onAgreementTypeStateChange () {
     this.agreementType = this.getAgreementType
     this.setIncorporationAgreementData()
+  }
+
+  /** Updates store when local Editing property has changed. */
+  @Watch('showAgreementTypeForm', { immediate: true })
+  private onEditingChanged (val: boolean): void {
+    this.setEditingIncorporationAgreement(val)
   }
 }
 </script>

--- a/src/components/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/PeopleAndRoles/PeopleAndRoles.vue
@@ -127,6 +127,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
   @Action setPeopleAndRoles!: ActionBindingIF
   @Action setPeopleAndRolesChanged!: ActionBindingIF
   @Action setPeopleAndRolesValidity!: ActionBindingIF
+  @Action setEditingPeopleAndRoles!: ActionBindingIF
 
   /** Empty OrgPerson for adding a new one. */
   private emptyOrgPerson: OrgPersonIF = {
@@ -508,6 +509,12 @@ export default class PeopleAndRoles extends Mixins(CommonMixin) {
   private onPeopleAndRolesChanged (): void {
     this.currentCompletingParty = this.getCompletingParty(this.getPeopleAndRoles)
     this.setPeopleAndRolesValidity(this.hasValidRoles && this.noMissingRoles)
+  }
+
+  /** Updates store when local Editing property has changed. */
+  @Watch('renderOrgPersonForm', { immediate: true })
+  private onEditingChanged (val: boolean): void {
+    this.setEditingPeopleAndRoles(val)
   }
 }
 </script>

--- a/src/components/ShareStructure/ShareStructure.vue
+++ b/src/components/ShareStructure/ShareStructure.vue
@@ -38,7 +38,6 @@
     <v-expand-transition>
       <v-card flat class="add-share-structure-container" v-if="showAddShareStructureForm">
         <edit-share-structure
-          v-show="showAddShareStructureForm"
           :initialValue="currentShareStructure"
           :activeIndex="activeIndex"
           :shareId="shareId"
@@ -406,6 +405,7 @@ export default class ShareStructure extends Mixins(CommonMixin) {
 
   @Action setShareClasses!: ActionBindingIF
   @Action setShareStructureChanged!: ActionBindingIF
+  @Action setEditingShareStructure!: ActionBindingIF
 
   // Local Properties
   private activeIndex: number = -1
@@ -824,6 +824,12 @@ export default class ShareStructure extends Mixins(CommonMixin) {
   @Watch('hasSeriesChanges')
   private emitHaveChanges (): void {
     this.setShareStructureChanged(this.hasClassChanges || this.hasSeriesChanges)
+  }
+
+  /** Updates store when local Editing property has changed. */
+  @Watch('addEditInProgress', { immediate: true })
+  private onEditingChanged (val: boolean): void {
+    this.setEditingShareStructure(val)
   }
 }
 </script>

--- a/src/components/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/YourCompany/NameTranslations/NameTranslation.vue
@@ -130,6 +130,7 @@
 // Libraries
 import { Component, Vue, Prop, Watch, Emit, Mixins } from 'vue-property-decorator'
 import { cloneDeep } from 'lodash'
+import { Action } from 'vuex-class'
 
 // Components
 import { ConfirmDialog } from '@/components/dialogs'
@@ -144,7 +145,6 @@ import { ActionTypes } from '@/enums'
 
 // Mixins
 import { CommonMixin } from '@/mixins'
-import { Action, Getter } from 'vuex-class'
 
 @Component({
   components: {
@@ -162,7 +162,8 @@ export default class NameTranslation extends Mixins(CommonMixin) {
   @Prop({ default: () => { return [] as [] } })
   private nameTranslations!: NameTranslationDraftIF[]
 
-  private actionTypes = ActionTypes
+  // Actions
+  @Action setEditingNameTranslations: ActionBindingIF
 
   // Properties
   private draftTranslations: NameTranslationDraftIF[] = []
@@ -324,6 +325,13 @@ export default class NameTranslation extends Mixins(CommonMixin) {
     this.emitHaveChanges(this.hasNameTranslationChange)
   }
 
+  /** Updates store when local Editing property has changed. */
+  @Watch('isEditing', { immediate: true })
+  private onEditingChanged (val: boolean): void {
+    this.setEditingNameTranslations(val)
+  }
+
+  // Emitters
   @Emit('nameTranslationsChange')
   private emitNameTranslations (translations: NameTranslationDraftIF[]): void {}
 

--- a/src/components/YourCompany/OfficeAddresses.vue
+++ b/src/components/YourCompany/OfficeAddresses.vue
@@ -308,6 +308,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
 
   // Global setters
   @Action setOfficeAddresses!: ActionBindingIF
+  @Action setEditingOfficeAddresses!: ActionBindingIF
 
   // Declarations for template
   readonly isEmpty = isEmpty
@@ -628,6 +629,12 @@ export default class OfficeAddresses extends Mixins(CommonMixin, EntityFilterMix
     // update external state
     this.emitValid()
     this.emitHaveChanges()
+  }
+
+  /** Updates store when local Editing property has changed. */
+  @Watch('isEditing', { immediate: true })
+  private onEditingChanged (val: boolean): void {
+    this.setEditingOfficeAddresses(val)
   }
 
   /** Emits the validity state of this component. */

--- a/src/components/YourCompany/YourCompany.vue
+++ b/src/components/YourCompany/YourCompany.vue
@@ -140,7 +140,8 @@ export default class YourCompany extends Mixins(DateMixin, EntityFilterMixin, Le
   @Getter getBusinessContact!: BusinessContactIF
 
   // Actions
-  @Action setDefineCompanyStepChanged: ActionBindingIF
+  @Action setDefineCompanyStepChanged!: ActionBindingIF
+  @Action setEditingCompanyName!: ActionBindingIF
 
   // Declaration for template
   readonly EntityTypes = EntityTypes
@@ -224,6 +225,12 @@ export default class YourCompany extends Mixins(DateMixin, EntityFilterMixin, Le
   /** Emits Have Changes event. */
   @Emit('haveChanges')
   private emitHaveChanges (haveChanges: boolean): void {}
+
+  /** Updates store when local Editing property has changed. */
+  @Watch('isEditingNames', { immediate: true })
+  private onEditingChanged (val: boolean): void {
+    this.setEditingCompanyName(val)
+  }
 }
 </script>
 

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -1,45 +1,46 @@
 <template>
   <v-container id="action-buttons-container" class="list-item">
-
-    <div class="buttons-left">
-      <!-- disable Save button for now -->
-      <v-btn id="save-btn" large
-        :disabled="isSaveButtonDisabled"
-        :loading="isSaving"
-        @click="onClickSave()"
-      >
-        <span>Save</span>
-      </v-btn>
-
-      <!-- disable Save and Resume Later button for now -->
-      <v-btn id="save-resume-btn" large
-        :disabled="isSaveResumeButtonDisabled"
-        :loading="isSavingResuming"
-        @click="onClickSaveResume()"
-      >
-        <span>Save and Resume Later</span>
-      </v-btn>
-    </div>
-
-    <div class="buttons-right">
-      <v-fade-transition hide-on-leave>
-        <v-btn id="file-pay-btn" large color="primary"
-          :disabled="isFilePayButtonDisabled"
-          :loading="isFilingPaying"
-          @click="onClickFilePay()"
+    <!-- don't show buttons until Entity Type is identified -->
+    <template v-if="isEntityType">
+      <div class="buttons-left">
+        <!-- disable Save button for now -->
+        <v-btn id="save-btn" large
+          :disabled="isSaveButtonDisabled"
+          :loading="isSaving"
+          @click="onClickSave()"
         >
-          <span>File and Pay</span>
+          <span>Save</span>
         </v-btn>
-      </v-fade-transition>
 
-      <v-btn id="app-cancel-btn" large outlined color="primary"
-        :disabled="isBusySaving"
-        @click="onClickCancel()"
-      >
-        <span>Cancel</span>
-      </v-btn>
-    </div>
+        <!-- disable Save and Resume Later button for now -->
+        <v-btn id="save-resume-btn" large
+          :disabled="isSaveResumeButtonDisabled"
+          :loading="isSavingResuming"
+          @click="onClickSaveResume()"
+        >
+          <span>Save and Resume Later</span>
+        </v-btn>
+      </div>
 
+      <div class="buttons-right">
+        <v-fade-transition hide-on-leave>
+          <v-btn id="file-pay-btn" large color="primary"
+            :disabled="isFilePayButtonDisabled"
+            :loading="isFilingPaying"
+            @click="onClickFilePay()"
+          >
+            <span>File and Pay</span>
+          </v-btn>
+        </v-fade-transition>
+
+        <v-btn id="app-cancel-btn" large outlined color="primary"
+          :disabled="isBusySaving"
+          @click="onClickCancel()"
+        >
+          <span>Cancel</span>
+        </v-btn>
+      </div>
+    </template>
   </v-container>
 </template>
 
@@ -58,11 +59,9 @@ import { DateMixin, FilingTemplateMixin, LegalApiMixin, NameRequestMixin } from 
 export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, LegalApiMixin, NameRequestMixin) {
   // Global getters
   @Getter isEntityType!: boolean
-  @Getter isEnableFilePayBtn!: boolean
   @Getter isBusySaving!: boolean
   @Getter isNamedBusiness!: boolean
   @Getter getNameRequestNumber!: string
-  @Getter getEffectiveDate!: Date
   @Getter isFilingChanged!: boolean
   @Getter isFilingValid!: boolean
   @Getter hasNewNr!: boolean
@@ -79,12 +78,12 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Lega
 
   /** True if the Save button should be disabled. */
   private get isSaveButtonDisabled (): boolean {
-    return (!this.isEntityType || this.isBusySaving || this.isEditing)
+    return (this.isBusySaving || this.isEditing)
   }
 
   /** True if the Save and Resume button should be disabled. */
   private get isSaveResumeButtonDisabled (): boolean {
-    return (!this.isEntityType || this.isBusySaving || this.isEditing)
+    return (this.isBusySaving || this.isEditing)
   }
 
   /** True if the File and Pay button should be disabled. */

--- a/src/store/actions/actions-model.ts
+++ b/src/store/actions/actions-model.ts
@@ -137,6 +137,10 @@ export const setIncorporationAgreementStepData: ActionIF = ({ commit }, stepData
   commit('mutateIncorporationAgreementStepData', stepData)
 }
 
+export const setIncorporationAgreementValidity: ActionIF = ({ commit }, validity: boolean): void => {
+  commit('mutateIncorporationAgreementValidity', validity)
+}
+
 export const setIgnoreChanges: ActionIF = ({ commit }, ignoreChanges): void => {
   commit('mutateIgnoreChanges', ignoreChanges)
 }
@@ -169,30 +173,26 @@ export const setDetailValidity: ActionIF = ({ commit }, validity: boolean): void
   commit('mutateDetailValidity', validity)
 }
 
-export const setCompanyNameEditing: ActionIF = ({ commit }, editing: boolean): void => {
-  commit('mutateCompanyNameEditing', editing)
+export const setEditingCompanyName: ActionIF = ({ commit }, editing: boolean): void => {
+  commit('mutateEditingCompanyName', editing)
 }
 
-export const setNameTranslationsEditing: ActionIF = ({ commit }, editing: boolean): void => {
-  commit('mutateNameTranslationsEditing', editing)
+export const setEditingNameTranslations: ActionIF = ({ commit }, editing: boolean): void => {
+  commit('mutateEditingNameTranslations', editing)
 }
 
-export const setOfficeAddressesEditing: ActionIF = ({ commit }, editing: boolean): void => {
-  commit('mutateOfficeAddressesEditing', editing)
+export const setEditingOfficeAddresses: ActionIF = ({ commit }, editing: boolean): void => {
+  commit('mutateEditingOfficeAddresses', editing)
 }
 
-export const setPeopleAndRolesEditing: ActionIF = ({ commit }, editing: boolean): void => {
-  commit('mutatePeopleAndRolesEditing', editing)
+export const setEditingPeopleAndRoles: ActionIF = ({ commit }, editing: boolean): void => {
+  commit('mutateEditingPeopleAndRoles', editing)
 }
 
-export const setShareStructureEditing: ActionIF = ({ commit }, editing: boolean): void => {
-  commit('mutateShareStructureEditing', editing)
+export const setEditingShareStructure: ActionIF = ({ commit }, editing: boolean): void => {
+  commit('mutateEditingShareStructure', editing)
 }
 
-export const setIncorporationAgreementValidity: ActionIF = ({ commit }, validity: boolean): void => {
-  commit('mutateIncorporationAgreementValidity', validity)
-}
-
-export const setIncorporationAgreementEditing: ActionIF = ({ commit }, editing: boolean): void => {
-  commit('mutateIncorporationAgreementEditing', editing)
+export const setEditingIncorporationAgreement: ActionIF = ({ commit }, editing: boolean): void => {
+  commit('mutateEditingIncorporationAgreement', editing)
 }

--- a/src/store/actions/actions-model.ts
+++ b/src/store/actions/actions-model.ts
@@ -1,6 +1,7 @@
 import { ActionIF } from '@/interfaces/store-interfaces/action-interface'
+import { EntityTypes } from '@/enums'
 
-export const setEntityType: ActionIF = ({ commit }, entityType): void => {
+export const setEntityType: ActionIF = ({ commit }, entityType: EntityTypes): void => {
   commit('mutateEntityType', entityType)
 }
 
@@ -54,6 +55,10 @@ export const setCertifyStatementResource: ActionIF = ({ commit }, certifyStateme
 
 export const setCertifyState: ActionIF = ({ commit }, certifyState): void => {
   commit('mutateCertifyState', certifyState)
+}
+
+export const setCertifyStateValidity: ActionIF = ({ commit }, validity): void => {
+  commit('mutateCertifyStateValidity', validity)
 }
 
 export const setBusinessContact: ActionIF = ({ commit }, businessContact): void => {

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -226,28 +226,13 @@ export const getFilingData = (state: StateIF): FilingDataIF => {
 }
 
 /** Whether People and Roles component is valid. */
-export const isPeopleAndRoleValid = (state: StateIF): boolean => {
+export const isPeopleAndRolesValid = (state: StateIF): boolean => {
   return state.stateModel.peopleAndRolesStep.valid
 }
 
 /** Whether Define Company Step is valid. */
 export const isDefineCompanyStepValid = (state: StateIF): boolean => {
   return state.stateModel.defineCompanyStep.valid
-}
-
-//
-// Below is the business logic that allows the Actions, etc
-// to know how they should behave (ie, what to show or enable).
-//
-
-/** Whether File and Pay button should be enabled. */
-export const isEnableFilePayBtn = (state: StateIF, getters: any): boolean => {
-  const step1Valid = isDefineCompanyStepValid(state)
-  const step2Valid = isPeopleAndRoleValid(state)
-  const step3Valid = getters.isTypeBcomp ? state.stateModel.shareStructureStep.valid : false
-  const step4Valid = getters.isTypeBcomp ? state.stateModel.incorporationAgreementStep.valid : false
-  const step5Valid = state.stateModel.certifyState.valid && state.stateModel.incorporationDateTime.valid
-  return (step1Valid && step2Valid && step3Valid && step4Valid && step5Valid)
 }
 
 /** Whether app is busy saving/saving and resuming/filing and paying. */

--- a/src/store/mutations/mutations-model.ts
+++ b/src/store/mutations/mutations-model.ts
@@ -164,6 +164,10 @@ export const mutateIncorporationAgreementChanged = (state: StateIF, changed: boo
   state.stateModel.incorporationAgreementStep.changed = changed
 }
 
+export const mutateIncorporationAgreementValidity = (state: StateIF, validity: boolean) => {
+  state.stateModel.incorporationAgreementStep.valid = validity
+}
+
 export const mutateIgnoreChanges = (state: StateIF, ignoreChanges: boolean) => {
   state.stateModel.tombstone.ignoreChanges = ignoreChanges
 }
@@ -201,30 +205,26 @@ export const mutateDetailComment = (state: StateIF, comment: string) => {
   state.stateModel.detail.comment = comment
 }
 
-export const mutateCompanyNameEditing = (state: StateIF, editing: boolean) => {
+export const mutateEditingCompanyName = (state: StateIF, editing: boolean) => {
   state.stateModel.editingFlags.companyName = editing
 }
 
-export const mutateNameTranslationsEditing = (state: StateIF, editing: boolean) => {
+export const mutateEditingNameTranslations = (state: StateIF, editing: boolean) => {
   state.stateModel.editingFlags.nameTranslations = editing
 }
 
-export const mutateOfficeAddressesEditing = (state: StateIF, editing: boolean) => {
+export const mutateEditingOfficeAddresses = (state: StateIF, editing: boolean) => {
   state.stateModel.editingFlags.officeAddresses = editing
 }
 
-export const mutatePeopleAndRolesEditing = (state: StateIF, editing: boolean) => {
+export const mutateEditingPeopleAndRoles = (state: StateIF, editing: boolean) => {
   state.stateModel.editingFlags.peopleAndRoles = editing
 }
 
-export const mutateShareStructureEditing = (state: StateIF, editing: boolean) => {
+export const mutateEditingShareStructure = (state: StateIF, editing: boolean) => {
   state.stateModel.editingFlags.shareStructure = editing
 }
 
-export const mutateIncorporationAgreementValidity = (state: StateIF, validity: boolean) => {
-  state.stateModel.incorporationAgreementStep.valid = validity
-}
-
-export const mutateIncorporationAgreementEditing = (state: StateIF, editing: boolean) => {
+export const mutateEditingIncorporationAgreement = (state: StateIF, editing: boolean) => {
   state.stateModel.editingFlags.incorporationAgreement = editing
 }

--- a/tests/unit/Actions.spec.ts
+++ b/tests/unit/Actions.spec.ts
@@ -83,7 +83,7 @@ describe('Action button states', () => {
 
     setEditing = async (val: boolean) => {
       // set any editing flag
-      await wrapper.vm.$store.commit('mutateCompanyNameEditing', val)
+      await wrapper.vm.$store.commit('mutateEditingCompanyName', val)
     }
   })
 

--- a/tests/unit/state-getters.spec.ts
+++ b/tests/unit/state-getters.spec.ts
@@ -122,39 +122,39 @@ describe('State Getters', () => {
     expect(vm.isEditing).toBe(false)
 
     // verify that the Company Name Editing flag works
-    await vm.$store.commit('mutateCompanyNameEditing', true)
+    await vm.$store.commit('mutateEditingCompanyName', true)
     expect(vm.isEditing).toBe(true)
-    await vm.$store.commit('mutateCompanyNameEditing', false)
+    await vm.$store.commit('mutateEditingCompanyName', false)
     expect(vm.isEditing).toBe(false)
 
     // verify that the Name Translations Editing flag works
-    await vm.$store.commit('mutateNameTranslationsEditing', true)
+    await vm.$store.commit('mutateEditingNameTranslations', true)
     expect(vm.isEditing).toBe(true)
-    await vm.$store.commit('mutateNameTranslationsEditing', false)
+    await vm.$store.commit('mutateEditingNameTranslations', false)
     expect(vm.isEditing).toBe(false)
 
     // verify that the Office Addresses Editing flag works
-    await vm.$store.commit('mutateOfficeAddressesEditing', true)
+    await vm.$store.commit('mutateEditingOfficeAddresses', true)
     expect(vm.isEditing).toBe(true)
-    await vm.$store.commit('mutateOfficeAddressesEditing', false)
+    await vm.$store.commit('mutateEditingOfficeAddresses', false)
     expect(vm.isEditing).toBe(false)
 
     // verify that the People And Roles Editing flag works
-    await vm.$store.commit('mutatePeopleAndRolesEditing', true)
+    await vm.$store.commit('mutateEditingPeopleAndRoles', true)
     expect(vm.isEditing).toBe(true)
-    await vm.$store.commit('mutatePeopleAndRolesEditing', false)
+    await vm.$store.commit('mutateEditingPeopleAndRoles', false)
     expect(vm.isEditing).toBe(false)
 
     // verify that the Company Share Structure flag works
-    await vm.$store.commit('mutateShareStructureEditing', true)
+    await vm.$store.commit('mutateEditingShareStructure', true)
     expect(vm.isEditing).toBe(true)
-    await vm.$store.commit('mutateShareStructureEditing', false)
+    await vm.$store.commit('mutateEditingShareStructure', false)
     expect(vm.isEditing).toBe(false)
 
     // verify that the Incorporation Agreement Editing flag works
-    await vm.$store.commit('mutateIncorporationAgreementEditing', true)
+    await vm.$store.commit('mutateEditingIncorporationAgreement', true)
     expect(vm.isEditing).toBe(true)
-    await vm.$store.commit('mutateIncorporationAgreementEditing', false)
+    await vm.$store.commit('mutateEditingIncorporationAgreement', false)
     expect(vm.isEditing).toBe(false)
   })
 })

--- a/tests/unit/state-getters.spec.ts
+++ b/tests/unit/state-getters.spec.ts
@@ -19,7 +19,7 @@ describe('State Getters', () => {
     await Vue.nextTick()
   })
 
-  it('returns correct values for "Is Busy Saving" getter', async () => {
+  it('returns correct values for "Is Busy Saving" et al getters', async () => {
     // initially, these getters should be false
     expect(vm.isSaving).toBe(false)
     expect(vm.isSavingResuming).toBe(false)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5115

*Description of changes:*

Commit 1:
- don't show buttons until Entity Type is known
- added missing setter (action)
- deleted unused getter
- updated Actions unit tests

Commit 2:
- set editing flag when Incorporation Agreement form is rendered
- set editing flag when People and Roles add/edit form is rendered
- set editing flag when Share Structure add/edit is in progress
- set editing flag when Office Addresses is in editing mode
- set editing flag when Company Name is in editing mode
- set editing flag when Name Translations is in editing mode
- renamed some actions and mutations for consistency
- updated unit tests due to renames

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).