### PR TITLE
5176 - show name translations on summary page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Summary/AlterationSummary.vue
+++ b/src/components/Summary/AlterationSummary.vue
@@ -86,13 +86,10 @@
       <v-divider class="mx-4" />
       <div class="section-container name-translation-summary">
         <v-row no-gutters>
-          <v-col cols="3">
-            <label><strong>Name Translation</strong></label>
-          </v-col>
-
-          <v-col cols="8">
-            <i>FUTURE</i>
-          </v-col>
+          <name-translation
+            :nameTranslations="getNameTranslations"
+            :isSummaryMode="true"
+          />
         </v-row>
       </div>
     </template>
@@ -185,20 +182,23 @@ import {
   NameRequestIF,
   ShareClassIF,
   ShareStructureIF,
-  ValidFlagsIF
+  ValidFlagsIF,
+  NameTranslationIF
 } from '@/interfaces'
 import { CommonMixin, DateMixin, EnumMixin, FilingTemplateMixin, LegalApiMixin } from '@/mixins'
 import { CorpTypeCd } from '@/enums'
 import { EffectiveDateTime } from '@/components/common'
 import { ShareStructures } from '@/components/ShareStructure'
 import { ResolutionDates } from '@/components/Articles'
+import { NameTranslation } from '@/components/YourCompany/NameTranslations'
 
 @Component({
   components: {
     ConfirmDialog,
     EffectiveDateTime,
     ResolutionDates,
-    ShareStructures
+    ShareStructures,
+    NameTranslation
   }
 })
 export default class AlterationSummary extends Mixins(
@@ -226,6 +226,7 @@ export default class AlterationSummary extends Mixins(
   @Getter getOriginalSnapshot!: BusinessSnapshotIF
   @Getter getNewResolutionDates!: string[]
   @Getter getPreviousResolutionDates!: string[]
+  @Getter getNameTranslations!: NameTranslationIF[]
 
   // Alteration flag getters
   @Getter getAlterationValidFlags!: ValidFlagsIF
@@ -352,6 +353,10 @@ export default class AlterationSummary extends Mixins(
       color: $BCgovInputError;
     }
   }
+}
+
+#name-translation {
+  width: 100%;
 }
 
 .inner-col-1 {

--- a/src/components/Summary/AlterationSummary.vue
+++ b/src/components/Summary/AlterationSummary.vue
@@ -85,12 +85,10 @@
     <template v-if="true">
       <v-divider class="mx-4" />
       <div class="section-container name-translation-summary">
-        <v-row no-gutters>
-          <name-translation
-            :nameTranslations="getNameTranslations"
-            :isSummaryMode="true"
-          />
-        </v-row>
+        <name-translation
+          :nameTranslations="getNameTranslations"
+          :isSummaryMode="true"
+        />
       </div>
     </template>
 
@@ -353,10 +351,6 @@ export default class AlterationSummary extends Mixins(
       color: $BCgovInputError;
     }
   }
