### PR TITLE
9014 HTML tags show up in the warning popup window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "2.1.10",
+  "version": "2.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "2.1.10",
+  "version": "2.1.9",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/dialogs/PaymentErrorDialog.vue
+++ b/src/components/common/dialogs/PaymentErrorDialog.vue
@@ -34,9 +34,12 @@
         <!-- display warnings-->
         <div class="genErr mb-4" v-if="numWarnings > 0">
           <p>Please note the following warnings:</p>
-          <ul>
-            <li v-for="(warning, index) in warnings" :key="index">{{ warning.message }}</li>
-          </ul>
+          <div v-for="(warning, index) in warnings" :key="index" class="d-flex">
+            <span class="flex-shrink-0 error-bullet">
+              <v-icon class="error-circle">mdi-circle-medium</v-icon>
+            </span>
+            <span class="flex-grow-1" v-html="warning.message" />
+          </div>
         </div>
 
         <template v-if="!isRoleStaff">

--- a/src/components/common/dialogs/PaymentErrorDialog.vue
+++ b/src/components/common/dialogs/PaymentErrorDialog.vue
@@ -24,7 +24,7 @@
         <div class="genErr mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <ul>
-            <li v-for="(error, index) in errors" :key="index">{{ error.message }}</li>
+            <li v-for="(error, index) in errors[0].message.split('<br/>')" :key="index">{{ error }}</li>
           </ul>
         </div>
 

--- a/src/components/common/dialogs/PaymentErrorDialog.vue
+++ b/src/components/common/dialogs/PaymentErrorDialog.vue
@@ -24,9 +24,7 @@
         <div class="genErr mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <div v-for="(error, index) in errors" :key="index" class="d-flex">
-            <span class="flex-shrink-0 error-bullet">
-              <v-icon class="error-circle">mdi-circle-medium</v-icon>
-            </span>
+            <span class="flex-shrink-0"><v-icon>mdi-circle-medium</v-icon></span>
             <span class="flex-grow-1" v-html="error.message" />
           </div>
         </div>
@@ -35,9 +33,7 @@
         <div class="genErr mb-4" v-if="numWarnings > 0">
           <p>Please note the following warnings:</p>
           <div v-for="(warning, index) in warnings" :key="index" class="d-flex">
-            <span class="flex-shrink-0 error-bullet">
-              <v-icon class="error-circle">mdi-circle-medium</v-icon>
-            </span>
+            <span class="flex-shrink-0"><v-icon>mdi-circle-medium</v-icon></span>
             <span class="flex-grow-1" v-html="warning.message" />
           </div>
         </div>
@@ -98,14 +94,3 @@ export default class PaymentErrorDialog extends Vue {
   }
 }
 </script>
-
-<style scoped>
-  .error-bullet {
-    padding-left: 1.4px;
-    padding-right: 5px;
-  }
-
-  .error-circle {
-    font-size: 18px;
-  }
-</style>

--- a/src/components/common/dialogs/PaymentErrorDialog.vue
+++ b/src/components/common/dialogs/PaymentErrorDialog.vue
@@ -24,8 +24,8 @@
         <div class="genErr mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <div v-for="(error, index) in errors" :key="index" class="d-flex">
-            <span id="error-bullet" class="flex-shrink-0 bullet">
-              <v-icon id="error-circle">mdi-circle-medium</v-icon>
+            <span class="flex-shrink-0 error-bullet">
+              <v-icon class="error-circle">mdi-circle-medium</v-icon>
             </span>
             <span class="flex-grow-1" v-html="error.message" />
           </div>
@@ -97,12 +97,12 @@ export default class PaymentErrorDialog extends Vue {
 </script>
 
 <style scoped>
-  #error-bullet {
+  .error-bullet {
     padding-left: 1.4px;
     padding-right: 5px;
   }
 
-  #error-circle {
+  .error-circle {
     font-size: 18px;
   }
 </style>

--- a/src/components/common/dialogs/PaymentErrorDialog.vue
+++ b/src/components/common/dialogs/PaymentErrorDialog.vue
@@ -23,9 +23,12 @@
         <!-- display errors -->
         <div class="genErr mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
-          <ul>
-            <li v-for="(error, index) in errors[0].message.split('<br/>')" :key="index">{{ error }}</li>
-          </ul>
+          <div v-for="(error, index) in errors" :key="index" class="d-flex">
+            <span id="error-bullet" class="flex-shrink-0 bullet">
+              <v-icon id="error-circle">mdi-circle-medium</v-icon>
+            </span>
+            <span class="flex-grow-1" v-html="error.message" />
+          </div>
         </div>
 
         <!-- display warnings-->
@@ -92,3 +95,14 @@ export default class PaymentErrorDialog extends Vue {
   }
 }
 </script>
+
+<style scoped>
+  #error-bullet {
+    padding-left: 1.4px;
+    padding-right: 5px;
+  }
+
+  #error-circle {
+    font-size: 18px;
+  }
+</style>

--- a/src/components/common/dialogs/StaffPaymentErrorDialog.vue
+++ b/src/components/common/dialogs/StaffPaymentErrorDialog.vue
@@ -13,7 +13,7 @@
         <div class="genErr mb-4" v-else>
           <p>We were unable to process your payment due to the following error(s):</p>
           <ul>
