### PR TITLE
10999 Fixed init bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.29",
+  "version": "0.6.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "0.6.29",
+  "version": "0.6.30",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10999

*Description of changes:*

This is not truly a bug since the code works, but it works due to lucky timing. This change -- same as in Create UI -- ensures that create() is run before onRouteChange() runs. This ensures that the current date is set before anything else that might depend on it runs.

- renamed initApp -> fetchData (same as Create UI)
- init app at end of create(), not on initial route change
- app version = 0.6.30

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).