### PR TITLE
11932 Proprietor and Partner - UX Improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -55,7 +55,6 @@ h1, h2, h3, h4 {
 }
 
 h1, h2{
-  letter-spacing: -0.04rem;
   font-weight: bold;
 }
 

--- a/src/components/Alteration/ChangeSummary.vue
+++ b/src/components/Alteration/ChangeSummary.vue
@@ -57,12 +57,16 @@
       <article id="org-person-summary-section" class="section-container">
         <v-row no-gutters>
           <v-col cols="12" sm="3">
-            <label>{{ firmLabel }} Information</label>
+            <label>{{ getResource.entityType === 'SP' ? 'Proprietor' : 'Partner' }} Information</label>
           </v-col>
         </v-row>
         <v-row no-gutters class="mt-4">
           <v-col cols="12">
-            <ListPeopleAndRoles :peopleAndRoles="getPeopleAndRoles" :isSummaryView="true" />
+            <ListPeopleAndRoles
+              :peopleAndRoles="getPeopleAndRoles"
+              :isSummaryView="true"
+              :hasMinimumPartners="hasMinimumPartners"
+            />
           </v-col>
         </v-row>
       </article>
@@ -93,6 +97,7 @@ export default class ChangeSummary extends Mixins(
   // Global getters
   @Getter getBusinessNumber!: string
   @Getter getResource!: ResourceIF
+  @Getter hasMinimumPartners!: boolean
 
   // Global actions
   @Action setSummaryMode!: ActionBindingIF
@@ -105,11 +110,6 @@ export default class ChangeSummary extends Mixins(
     if (this.getApprovedName) return this.getApprovedName
 
     return `${this.getBusinessNumber || '[Incorporation Number]'} B.C. Ltd.`
-  }
-
-  /** The firm type label. */
-  get firmLabel (): string {
-    return this.getResource.changeData.orgPersonInfo.orgPersonLabel
   }
 }
 </script>

--- a/src/components/common/HelpSection.vue
+++ b/src/components/common/HelpSection.vue
@@ -18,7 +18,7 @@
         <BcRegContacts class="mb-6" :direction="'col'" />
 
         <label>Hours of Operation:</label>
-        <p>Monday to Friday, 8:30am - 4:30pm Pacific Time</p>
+        <p>Monday to Friday, 8:30am - 4:30pm Pacific time</p>
         <div class="help-btn bottom" @click="helpToggle = !helpToggle">Hide Help</div>
       </section>
     </v-expand-transition>

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -39,7 +39,10 @@
       <!-- List Content -->
       <v-row
         class="people-roles-content section-container"
-        :class="{'invalid-section': invalidOrgPersons, 'summary-view': isSummaryView}"
+        :class="{
+          'invalid-section': invalidOrgPersons || !hasMinimumPartners,
+          'summary-view': isSummaryView
+        }"
         v-for="(orgPerson, index) in currentPeopleAndRoles"
         :key="index"
         no-gutters
@@ -302,6 +305,8 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
 
   // declaration for template
   readonly isSame = isSame
