### PR TITLE
11932 Fix Proprietor and Partner - UX Improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -553,6 +553,11 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
   }
 }
 
+// adjust error bar left spacing
+.people-roles-content.section-container.invalid-section {
+  margin-left: -30px
+}
+
 // adjust error container padding for last section
 .people-roles-content.section-container.invalid-section:last-of-type {
   padding: 1.25rem 1.875rem 2.5rem;

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -493,6 +493,11 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
   .dropdown-action {
     border-left: 1px solid $gray3;
   }
+
+  // adjust error bar left spacing
+  &.invalid-section {
+    margin-left: -30px;
+  }
 }
 
 .summary-view {
@@ -551,11 +556,6 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
   .badges .v-icon{
     margin-top: 4px
   }
-}
-
-// adjust error bar left spacing
-.people-roles-content.section-container.invalid-section {
-  margin-left: -30px
 }
 
 // adjust error container padding for last section

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -121,7 +121,7 @@
                   <v-checkbox
                     class="mb-8"
                     :label="`I confirm ${orgPersonLabel} has legally changed their name and that they remain the ` +
-                      `same business.`"
+                      `same ${orgTargetType}.`"
                     :hide-details="true"
                     :rules="confirmNameChangeRules"
                     v-model="orgPerson.confirmNameChange"
@@ -404,6 +404,13 @@ export default class OrgPerson extends Mixins(CommonMixin) {
   /** True if current data object is a person. */
   get isPerson (): boolean {
     return (this.orgPerson?.officer.partyType === PartyTypes.PERSON)
+  }
+
+  /** Text same target */
+  get orgTargetType (): string {
+    if (this.isProprietor) return this.isPerson ? 'person' : 'business'
+    if (this.isPartner) return 'business'
+    return 'business'
   }
 
   /** True if current data object is an organization (corporation/firm). */

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -408,9 +408,9 @@ export default class OrgPerson extends Mixins(CommonMixin) {
 
   /** Text same target */
   get orgTargetType (): string {
-    if (this.isProprietor) return this.isPerson ? 'person' : 'business'
-    if (this.isPartner) return 'business'
-    return 'business'
+    let target = 'business'
+    if (this.isProprietor) target = this.isPerson ? 'person' : 'business'
+    return target
   }
 
   /** True if current data object is an organization (corporation/firm). */

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -864,6 +864,7 @@ li {
     font-size: 1rem;
     color: $gray7;
     font-weight: normal;
+    padding-top: 2px; // label align with checkbox
   }
 
   .theme--light.v-input input, .theme--light.v-input textarea {

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -119,9 +119,9 @@
               <template v-if="isProprietor || isPartner && !isNaN(activeIndex)">
                 <article class="mt-n4">
                   <v-checkbox
-                    class="mb-8"
+                    class="mb-8 legal-confirm-label"
                     :label="`I confirm ${orgPersonLabel} has legally changed their name and that they remain the ` +
-                      `same ${orgTargetType}.`"
+                      `same ${orgConfirmLabel}.`"
                     :hide-details="true"
                     :rules="confirmNameChangeRules"
                     v-model="orgPerson.confirmNameChange"
@@ -385,6 +385,11 @@ export default class OrgPerson extends Mixins(CommonMixin) {
     return this.isProprietor ? 'the proprietor' : 'this partner'
   }
 
+  /** Text confirm label for firm orgPerson */
+  get orgConfirmLabel (): string {
+    return this.isProprietor && this.isPerson ? 'person' : 'business'
+  }
+
   /** True if the form is valid. */
   get isFormValid (): boolean {
     let isFormValid = (this.orgPersonFormValid && this.mailingAddressValid)
@@ -404,13 +409,6 @@ export default class OrgPerson extends Mixins(CommonMixin) {
   /** True if current data object is a person. */
   get isPerson (): boolean {
     return (this.orgPerson?.officer.partyType === PartyTypes.PERSON)
-  }
-
-  /** Text same target */
-  get orgTargetType (): string {
-    let target = 'business'
-    if (this.isProprietor) target = this.isPerson ? 'person' : 'business'
-    return target
   }
 
   /** True if current data object is an organization (corporation/firm). */

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -556,8 +556,8 @@ describe('Org/Person component for Correction', () => {
         currentOrgPerson: validProprietorData,
         activeIndex: 0,
         currentCompletingParty: null,
-        isProprietor: true,
-      },
+        isProprietor: true
+      }
     })
     expect(wrapper.findAll('.legal-confirm-label').at(0).text()).toContain('the same person')
 
@@ -588,8 +588,8 @@ describe('Org/Person component for Correction', () => {
         currentOrgPerson: validProprietorData,
         activeIndex: 0,
         currentCompletingParty: null,
-        isProprietor: true,
-      },
+        isProprietor: true
+      }
     })
     expect(wrapper.findAll('.legal-confirm-label').at(0).text()).toContain('the same business')
 
@@ -620,8 +620,8 @@ describe('Org/Person component for Correction', () => {
         currentOrgPerson: validPartnerData,
         activeIndex: 0,
         currentCompletingParty: null,
-        isProprietor: true,
-      },
+        isProprietor: true
+      }
     })
     expect(wrapper.findAll('.legal-confirm-label').at(0).text()).toContain('the same business')
 

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -531,4 +531,100 @@ describe('Org/Person component for Correction', () => {
 
     wrapper.destroy()
   })
