### PR TITLE
Show Folio Number with conditional actions

### DIFF
--- a/src/components/YourCompany/FolioInformation.vue
+++ b/src/components/YourCompany/FolioInformation.vue
@@ -4,7 +4,7 @@
     :originalValue="originalFolioNumber"
     :editLabel="editLabel"
     :editedLabel="editedLabel"
-    :disableActions="isCorrectionFiling"
+    :hideActions="hideActions"
     :invalidSection="invalidSection"
     @newFolioNumber="onNewFolioNumber($event)"
     @haveChanges="onHaveChanges($event)"
@@ -30,6 +30,7 @@ export default class FolioInformation extends Mixins(AuthApiMixin, CommonMixin) 
   @Getter isAlterationFiling!: boolean
   @Getter getOriginalIA!: IncorporationFilingIF
   @Getter getSnapshotFolioNumber!: string
+  @Getter isRoleStaff!: boolean
 
   // Global setters
   @Action setFolioNumber!: ActionBindingIF
@@ -45,6 +46,13 @@ export default class FolioInformation extends Mixins(AuthApiMixin, CommonMixin) 
     if (this.isCorrectionFiling) return this.getOriginalIA.header.folioNumber
     if (this.isAlterationFiling) return this.getSnapshotFolioNumber
     return null
+  }
+
+  /** Whether to hide the component's actions. */
+  private get hideActions (): boolean {
+    // hide actions in a correction filing
+    // hide actions from staff users
+    return (this.isCorrectionFiling || this.isRoleStaff)
   }
 
   /** On new folio number, updates auth db and store. */

--- a/src/components/YourCompany/FolioNumber.vue
+++ b/src/components/YourCompany/FolioNumber.vue
@@ -11,12 +11,12 @@
         </label>
       </v-col>
 
-      <v-col :cols="disableActions ? '9' : '7'">
+      <v-col :cols="hideActions ? '9' : '7'">
         <div id="folio-number-readonly">{{ !!folioNumber ? folioNumber : 'None' }}</div>
       </v-col>
 
       <!-- Edit Actions -->
-      <v-col cols="2" class="mt-n2" v-if="!disableActions">
+      <v-col cols="2" class="mt-n2" v-if="!hideActions">
         <div class="edit-actions mr-4">
           <v-btn
             v-if="hasFolioNumberChanged"
@@ -151,7 +151,7 @@ export default class FolioNumber extends Vue {
   // Props
   @Prop({ default: null }) readonly initialValue: string
   @Prop({ default: null }) readonly originalValue: string
-  @Prop({ default: false }) readonly disableActions: boolean
+  @Prop({ default: false }) readonly hideActions: boolean
   @Prop() readonly editLabel: string
   @Prop() readonly editedLabel!: string
   @Prop({ default: false }) readonly invalidSection!: boolean

--- a/src/components/YourCompany/YourCompany.vue
+++ b/src/components/YourCompany/YourCompany.vue
@@ -231,9 +231,7 @@
     </div>
 
     <!-- Folio Information -->
-    <!-- TODO: show for corrections -->
-    <!-- TODO: show for staff but hide action buttons -->
-    <template v-if="isPremiumAccount && !isRoleStaff">
+    <template v-if="isPremiumAccount">
       <v-divider class="mx-4" />
 
       <div id="folio-number" class="section-container" :class="{'invalid-section': invalidFolioSection}">
@@ -312,7 +310,6 @@ export default class YourCompany extends Mixins(
   @Getter getBusinessContact!: ContactPointIF
   @Getter isCorrectionFiling!: boolean
   @Getter isAlterationFiling!: boolean
-  @Getter isRoleStaff!: boolean
 
   // Alteration flag getters
   @Getter hasBusinessNameChanged!: boolean

--- a/tests/unit/FolioInformation.spec.ts
+++ b/tests/unit/FolioInformation.spec.ts
@@ -16,7 +16,6 @@ const store = getVuexStore()
 describe('Folio Information component', () => {
   it('renders itself and its sub-component', () => {
     const wrapper = mount(FolioInformation, { vuetify, store })
-    const vm: any = wrapper.vm
 
     expect(wrapper.findComponent(FolioInformation).exists()).toBe(true)
     expect(wrapper.findComponent(FolioNumber).exists()).toBe(true)
@@ -118,6 +117,7 @@ describe('Folio Information component', () => {
     const vm: any = wrapper.vm
 
     await vm.onHaveChanges(true)
+
     expect(wrapper.emitted('haveChanges')).toEqual([[true]])
 
     wrapper.destroy()
@@ -128,6 +128,7 @@ describe('Folio Information component', () => {
     const vm: any = wrapper.vm
 
     await vm.onIsEditing(true)
+
     expect(store.state.stateModel.editingFlags.folioNumber).toBe(true)
     expect(store.state.stateModel.newAlteration.validComponents['isValidFolioInfo']).toBe(false)
     expect(wrapper.emitted('isEditing')).toEqual([[true]])


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5024

*Description of changes:*
- show FN for premium accounts only
- hide FN actions in a correction filing
- hide FN actions from staff users

Note that I'm not updating the app version so that: I don't conflict with Andre's PR, and because this build is close enough to other builds today.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).