### PR TITLE
Update for set environment variables issue of GHA.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,12 +19,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set env by input
         run: |
-          echo "::set-env name=TAG_NAME::${{ github.event.inputs.environement }}"
+          echo "TAG_NAME=${{ github.event.inputs.environement }}" >> $GITHUB_ENV
 
-      - name: Set default env by master branch
+      - name: Set env by master branch
         if: env.TAG_NAME == '' && github.ref == 'refs/heads/master'
         run: |
-          echo "::set-env name=TAG_NAME::dev"
+          echo "TAG_NAME=dev" >> $GITHUB_ENV
 
       - uses: pwei1018/bcrs-cd-action@latest
         with:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -10,13 +10,13 @@ comment:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "50...100"
   status:
-    patch: false
     project:
       default:
         target: auto
         if_not_found: success
+        only_pulls: true
 
 ignore:
   - "^/tests/**/*" # ignore test harness code
@@ -28,6 +28,3 @@ parsers:
       loop: true
       method: false
       macro: false
-
-github_checks:
-    annotations: true


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5626

*Description of changes:*
1. Update for deprecating set-env command of GHA.
2. Expand the range of codecov check to 50% - 100%.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