-            <li v-for="(error, index) in errors[0].message.split('<br/>')" :key="index">{{ error }}</li>
+            <li v-for="(error, index) in errors" :key="index">{{ error.message }}</li>
           </ul>
         </div>
 

--- a/src/components/common/dialogs/StaffPaymentErrorDialog.vue
+++ b/src/components/common/dialogs/StaffPaymentErrorDialog.vue
@@ -13,7 +13,7 @@
         <div class="genErr mb-4" v-else>
           <p>We were unable to process your payment due to the following error(s):</p>
           <ul>
-            <li v-for="(error, index) in errors" :key="index">{{ error.message }}</li>
+            <li v-for="(error, index) in errors[0].message.split('<br/>')" :key="index">{{ error }}</li>
           </ul>
         </div>
 

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -87,7 +87,7 @@ describe('Payment Error Dialog', () => {
     wrapper.destroy()
   })
 
-  it('renders PAD error messages correctly when they are present', () => {
+  it('renders error messages correctly when they are present', () => {
     store.state.stateModel.tombstone.keycloakRoles = ['edit', 'view']
     const wrapper = shallowMount(PaymentErrorDialog,
       {
@@ -115,7 +115,7 @@ describe('Payment Error Dialog', () => {
     wrapper.destroy()
   })
 
-  it('renders PAD warning messages correctly when they are present', () => {
+  it('renders warning messages correctly when they are present', () => {
     store.state.stateModel.tombstone.authRoles = ['edit', 'view']
     const wrapper = shallowMount(PaymentErrorDialog,
       {

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -105,8 +105,39 @@ describe('Payment Error Dialog', () => {
       'We were unable to process your payment due to the following errors:'
     )
     expect(wrapper.findAll('p').at(2).text()).toContain('If this error persists')
-    expect(wrapper.findAll('li').length).toBe(1)
-    expect(wrapper.findAll('li').at(0).text()).toContain(padError[0].message)
+    expect(wrapper.findAll('li').length).toBe(0)
+    expect(wrapper.findAll('span').length).toBe(2)
+    expect(wrapper.findAll('span').at(1).text()).toContain('Your account is in the 3 day PAD confirmation period.')
+
+    expect(wrapper.findComponent(ErrorContact).exists()).toBe(true)
+    expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('renders PAD warning messages correctly when they are present', () => {
+    store.state.stateModel.tombstone.authRoles = ['edit', 'view']
+    const wrapper = shallowMount(PaymentErrorDialog,
+      {
+        vuetify,
+        store,
+        propsData: { dialog: true, warnings: [
+          { message: 'Test Warning 1' },
+          { message: 'Test Warning 2' }
+        ]}
+      })
+
+    expect(wrapper.attributes('contentclass')).toBe('payment-error-dialog')
+    expect(wrapper.isVisible()).toBe(true)
+    expect(wrapper.find('#dialog-title').text()).toBe('Unable to process payment')
+    expect(wrapper.findAll('p').length).toBe(3)
+    expect(wrapper.findAll('p').at(0).text()).toContain('We are unable to process your payment')
+    expect(wrapper.findAll('p').at(1).text()).toContain('Please note the following warnings')
+    expect(wrapper.findAll('li').length).toBe(2)
+    expect(wrapper.findAll('li').at(0).text()).toBe('Test Warning 1')
+    expect(wrapper.findAll('li').at(1).text()).toBe('Test Warning 2')
+    expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
+    expect(wrapper.find('#dialog-okay-button').exists()).toBe(false)
 
     expect(wrapper.findComponent(ErrorContact).exists()).toBe(true)
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -133,9 +133,11 @@ describe('Payment Error Dialog', () => {
     expect(wrapper.findAll('p').length).toBe(3)
     expect(wrapper.findAll('p').at(0).text()).toContain('We are unable to process your payment')
     expect(wrapper.findAll('p').at(1).text()).toContain('Please note the following warnings')
-    expect(wrapper.findAll('li').length).toBe(2)
-    expect(wrapper.findAll('li').at(0).text()).toBe('Test Warning 1')
-    expect(wrapper.findAll('li').at(1).text()).toBe('Test Warning 2')
+    expect(wrapper.findAll('li').length).toBe(0)
+    expect(wrapper.findAll('span').length).toBe(4)
+    expect(wrapper.findAll('span').at(1).text()).toContain('Test Warning 1')
+    expect(wrapper.findAll('span').at(3).text()).toContain('Test Warning 2')
+
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
     expect(wrapper.find('#dialog-okay-button').exists()).toBe(false)
 

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -121,10 +121,11 @@ describe('Payment Error Dialog', () => {
       {
         vuetify,
         store,
-        propsData: { dialog: true, warnings: [
-          { message: 'Test Warning 1' },
-          { message: 'Test Warning 2' }
-        ]}
+        propsData: { dialog: true,
+          warnings: [
+            { message: 'Test Warning 1' },
+            { message: 'Test Warning 2' }
+          ] }
       })
 
     expect(wrapper.attributes('contentclass')).toBe('payment-error-dialog')


### PR DESCRIPTION
Issue #: [/bcgov/entity#9014](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/9014)

Description of changes:
When a payment error occurred, a popup window for "Unable to process payment" show up.
tags are included in the text in the popup window, and they need to be removed.

- [ ] Edit UI


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
