### PR TITLE
6724 - EffectiveDateTime to enable all the fields when selecting FED

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1233,9 +1233,9 @@
       }
     },
     "@bcrs-shared-components/date-picker": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/date-picker/-/date-picker-1.1.0.tgz",
-      "integrity": "sha512-bq4WdmMaiAt+ZT2fB9QqPFrFbuvDcMRu5Utq9VJKJMrDQZBGthEQ25gIL/0eDCUcYf6Jb45Cz6Ik/WGjqr77Tw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/date-picker/-/date-picker-1.1.1.tgz",
+      "integrity": "sha512-GB/zKLC20MEUKEPLrZu/koIBTjNoNK/6e6Tjsa9UMHDOKbbEdVUuAfIT+WZUqzFVjMJix3MSFYR2Tb5d7k0qYQ==",
       "requires": {
         "vue-property-decorator": "^8.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@bcrs-shared-components/contact-info": "1.0.12",
     "@bcrs-shared-components/corp-type-module": "1.0.3",
     "@bcrs-shared-components/court-order-poa": "1.0.7",
-    "@bcrs-shared-components/date-picker": "1.1.0",
+    "@bcrs-shared-components/date-picker": "1.1.1",
     "@bcrs-shared-components/detail-comment": "1.0.4",
     "@bcrs-shared-components/enums": "1.0.11",
     "@bcrs-shared-components/fee-summary": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/PeopleAndRoles/OrgPerson.vue
@@ -177,7 +177,7 @@
 import { Component, Prop, Emit, Mixins } from 'vue-property-decorator'
 import { cloneDeep, isEqual } from 'lodash'
 import { v4 as uuidv4 } from 'uuid'
-import { OrgPersonIF, BaseAddressType, FormType, AddressIF, ConfirmDialogType, RoleIF } from '@/interfaces'
+import { OrgPersonIF, BaseAddressType, FormIF, AddressIF, ConfirmDialogType, RoleIF } from '@/interfaces'
 import BaseAddress from 'sbc-common-components/src/components/BaseAddress.vue'
 import { ConfirmDialog } from '@/components/dialogs'
 import { CommonMixin } from '@/mixins'
@@ -194,7 +194,7 @@ import { Getter } from 'vuex-class'
 export default class OrgPerson extends Mixins(CommonMixin) {
   // Refs
   $refs!: {
-    orgPersonForm: FormType,
+    orgPersonForm: FormIF,
     mailingAddressNew: BaseAddressType,
     deliveryAddressNew: BaseAddressType,
     reassignCpDialog: ConfirmDialogType

--- a/src/components/YourCompany/NameTranslations/AddNameTranslation.vue
+++ b/src/components/YourCompany/NameTranslations/AddNameTranslation.vue
@@ -58,7 +58,7 @@ import { Component, Emit, Prop, Mixins } from 'vue-property-decorator'
 import { ConfirmDialog } from '@/components/dialogs'
 
 // Interfaces
-import { ConfirmDialogType, FormType } from '@/interfaces'
+import { ConfirmDialogType, FormIF } from '@/interfaces'
 
 // Mixins
 import { CommonMixin } from '@/mixins'
@@ -72,7 +72,7 @@ export default class AddNameTranslation extends Mixins(CommonMixin) {
   // Refs
   $refs!: {
     confirmTranslationDialog: ConfirmDialogType,
-    nameTranslationForm: FormType
+    nameTranslationForm: FormIF
   }
 
   @Prop({ default: '' })

--- a/src/components/common/EffectiveDateTime.vue
+++ b/src/components/common/EffectiveDateTime.vue
@@ -266,7 +266,7 @@ export default class EffectiveDateTime extends Mixins(DateMixin) {
     // wait for form to update itself before checking validity
     await Vue.nextTick()
 
-    const isDateValid = this.$refs.datePickerRef.$refs.form['validate']()
+    const isDateValid = this.$refs.datePickerRef.validateForm()
     const isTimeValid = this.$refs.form.validate()
     if (isDateValid && isTimeValid) {
       const year = +this.dateText.slice(0, 4)
@@ -363,7 +363,7 @@ export default class EffectiveDateTime extends Mixins(DateMixin) {
       this.selectHour = []
       this.selectMinute = []
       this.selectPeriod = PeriodTypes.AM
-      this.$refs.datePickerRef.$refs.form['reset']()
+      this.$refs.datePickerRef.clearDate()
     }
 
     // update the parent
@@ -389,7 +389,7 @@ export default class EffectiveDateTime extends Mixins(DateMixin) {
 
     // wait for form to update itself before checking validity
     await Vue.nextTick()
-    const isDateValid = this.$refs.datePickerRef.$refs.form['validate']()
+    const isDateValid = this.$refs.datePickerRef.validateForm()
     const isTimeValid = this.$refs.form.validate()
     return (!!this.effectiveDateType &&
       isDateValid && isTimeValid &&

--- a/src/components/common/EffectiveDateTime.vue
+++ b/src/components/common/EffectiveDateTime.vue
@@ -78,7 +78,7 @@ import { Getter } from 'vuex-class'
 import { DatePicker } from '@bcrs-shared-components/date-picker'
 import { DateMixin } from '@/mixins'
 import { EffectiveDateTypes } from '@/enums'
-import { EffectiveDateTimeIF, FormFieldType, FormType } from '@/interfaces'
+import { EffectiveDateTimeIF, FormFieldType, FormIF } from '@/interfaces'
 
 enum PeriodTypes {
   AM = 'am',
@@ -96,7 +96,7 @@ export default class EffectiveDateTime extends Mixins(DateMixin) {
 
   // Add element types to refs
   $refs!: {
-    form: FormType,
+    form: FormIF,
     datePickerRef: DatePicker,
     hourSelector: FormFieldType, // used in unit tests
     minuteSelector: FormFieldType // used in unit tests

--- a/src/interfaces/utils-interfaces/form-field-type.ts
+++ b/src/interfaces/utils-interfaces/form-field-type.ts
@@ -1,6 +1,6 @@
-import { FormType } from './form-type'
+import { FormIF } from './form-type'
 
-export interface FormFieldType extends FormType {
+export interface FormFieldType extends FormIF {
   valid: boolean
   hasError: boolean
 }

--- a/src/interfaces/utils-interfaces/form-type.ts
+++ b/src/interfaces/utils-interfaces/form-type.ts
@@ -1,8 +1,6 @@
 // Reference to vuetify form api: https://vuetifyjs.com/en/api/v-form/#functions
-export interface FormType extends HTMLFormElement {
+export interface FormIF extends HTMLFormElement {
   reset(): void
   validate(): boolean
   resetValidation(): void
 }
-// To keep compatibility with the shared components that use FormIF and not FormType
-export interface FormIF extends FormType {}

--- a/src/interfaces/utils-interfaces/form-type.ts
+++ b/src/interfaces/utils-interfaces/form-type.ts
@@ -4,3 +4,5 @@ export interface FormType extends HTMLFormElement {
   validate(): boolean
   resetValidation(): void
 }
+// To keep compatibility with the shared components that use FormIF and not FormType
+export interface FormIF extends FormType {}

--- a/tests/unit/EffectiveDateTime.spec.ts
+++ b/tests/unit/EffectiveDateTime.spec.ts
@@ -142,7 +142,6 @@ describe('Effective Date Time component', () => {
     const radioIsFutureEffective = radioInput.at(1)
 
     await radioIsFutureEffective.trigger('click')
-    wrapper.vm.dateText = new Date().toISOString().split('T')[0]
 
     await Vue.nextTick()
 

--- a/tests/unit/EffectiveDateTime.spec.ts
+++ b/tests/unit/EffectiveDateTime.spec.ts
@@ -122,10 +122,9 @@ describe('Effective Date Time component', () => {
     const radioIsFutureEffective = radioInput.at(1)
 
     await radioIsFutureEffective.trigger('click')
-    wrapper.vm.dateText = new Date().toISOString().split('T')[0]
-
     await Vue.nextTick()
 
+    expect(wrapper.vm.dateText).toBe('') // No need to have a selected date
     expect(wrapper.find('#date-text-field').attributes('disabled')).toBeUndefined()
     expect(wrapper.find('#hour-selector').attributes('disabled')).toBeUndefined()
     expect(wrapper.find('#minute-selector').attributes('disabled')).toBeUndefined()
@@ -158,6 +157,8 @@ describe('Effective Date Time component', () => {
     expect(wrapper.find('#hour-selector').attributes('disabled')).toBe('disabled')
     expect(wrapper.find('#minute-selector').attributes('disabled')).toBe('disabled')
     expect(wrapper.find('#period-selector').attributes('disabled')).toBe('disabled')
+
+    expect(wrapper.find('#date-text-field').text()).toBe('')
   })
 
   it('emits a valid state when Immediate is selected', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6724

*Description of changes:*

- Changed EffectiveDateTime to enable all the fields when selecting FED;
- Updated tests

**This PR is part of 6724 regarding the checkbox: "Can we have the users able to select date/time/am in any order or is there a reason we force users to select the date field first? Would prefer all the fields are "active" when you click the FED radio button"**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