+  @Prop({ default: true })
+  readonly hasMinimumPartners: boolean
 
   /** The name section validity state (when prompted by app). */
   get invalidOrgPersons (): boolean {

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -303,10 +303,11 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
   @Prop({ default: false })
   readonly validate!: boolean
 
-  // declaration for template
-  readonly isSame = isSame
   @Prop({ default: true })
   readonly hasMinimumPartners: boolean
+
+  // declaration for template
+  readonly isSame = isSame
 
   /** The name section validity state (when prompted by app). */
   get invalidOrgPersons (): boolean {

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -119,7 +119,7 @@
               <template v-if="isProprietor || isPartner && !isNaN(activeIndex)">
                 <article class="mt-n4">
                   <v-checkbox
-                    class="confirm-proprietor-name-change-chkbx mb-6"
+                    class="confirm-proprietor-name-change-chkbx mb-8"
                     :label="`I confirm ${orgPersonLabel} has legally changed their name and that they remain the ` +
                       `same person.`"
                     :hide-details="true"

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -30,7 +30,8 @@
               <template v-if="isPerson">
                 <label class="sub-header">Person's Name</label>
                 <p v-if="isProprietor" class="info-text mb-0">
-                  If the proprietor has changed their legal name, enter their new legal name.
+                  If the {{ isProprietor ? 'proprietor' : 'partner' }} has changed their legal name,
+                  enter their new legal name.
                 </p>
                 <article class="form__row three-column pt-6">
                   <v-text-field
@@ -44,7 +45,7 @@
                   <v-text-field
                     filled
                     class="item"
-                    label="Middle Name"
+                    label="Middle Name (Optional)"
                     id="person__middle-name"
                     v-model="orgPerson.officer.middleName"
                     :rules="middleNameRules"
@@ -65,15 +66,17 @@
 
                 <!-- Orgs from BC -->
                 <article v-if="isChangeFiling && toggleBcLookUp && isNaN(activeIndex)">
-                  <label class="sub-header">{{ orgTypesLabel }} Look up</label>
+                  <label class="sub-header">{{ orgTypesLabel }} Look Up</label>
                   <span class="toggle-business-entry" @click="toggleBcLookUp = !toggleBcLookUp">
                     {{ orgTypesLabel }} is Unregistered in B.C.
                   </span>
-                  <p class="info-text mt-4">To add a registered B.C. business or corporation as the Proprietor, enter
-                    the name or incorporation number.</p>
-                  <p class="info-text">If you are a company that is not legally required to register in BC such as a
-                    bank or a railway, use the manual lookup. All other types of businesses cannot be a proprietor or
-                    partner.</p>
+                  <p class="info-text mt-4">To add a registered B.C. business or corporation as the
+                    {{ isProprietor ? 'Proprietor' : 'Partner' }}, enter the name or incorporation number.
+                  </p>
+                  <p class="info-text">If you want to add a company that is not legally required to register in B.C.
+                    such as a bank or a railway, use the manual entry form. All other types of businesses cannot be
+                    a {{ isProprietor ? 'proprietor' : 'partner' }}.
+                  </p>
                   <!-- FUTURE: Inject subcomponent here for business Look Up -->
                 </article>
 
@@ -81,11 +84,12 @@
                 <article v-else-if="isChangeFiling && !toggleBcLookUp && isNaN(activeIndex)">
                   <label class="sub-header">{{ orgTypesLabel }} Unregistered in B.C.</label>
                   <span class="toggle-business-entry" @click="toggleBcLookUp = !toggleBcLookUp">
-                    {{ orgTypesLabel }} Look up
+                    {{ orgTypesLabel }} Look Up
                   </span>
-                  <p class="info-text mt-4">Use this manual entry form to add a company that is not legally required to
-                    register in B.C. such as a bank or a railway as a partner. All other types of businesses not
-                    registered in B.C. cannot be a proprietor or partner.</p>
+                  <p class="info-text mt-4">Use this form only if want to add a company that is not legally required to
+                    register in B.C. E.g. a bank, a railway, parishes, private acts, and credit unions. All other types
+                    of businesses not registered in B.C. cannot be a partner.
+                  </p>
                   <HelpSection :helpSection="getResource.changeData.orgPersonInfo.helpSection" />
                 </article>
 
@@ -122,6 +126,21 @@
                     :rules="confirmNameChangeRules"
                     v-model="orgPerson.confirmNameChange"
                   />
+                </article>
+              </template>
+
+              <!-- FUTURE: Firm incorporation number -->
+              <!-- <template v-if="orgPerson.officer.?">
+                <article class="mb-8">
+                  <label class="sub-header">Incorporation Number:</label>
+                  <span class="sp-number-text">{{ 'orgPerson.officer.?' }}</span>
+                </article>
+              </template> -->
+
+              <template v-if="orgPerson.officer.taxId">
+                <article class="mb-8">
+                  <label class="sub-header">Business Number:</label>
+                  <span class="ml-2 sp-number-text">{{ 'orgPerson.officer.taxId' }}</span>
                 </article>
               </template>
 
@@ -838,6 +857,11 @@ li {
     font-weight: normal;
   }
 
+  // align/center text with checkbox
+  .v-input--checkbox .v-input__control .v-input__slot .v-label.theme--light {
+    padding-top: 2px;
+  }
+
   .theme--light.v-input input, .theme--light.v-input textarea {
     color: $gray9;
   }
@@ -848,5 +872,9 @@ li {
    {
     margin-top: -4px;
   }
+}
+
+.sp-number-text {
+  color: $gray7;
 }
 </style>

--- a/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
@@ -123,6 +123,7 @@
           :activeIndex="activeIndex"
           :currentCompletingParty="currentCompletingParty"
           :validate="getComponentValidate"
+          :hasMinimumPartners="hasMinimumPartners"
           @initEdit="initEdit($event)"
           @addEdit="addEdit($event)"
           @remove="remove($event)"

--- a/src/resources/Change/GeneralPartnershipResource.ts
+++ b/src/resources/Change/GeneralPartnershipResource.ts
@@ -24,7 +24,7 @@ export const GeneralPartnershipResource: ResourceIF = {
       orgTypesLabel: 'Business or Corporation',
       subtitle: 'You must have a minimum of two partners. You can add or remove partners (individual person or ' +
         'business) as well as change the mailing and delivery addresses and email address of individual people and ' +
-        'business partners that were added manually during registration.',
+        'business partners.',
       helpSection: {
         header: 'Need Help? Contact Us',
         helpText: [

--- a/src/resources/Change/SoleProprietorshipResource.ts
+++ b/src/resources/Change/SoleProprietorshipResource.ts
@@ -23,8 +23,8 @@ export const SoleProprietorshipResource: ResourceIF = {
       orgPersonLabel: 'Proprietor',
       orgTypesLabel: 'Business or Corporation',
       subtitle: 'You can change the legal name, mailing and delivery addresses and the email address of the ' +
-        'individual proprietor. To change to a different proprietor, you must form a new business with that ' +
-        'proprietor and dissolve this registration.',
+        'proprietor. To change to a different proprietor, you must form a new business with that proprietor ' +
+        'and dissolve this registration.',
       helpSection: {
         header: 'Need Help? Contact Us',
         helpText: [

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -551,7 +551,8 @@ export const hasPeopleAndRolesChanged = (state: StateIF): boolean => {
 /** Is true when the minimum partners met. */
 export const hasMinimumPartners = (state: StateIF): boolean => {
   // REMOVED Parties are still in the parties array until FILING, so exclude them for component level validations.
-  return getPeopleAndRoles(state).filter(party => !party.actions?.includes(ActionTypes.REMOVED)).length >= 2
+  const isGP = state.resourceModel.entityType === 'GP'
+  return (!isGP || getPeopleAndRoles(state).filter(party => !party.actions?.includes(ActionTypes.REMOVED)).length >= 2)
 }
 
 /** Whether share structure data has changed. */


### PR DESCRIPTION
*Issue #:* [bcgov/entity/11932](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/11932)

*Description of changes:*

_UXA 1 of 4 - Reviewed in DEV / BCREG0017 using: TRACEY'S SP DBA TEST BUSINESS_

**Sole Prop (Person):**
- [x] Proprietor component intro text: remove the word "individual":
- [x] Increase white space below Name check box text by 5px so its further away from Email Address:
**Edit View:**
- [x] Future*: Missing the read only view of Business Number when a user enters it in registration:
**Table View:**
- [x] Future*: P&R Tables in screen 1 and screen 2 are missing the Business Number that appears under the Proprietor's email (I did enter the optional BN when I registered this business originally)


_UXA 2 of 4 - Reviewed in DEV / BCREG0017 using: TRACEY'S SP DBA TEST BUSINESS_

**DBA - Sole Prop (Business):**
- [x] Proprietor component intro text: remove the word "individual":
- [x] Wrong text for business name check box - should say: I confirm the proprietor has legally changed their name and that the proprietor remains the same "business." (not "person")
**Edit View:**
- [x] Missing the read only Inc and/or Business number information that should appear if/when the user includes these during registration as per DBA design comp (Inc may not be visible until we have Business look up done):
**Table View:**
- [x] Future: P&R Tables in screen 1 and screen 2 are missing the Business Number that appears under the Proprietor's email (I did enter the optional BN when I registered this business originally)
- [x] DBA Proprietor's mailing and delivery addresses can be anywhere - should not serve an error if they select outside of BC


_UXA 3 of 4 - Reviewed in DEV / BCREG0017 using: TRACEY'S TEST GP BUSINESS_

**GP Flow:**
- [x] Partner component intro text: remove "that were added manually during registration."
**Validation for less than 2 Partners:**
- [x] If user removes partners and has less than two, and clicks the "Review and Confirm" Button, also show the vertical red validation bar, like this:
**Edit Partner View:**
- [x] Missing intro sentence under "Person's Name"
**Add Business Partner - Business or Corporation Unregistered in B.C. intro text:**
- [x] Update text to be: "Use this form only if want to add a company that is not legally required to register in B.C. E.g. a bank, a railway, parishes, private acts, and credit unions. All other types of businesses not registered in B.C. cannot be a partner."
**Add Business Partner- Business or Corporation Look Up intro text:**
- [x] Update text to be: "To add a registered B.C. business or corporation as the Partner, enter the name or incorporation number.
**Add Business Partner:**
- [x] Capital "U" for "Look Up" for title and link
Business Partner mailing/delivery addresses:
- [x] Business Partner mailing and delivery addresses can be anywhere - should not serve an error if they select outside of BC (same as SP DBA)
**Table View:**
- [x] Business names should appear in all caps:
**Review Screen:**
- [x] Remove "s" from "Partners Information" header


_UXA 4 of 4_

**All Flows - SP/DBA/GP:**
- [x] Middle name fields should say "(Optional)" (it is not required) - (SP/GP):
**Help Text Expansion (SPG/DBA/GP):**
Lower Priority
- [x] Remove the negative letterspacing from "Contact BC Registries" header
- [x] Lower case "t" for Pacific time
- [x] Lower Priority - Can the check box text sit vertically centred with all the checkboxes (text is sitting high)?


Future*:
- Business Number isn't hooked from states/BE
- Incorportation Number isn't hooked from states/BE


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
