### PR TITLE
Staff Payment and Office Address Bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2907,6 +2907,78 @@
         "tslint": "^5.20.1",
         "webpack": "^4.0.0",
         "yorkie": "^2.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "fork-ts-checker-webpack-plugin-v5": {
+          "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+          "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@types/json-schema": "^7.0.5",
+            "chalk": "^4.1.0",
+            "cosmiconfig": "^6.0.0",
+            "deepmerge": "^4.2.2",
+            "fs-extra": "^9.0.0",
+            "memfs": "^3.1.2",
+            "minimatch": "^3.0.4",
+            "schema-utils": "2.7.0",
+            "semver": "^7.3.2",
+            "tapable": "^1.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "@vue/cli-plugin-unit-jest": {
@@ -8656,78 +8728,6 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        }
-      }
-    },
-    "fork-ts-checker-webpack-plugin-v5": {
-      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-      "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@types/json-schema": "^7.0.5",
-        "chalk": "^4.1.0",
-        "cosmiconfig": "^6.0.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^9.0.0",
-        "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
-        "schema-utils": "2.7.0",
-        "semver": "^7.3.2",
-        "tapable": "^1.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true,
-          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/YourCompany/OfficeAddresses.vue
+++ b/src/components/YourCompany/OfficeAddresses.vue
@@ -354,6 +354,11 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   /** Model value for "same as (records) mailing address" checkbox. */
   private inheritRecMailingAddress: boolean = true
 
+  /** Use 'mounted' lifecycle hook to ensure component is kept up to date after changing views. */
+  mounted (): void {
+    this.updateAddresses()
+  }
+
   /** The office addresses from the original IA. NB: may be {} */
   private get originalOfficeAddresses (): IncorporationAddressIf {
     return (this.getOriginalIA.incorporationApplication.offices as IncorporationAddressIf)
@@ -624,7 +629,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * sets local properties and emits state events.
    */
   @Watch('getOfficeAddresses', { deep: true })
-  private updateAddresses (addresses: IncorporationAddressIf): void {
+  private updateAddresses (): void {
     // set local properties from store
     this.setLocalProperties()
 

--- a/src/components/YourCompany/OfficeAddresses.vue
+++ b/src/components/YourCompany/OfficeAddresses.vue
@@ -620,7 +620,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   }
 
   /**
-   * When stored office addresses change (ie, when data is loaded/updated/reset),
+   * When the component is mounted or stored office addresses change (ie, when data is loaded/updated/reset),
    * sets local properties and emits state events.
    */
   @Watch('getOfficeAddresses', { deep: true, immediate: true })
@@ -629,6 +629,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
     this.setLocalProperties()
 
     // update external state
+    // Will emit on component mount and subsequent changes
     this.emitHaveChanges()
   }
 

--- a/src/components/YourCompany/OfficeAddresses.vue
+++ b/src/components/YourCompany/OfficeAddresses.vue
@@ -354,11 +354,6 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   /** Model value for "same as (records) mailing address" checkbox. */
   private inheritRecMailingAddress: boolean = true
 
-  /** Use 'mounted' lifecycle hook to ensure component is kept up to date after changing views. */
-  mounted (): void {
-    this.updateAddresses()
-  }
-
   /** The office addresses from the original IA. NB: may be {} */
   private get originalOfficeAddresses (): IncorporationAddressIf {
     return (this.getOriginalIA.incorporationApplication.offices as IncorporationAddressIf)
@@ -628,7 +623,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * When stored office addresses change (ie, when data is loaded/updated/reset),
    * sets local properties and emits state events.
    */
-  @Watch('getOfficeAddresses', { deep: true })
+  @Watch('getOfficeAddresses', { deep: true, immediate: true })
   private updateAddresses (): void {
     // set local properties from store
     this.setLocalProperties()

--- a/src/components/YourCompany/OfficeAddresses.vue
+++ b/src/components/YourCompany/OfficeAddresses.vue
@@ -622,6 +622,9 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   /**
    * When the component is mounted or stored office addresses change (ie, when data is loaded/updated/reset),
    * sets local properties and emits state events.
+   *
+   * Called on mount to init data in the event the component is destroyed and there is no changes to trigger the Watcher
+   * This happens in Alterations when navigating between views and where office addresses are not editable.
    */
   @Watch('getOfficeAddresses', { deep: true, immediate: true })
   private updateAddresses (): void {

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -167,7 +167,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     }
 
     // Include Staff Payment into the Correction filing
-    filing = this.buildStaffPayment(filing)
+    this.buildStaffPayment(filing)
 
     return filing
   }
@@ -264,7 +264,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     if (this.hasNewNr || this.hasBusinessNameChanged) filing.alteration.nameRequest = { ...this.getNameRequest }
 
     // Include Staff Payment into the Alteration filing
-    filing = this.buildStaffPayment(filing)
+    this.buildStaffPayment(filing)
 
     return filing
   }
@@ -565,7 +565,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
   /** Build Staff Payment data into the filing.
    * @param filing The alteration or correction filing.
    */
-  private buildStaffPayment (filing: AlterationFilingIF | CorrectionFilingIF): any {
+  private buildStaffPayment (filing: AlterationFilingIF | CorrectionFilingIF): void {
     // Populate Staff Payment according to payment option
     switch (this.getStaffPayment.option) {
       case StaffPaymentOptions.FAS:
@@ -588,8 +588,6 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
       case StaffPaymentOptions.NONE: // should never happen
         break
     }
-
-    return filing
   }
 
   /** Parse Staff Payment data into store.

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -119,7 +119,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     }
 
     // Build correction filing
-    const filing: CorrectionFilingIF = {
+    let filing: CorrectionFilingIF = {
       header: {
         name: FilingTypes.CORRECTION,
         certifiedBy: this.getCertifyState.certifiedBy,
@@ -166,28 +166,8 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
       filing.incorporationApplication.nameRequest.legalName = this.getApprovedName
     }
 
-    // Populate Staff Payment according to payment option
-    switch (this.getStaffPayment.option) {
-      case StaffPaymentOptions.FAS:
-        filing.header.routingSlipNumber = this.getStaffPayment.routingSlipNumber
-        filing.header.priority = this.getStaffPayment.isPriority
-        break
-
-      case StaffPaymentOptions.BCOL:
-        filing.header.bcolAccountNumber = this.getStaffPayment.bcolAccountNumber
-        filing.header.datNumber = this.getStaffPayment.datNumber
-        filing.header.folioNumber = this.getStaffPayment.folioNumber // this overrides original folio number
-        filing.header.priority = this.getStaffPayment.isPriority
-        break
-
-      case StaffPaymentOptions.NO_FEE:
-        filing.header.waiveFees = true
-        filing.header.priority = false
-        break
-
-      case StaffPaymentOptions.NONE: // should never happen
-        break
-    }
+    // Include Staff Payment into the Correction filing
+    filing = this.buildStaffPayment(filing)
 
     return filing
   }
@@ -222,7 +202,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     }
 
     // Build alteration filing
-    const filing: AlterationFilingIF = {
+    let filing: AlterationFilingIF = {
       header: {
         name: FilingTypes.ALTERATION,
         certifiedBy: this.getCertifyState.certifiedBy,
@@ -283,28 +263,8 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     // Include name request info when applicable
     if (this.hasNewNr || this.hasBusinessNameChanged) filing.alteration.nameRequest = { ...this.getNameRequest }
 
-    // Populate Staff Payment according to payment option
-    switch (this.getStaffPayment.option) {
-      case StaffPaymentOptions.FAS:
-        filing.header.routingSlipNumber = this.getStaffPayment.routingSlipNumber
-        filing.header.priority = this.getStaffPayment.isPriority
-        break
-
-      case StaffPaymentOptions.BCOL:
-        filing.header.bcolAccountNumber = this.getStaffPayment.bcolAccountNumber
-        filing.header.datNumber = this.getStaffPayment.datNumber
-        filing.header.folioNumber = this.getStaffPayment.folioNumber // this overrides original folio number
-        filing.header.priority = this.getStaffPayment.isPriority
-        break
-
-      case StaffPaymentOptions.NO_FEE:
-        filing.header.waiveFees = true
-        filing.header.priority = false
-        break
-
-      case StaffPaymentOptions.NONE: // should never happen
-        break
-    }
+    // Include Staff Payment into the Alteration filing
+    filing = this.buildStaffPayment(filing)
 
     return filing
   }
@@ -602,10 +562,40 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     this.setBusinessContact(contactPoint)
   }
 
+  /** Build Staff Payment data into the filing.
+   * @param filing The alteration or correction filing.
+   */
+  private buildStaffPayment (filing: AlterationFilingIF | CorrectionFilingIF): any {
+    // Populate Staff Payment according to payment option
+    switch (this.getStaffPayment.option) {
+      case StaffPaymentOptions.FAS:
+        filing.header.routingSlipNumber = this.getStaffPayment.routingSlipNumber
+        filing.header.priority = this.getStaffPayment.isPriority
+        break
+
+      case StaffPaymentOptions.BCOL:
+        filing.header.bcolAccountNumber = this.getStaffPayment.bcolAccountNumber
+        filing.header.datNumber = this.getStaffPayment.datNumber
+        filing.header.folioNumber = this.getStaffPayment.folioNumber // this overrides original folio number
+        filing.header.priority = this.getStaffPayment.isPriority
+        break
+
+      case StaffPaymentOptions.NO_FEE:
+        filing.header.waiveFees = true
+        filing.header.priority = false
+        break
+
+      case StaffPaymentOptions.NONE: // should never happen
+        break
+    }
+
+    return filing
+  }
+
   /** Parse Staff Payment data into store.
    * @param filing The alteration or correction filing to parse.
    */
-  storeStaffPayment (filing: AlterationFilingIF | CorrectionFilingIF): void {
+  private storeStaffPayment (filing: AlterationFilingIF | CorrectionFilingIF): void {
     // Parse staff payment
     if (filing.header.routingSlipNumber) {
       this.setStaffPayment({

--- a/tests/unit/OfficeAddresses.spec.ts
+++ b/tests/unit/OfficeAddresses.spec.ts
@@ -957,7 +957,7 @@ describe('actions and events', () => {
 
     // verify initial events
     const haveChanges = wrapper.emitted('haveChanges')
-    expect(haveChanges.length).toBe(1)
+    expect(haveChanges.length).toBe(2)
     expect(haveChanges.pop()).toEqual([false])
   })
 
@@ -974,7 +974,7 @@ describe('actions and events', () => {
     expect(wrapper.vm.getOfficeAddresses.registeredOffice.mailingAddress.addressCity).toBe('addressCity1')
 
     // verify there are no new events
-    expect(wrapper.emitted('haveChanges').length).toEqual(1)
+    expect(wrapper.emitted('haveChanges').length).toEqual(2)
   })
 
   it('ignores a canceled change', async () => {
@@ -999,7 +999,7 @@ describe('actions and events', () => {
     expect(wrapper.vm.getOfficeAddresses.registeredOffice.mailingAddress.addressCity).toBe('addressCity1')
 
     // verify there are no new events
-    expect(wrapper.emitted('haveChanges').length).toEqual(1)
+    expect(wrapper.emitted('haveChanges').length).toEqual(2)
   })
 
   it('ignores a null change', async () => {
@@ -1029,7 +1029,7 @@ describe('actions and events', () => {
 
     // verify new events
     const haveChanges = wrapper.emitted('haveChanges')
-    expect(haveChanges.length).toBe(2)
+    expect(haveChanges.length).toBe(3)
     expect(haveChanges.pop()).toEqual([false])
   })
 
@@ -1056,7 +1056,7 @@ describe('actions and events', () => {
 
     // verify new events
     const haveChanges = wrapper.emitted('haveChanges')
-    expect(haveChanges.length).toBe(2)
+    expect(haveChanges.length).toBe(3)
     expect(haveChanges.pop()).toEqual([true])
   })
 
@@ -1092,7 +1092,7 @@ describe('actions and events', () => {
 
     // verify new events
     const haveChanges = wrapper.emitted('haveChanges')
-    expect(haveChanges.length).toBe(3)
+    expect(haveChanges.length).toBe(4)
     expect(haveChanges.pop()).toEqual([false])
   })
 
@@ -1137,7 +1137,7 @@ describe('actions and events', () => {
 
     // verify new events
     const haveChanges = wrapper.emitted('haveChanges')
-    expect(haveChanges.length).toBe(3)
+    expect(haveChanges.length).toBe(4)
     expect(haveChanges.pop()).toEqual([true])
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7416

*Description of changes:*

* Include Staff payment in filing and draft parsing.

* Added Staff payment to alteration filing build.

* Created method to parse staff payment into store for both alterations and corrections.

* Fixed Office addresses bug where it wouldn't initialize the data after changing views, would only update the component when the Store values changed, which only happened once in Alterations.

* verified resolution dates are working as expected.

* Minor unit test updates to include the additional event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