-}
-
-#name-translation {
-  width: 100%;
 }
 
 .inner-col-1 {

--- a/src/components/YourCompany/NameTranslations/AddNameTranslation.vue
+++ b/src/components/YourCompany/NameTranslations/AddNameTranslation.vue
@@ -14,7 +14,8 @@
             label="Name Translation"
             id="name-translation-input"
             v-model="nameTranslation"
-            :rules="nameTranslationRules">
+            :rules="nameTranslationRules"
+            @keyup="uppercase('nameTranslation')">
           </v-text-field>
         </v-col>
       </v-row>
@@ -52,7 +53,7 @@
 
 <script lang="ts">
 // Libraries
-import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
+import { Component, Emit, Prop, Mixins } from 'vue-property-decorator'
 
 // Components
 import { ConfirmDialog } from '@/components/dialogs'
@@ -60,12 +61,15 @@ import { ConfirmDialog } from '@/components/dialogs'
 // Interfaces
 import { ConfirmDialogType, FormType } from '@/interfaces'
 
+// Mixins
+import { CommonMixin } from '@/mixins'
+
 @Component({
   components: {
     ConfirmDialog
   }
 })
-export default class AddNameTranslation extends Vue {
+export default class AddNameTranslation extends Mixins(CommonMixin) {
   // Refs
   $refs!: {
     confirmTranslationDialog: ConfirmDialogType,

--- a/src/components/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/YourCompany/NameTranslations/NameTranslation.vue
@@ -9,7 +9,8 @@
         <label><strong>Name Translation(s)</strong></label>
         <v-flex md1>
             <v-chip v-if="hasNameTranslationChange" x-small label color="#1669BB" text-color="white">
-                Corrected
+              <span v-if="isCorrectionView">Corrected</span>
+              <span v-else>Changed</span>
             </v-chip>
           </v-flex>
       </v-flex>
@@ -20,7 +21,7 @@
       <v-flex class="info-text" xs7 v-else>
         No name translations
       </v-flex>
-      <v-flex xs2 class="align-right" v-if="!hasNameTranslationChange">
+      <v-flex xs2 class="align-right" v-if="!hasNameTranslationChange && !isSummaryMode">
         <v-btn
           id="correct-name-translation"
           text color="primary"
@@ -30,7 +31,7 @@
           <span>{{editLabel}}</span>
         </v-btn>
       </v-flex>
-      <v-flex xs2 class="align-right" v-else>
+      <v-flex xs2 class="align-right" v-else-if="hasNameTranslationChange && !isSummaryMode">
         <v-btn
           id="undo-name-translation"
           text color="primary" class="undo-name-translation"
@@ -162,6 +163,9 @@ export default class NameTranslation extends Mixins(CommonMixin) {
 
   @Prop({ default: () => { return [] as [] } })
   private nameTranslations!: NameTranslationIF[]
+
+  @Prop({ default: false })
+  private isSummaryMode: boolean
 
   // Global action
   @Action setEditingNameTranslations: ActionBindingIF
@@ -329,6 +333,11 @@ export default class NameTranslation extends Mixins(CommonMixin) {
   // Watchers
   @Watch('nameTranslations', { deep: true, immediate: true })
   private onNameTranslationsPropValueChanged (): void {
+    if (this.isSummaryMode) {
+      this.nameTranslations.forEach(function (translation) {
+        translation.name = translation.name.toUpperCase()
+      })
+    }
     this.draftTranslations = this.nameTranslations ? cloneDeep(this.nameTranslations) : []
     this.emitHaveChanges(this.hasNameTranslationChange)
   }

--- a/src/components/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/YourCompany/NameTranslations/NameTranslation.vue
@@ -4,24 +4,23 @@
       ref="confirmTranslationDialog"
       attach="#name-translation"
     />
-    <v-layout v-if="!isEditing">
-      <v-flex xs3>
+    <v-row no-gutters v-if="!isEditing">
+      <v-col cols="3">
         <label><strong>Name Translation(s)</strong></label>
-        <v-flex md1>
-            <v-chip v-if="hasNameTranslationChange" x-small label color="#1669BB" text-color="white">
-              <span v-if="isCorrectionView">Corrected</span>
-              <span v-else>Changed</span>
-            </v-chip>
-          </v-flex>
-      </v-flex>
-      <v-flex xs7 v-if="draftTranslations && translationsExceptRemoved.length">
-        <div class="info-text" v-for="(translation, index) in translationsExceptRemoved"
+          <v-col cols="1">
+            <action-chip v-if="hasNameTranslationChange"
+                      :actionable-item="{ action: ActionTypes.EDITED }"
+                      :editedLabel="editedLabel" />
+          </v-col>
+      </v-col>
+      <v-col cols="7" v-if="draftTranslations && translationsExceptRemoved.length">
+        <div class="info-text text-uppercase" v-for="(translation, index) in translationsExceptRemoved"
           :key="`name_translation_${index}`">{{translation.name}}</div>
-      </v-flex>
-      <v-flex class="info-text" xs7 v-else>
+      </v-col>
+      <v-col cols="7" class="info-text" v-else>
         No name translations
-      </v-flex>
-      <v-flex xs2 class="align-right" v-if="!hasNameTranslationChange && !isSummaryMode">
+      </v-col>
+      <v-col cols="2" class="align-right" v-if="!hasNameTranslationChange && !isSummaryMode">
         <v-btn
           id="correct-name-translation"
           text color="primary"
@@ -30,8 +29,8 @@
           <v-icon small>mdi-pencil</v-icon>
           <span>{{editLabel}}</span>
         </v-btn>
-      </v-flex>
-      <v-flex xs2 class="align-right" v-else-if="hasNameTranslationChange && !isSummaryMode">
+      </v-col>
+      <v-col cols="2" class="align-right" v-else-if="hasNameTranslationChange && !isSummaryMode">
         <v-btn
           id="undo-name-translation"
           text color="primary" class="undo-name-translation"
@@ -66,15 +65,15 @@
             </v-list>
           </v-menu>
         </span>
-      </v-flex>
-    </v-layout>
-    <v-layout v-else>
-      <v-flex xs3>
+      </v-col>
+    </v-row>
+    <v-row no-gutters v-else>
+      <v-col cols="3">
         <label><strong>Name Translation(s)</strong></label>
-      </v-flex>
-      <v-flex xs9>
-        <v-layout>
-          <v-flex>
+      </v-col>
+      <v-col cols="9">
+        <v-row no-gutters>
+          <v-col>
             <p>Name translations must use the Latin Alphabet (English, French, etc.).
               Names that use other writing systems must spell the name phonetically in English or French.
             </p>
@@ -82,10 +81,10 @@
               <v-icon>mdi-plus</v-icon>
               <span>Add Name Translation</span>
             </v-btn>
-          </v-flex>
-        </v-layout>
-        <v-layout>
-          <v-flex>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
             <add-name-translation
               v-if="isAddingNameTranslation"
               :editNameTranslation="editingNameTranslation"
@@ -102,10 +101,10 @@
               @removeNameTranslation="removeNameTranslation($event)"
               @nameUndo="undoNameTranslation($event)"
             />
-          </v-flex>
-        </v-layout>
-        <v-layout pt-5>
-          <v-flex xs12>
+          </v-col>
+        </v-row>
+        <v-row pt-5>
+          <v-col cols="12">
             <div class="action-btns">
               <v-btn large color="primary"
                 id="name-translation-done"
@@ -122,10 +121,10 @@
                 <span>Cancel</span>
               </v-btn>
             </div>
-          </v-flex>
-        </v-layout>
-      </v-flex>
-    </v-layout>
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
   </div>
 </template>
 
@@ -134,6 +133,7 @@
 import { Component, Vue, Prop, Watch, Emit, Mixins } from 'vue-property-decorator'
 import { cloneDeep } from 'lodash'
 import { Action } from 'vuex-class'
+import { ActionChip } from '@bcrs-shared-components/action-chip'
 
 // Components
 import { ConfirmDialog } from '@/components/dialogs'
@@ -152,7 +152,8 @@ import { CommonMixin } from '@/mixins'
   components: {
     AddNameTranslation,
     ListNameTranslation,
-    ConfirmDialog
+    ConfirmDialog,
+    ActionChip
   }
 })
 export default class NameTranslation extends Mixins(CommonMixin) {
@@ -169,6 +170,9 @@ export default class NameTranslation extends Mixins(CommonMixin) {
 
   // Global action
   @Action setEditingNameTranslations: ActionBindingIF
+
+  // Declaration for template
+  readonly ActionTypes = ActionTypes
 
   // Local properties
   private draftTranslations: NameTranslationIF[] = []
@@ -333,11 +337,6 @@ export default class NameTranslation extends Mixins(CommonMixin) {
   // Watchers
   @Watch('nameTranslations', { deep: true, immediate: true })
   private onNameTranslationsPropValueChanged (): void {
-    if (this.isSummaryMode) {
-      this.nameTranslations.forEach(function (translation) {
-        translation.name = translation.name.toUpperCase()
-      })
-    }
     this.draftTranslations = this.nameTranslations ? cloneDeep(this.nameTranslations) : []
     this.emitHaveChanges(this.hasNameTranslationChange)
   }

--- a/tests/unit/AlterationSummary.spec.ts
+++ b/tests/unit/AlterationSummary.spec.ts
@@ -10,10 +10,18 @@ import { createLocalVue, mount } from '@vue/test-utils'
 import { AlterationSummary } from '@/components/Summary'
 import { EffectiveDateTime } from '@/components/common'
 import { ConfirmDialog } from '@/components/dialogs'
+import { NameTranslationIF } from '@/interfaces'
+import { NameTranslation } from '@/components/YourCompany/NameTranslations'
 
 Vue.use(Vuetify)
 const localVue = createLocalVue()
 const vuetify = new Vuetify({})
+const nameTranslationsList: NameTranslationIF[] = [
+  { name: 'First mock name translation ltd.' },
+  { name: 'Second mock name translation inc' },
+  { name: 'Third mock name translation ltd.' },
+  { name: 'Quatrième nom simulé' }
+]
 
 describe('Alteration Summary component', () => {
   let wrapper: any
@@ -40,6 +48,7 @@ describe('Alteration Summary component', () => {
     store.state.stateModel.nameRequest.legalName = originalSnapShot.businessInfo.legalName
     store.state.stateModel.tombstone.entityType = originalSnapShot.businessInfo.legalType
     store.state.stateModel.summaryMode = true
+    store.state.stateModel.nameTranslations = nameTranslationsList
 
     wrapper = mount(AlterationSummary, { vuetify, store, localVue })
   })
@@ -52,6 +61,7 @@ describe('Alteration Summary component', () => {
     expect(wrapper.find(AlterationSummary).exists()).toBe(true)
     expect(wrapper.find(EffectiveDateTime).exists()).toBe(true)
     expect(wrapper.find(ConfirmDialog).exists()).toBe(true)
+    expect(wrapper.find(NameTranslation).exists()).toBe(true)
   })
 
   it('renders the Change and Remove actions', async () => {
@@ -143,4 +153,18 @@ describe('Alteration Summary component', () => {
     expect(divs.at(1).text()).toContain('The alteration for this business will be effective as of:')
     expect(divs.at(1).text()).toContain('Friday, March 5, 2021 at 8:30 am Pacific time')
   })
+
+  it('displays the list of name translations', async () => {
+
+    // Verify list exists
+    expect(wrapper.find('#name-translation').exists()).toBeTruthy()
+
+    // Verify list items
+    const namesList = wrapper.vm.$el.querySelectorAll('.info-text')
+    expect(namesList[0].textContent).toContain(nameTranslationsList[0].name)
+    expect(namesList[1].textContent).toContain(nameTranslationsList[1].name)
+    expect(namesList[2].textContent).toContain(nameTranslationsList[2].name)
+    expect(namesList[3].textContent).toContain(nameTranslationsList[3].name)
+  })
+
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5176

*Description of changes:*

- repurpose name translation component to show on summary page
- ensure translations are in upper case on summary page
- add test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
