### PR TITLE
Added flag to display filings filed by Registry Staff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.14",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.14",
+  "version": "0.7.0",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -64,6 +64,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
   @Getter getProvisionsRemoved!: boolean
   @Getter getFileNumber!: string
   @Getter getHasPlanOfArrangement!: boolean
+  @Getter isRoleStaff!: boolean
 
   // Global actions
   @Action setBusinessContact!: ActionBindingIF
@@ -126,7 +127,8 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
         name: FilingTypes.CORRECTION,
         certifiedBy: this.getCertifyState.certifiedBy,
         date: this.getCurrentDate, // "absolute day" (YYYY-MM-DD in Pacific time)
-        folioNumber: this.getFolioNumber // original folio number, unless overridden by staff payment below
+        folioNumber: this.getFolioNumber, // original folio number, unless overridden by staff payment below
+        isStaff: this.isRoleStaff
       },
       business: {
         legalType: this.getEntityType,
@@ -209,7 +211,8 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
         name: FilingTypes.ALTERATION,
         certifiedBy: this.getCertifyState.certifiedBy,
         date: this.getCurrentDate, // "absolute day" (YYYY-MM-DD in Pacific time)
-        folioNumber: this.getFolioNumber
+        folioNumber: this.getFolioNumber,
+        isStaff: this.isRoleStaff
       },
       business: {
         foundingDate: this.getBusinessSnapshot.businessInfo.foundingDate,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6814

*Description of changes:*
- added isStaff flag to Correction and Alteration filings
- updated app minor release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).