### PR TITLE
only show section if name translations has changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Summary/AlterationSummary.vue
+++ b/src/components/Summary/AlterationSummary.vue
@@ -82,7 +82,7 @@
     </template>
 
     <!-- Name Translation -->
-    <template v-if="true">
+    <template v-if="hasNameTranslationChange">
       <v-divider class="mx-4" />
       <div class="section-container name-translation-summary">
         <name-translation
@@ -272,6 +272,11 @@ export default class AlterationSummary extends Mixins(
   /** Local getter, using a mixin method to detect changes to Share Structure. */
   get hasShareStructureChanged (): boolean {
     return !this.isSame(this.getShareClasses, this.getSnapshotShareStructure?.shareClasses, ['action'])
+  }
+
+  get hasNameTranslationChange (): boolean {
+    return this.getNameTranslations.length > 0 &&
+      this.getNameTranslations.filter(x => x.action).length > 0
   }
 
   /** Restore baseline data to original snapshot. */

--- a/src/components/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/YourCompany/NameTranslations/NameTranslation.vue
@@ -8,7 +8,7 @@
       <v-col cols="3">
         <label><strong>Name Translation(s)</strong></label>
           <v-col cols="1" class="pa-0">
-            <action-chip v-if="hasNameTranslationChange"
+            <action-chip v-if="hasNameTranslationChange && !isSummaryMode"
                       :actionable-item="{ action: ActionTypes.EDITED }"
                       :editedLabel="editedLabel" />
           </v-col>

--- a/tests/unit/AlterationSummary.spec.ts
+++ b/tests/unit/AlterationSummary.spec.ts
@@ -54,7 +54,6 @@ describe('Alteration Summary component', () => {
     expect(wrapper.find(AlterationSummary).exists()).toBe(true)
     expect(wrapper.find(EffectiveDateTime).exists()).toBe(true)
     expect(wrapper.find(ConfirmDialog).exists()).toBe(true)
-    expect(wrapper.find(NameTranslation).exists()).toBe(true)
   })
 
   it('renders the Change and Remove actions', async () => {

--- a/tests/unit/AlterationSummary.spec.ts
+++ b/tests/unit/AlterationSummary.spec.ts
@@ -27,6 +27,12 @@ describe('Alteration Summary component', () => {
       legalType: 'BC'
     }
   }
+  const nameTranslationsListChanged = [
+    { name: 'First mock name translation ltd.', action: 'edited' },
+    { name: 'Second mock name translation inc' },
+    { name: 'Third mock name translation ltd.' },
+    { name: 'Quatrième nom simulé' }
+  ]
 
   beforeAll(() => {
     // init store
@@ -42,6 +48,7 @@ describe('Alteration Summary component', () => {
     store.state.stateModel.nameRequest.legalName = originalSnapShot.businessInfo.legalName
     store.state.stateModel.tombstone.entityType = originalSnapShot.businessInfo.legalType
     store.state.stateModel.summaryMode = true
+    store.state.stateModel.nameTranslations = nameTranslationsListChanged
 
     wrapper = mount(AlterationSummary, { vuetify, store, localVue })
   })
@@ -54,6 +61,7 @@ describe('Alteration Summary component', () => {
     expect(wrapper.find(AlterationSummary).exists()).toBe(true)
     expect(wrapper.find(EffectiveDateTime).exists()).toBe(true)
     expect(wrapper.find(ConfirmDialog).exists()).toBe(true)
+    expect(wrapper.find(NameTranslation).exists()).toBe(true)
   })
 
   it('renders the Change and Remove actions', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5176

*Description of changes:*
- was showing blank section with line before
- also, don't show "changed" chip on summary page

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
