### PR TITLE
BUGFIX: restore Folio Number when parsing draft alteration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -393,11 +393,9 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     this.setBusinessSnapshot(businessSnapshot)
 
     // Restore current entity type
-    // TODO: should we omit this as it was set from business snapshot ???
     this.setEntityType(filing.alteration.business.legalType)
 
     // Restore business information
-    // TODO: should we omit this as it was set from business snapshot ???
     this.setBusinessInformation({
       ...filing.business,
       ...filing.alteration.business
@@ -468,7 +466,8 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
       certifiedBy: filing.header.certifiedBy
     })
 
-    // NB: do not restore Folio Number - it was already set from business snapshot
+    // Restore Folio Number
+    this.setFolioNumber(businessSnapshot.authInfo.folioNumber || '')
 
     // If Transactional Folio Number was saved then restore it.
     if (filing.header.isTransactionalFolioNumber) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5024

*Description of changes:*
- the Folio Number needs to be restored when parsing a draft alteration
- as this is a functional change, the app version was updated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).