+
+  it('Displays label "person" for SP (person)', async () => {
+    const validProprietorData = {
+      officer: {
+        id: '2',
+        firstName: '',
+        lastName: '',
+        middleName: '',
+        organizationName: 'Test Org',
+        partyType: 'person',
+        taxId: '1111'
+      },
+      roles: [
+        { roleType: 'Proprietor', appointmentDate: '2020-03-30' }
+      ],
+      mailingAddress: null
+    }
+
+    const wrapper = mount(OrgPerson, {
+      store,
+      vuetify,
+      propsData: {
+        currentOrgPerson: validProprietorData,
+        activeIndex: 0,
+        currentCompletingParty: null,
+        isProprietor: true,
+      },
+    })
+    expect(wrapper.findAll('.legal-confirm-label').at(0).text()).toContain('the same person')
+
+    wrapper.destroy()
+  })
+
+  it('Displays label "business" for SP (organization)', async () => {
+    const validProprietorData = {
+      officer: {
+        id: '2',
+        firstName: '',
+        lastName: '',
+        middleName: '',
+        organizationName: 'Test Org',
+        partyType: 'organization',
+        taxId: '1111'
+      },
+      roles: [
+        { roleType: 'Proprietor', appointmentDate: '2020-03-30' }
+      ],
+      mailingAddress: null
+    }
+
+    const wrapper = mount(OrgPerson, {
+      store,
+      vuetify,
+      propsData: {
+        currentOrgPerson: validProprietorData,
+        activeIndex: 0,
+        currentCompletingParty: null,
+        isProprietor: true,
+      },
+    })
+    expect(wrapper.findAll('.legal-confirm-label').at(0).text()).toContain('the same business')
+
+    wrapper.destroy()
+  })
+
+  it('Displays label "business" for GP (organization)', async () => {
+    const validPartnerData = {
+      officer: {
+        id: '2',
+        firstName: '',
+        lastName: '',
+        middleName: '',
+        organizationName: 'Test Org',
+        partyType: 'organization',
+        taxId: '1111'
+      },
+      roles: [
+        { roleType: 'Partner', appointmentDate: '2020-03-30' }
+      ],
+      mailingAddress: null
+    }
+
+    const wrapper = mount(OrgPerson, {
+      store,
+      vuetify,
+      propsData: {
+        currentOrgPerson: validPartnerData,
+        activeIndex: 0,
+        currentCompletingParty: null,
+        isProprietor: true,
+      },
+    })
+    expect(wrapper.findAll('.legal-confirm-label').at(0).text()).toContain('the same business')
+
+    wrapper.destroy()
+  })
 })


### PR DESCRIPTION
Issue #: [bcgov/entity/11932](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/11932)

*Description of changes:*
**SP with Individual Proprietor**
- [x] When editing an individual proprietor, "I confirm the proprietor has legally changed their name and that they remain the same person." should read, "I confirm the proprietor has legally changed their name and that they remain the same business." Note that in SP, there are two cases. Case A: the proprietor is an individual and we want "person" in the sentence. Case B: the proprietor is a business and we want "business" in the sentence.

**GP**
- [x] The error bar is still not at the edge of the white background


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-edit-ui license (Apache 2.0).

Added:
- [x] Align checkbox with label texts, e.g. [x] I confirm the proprietor...