### PR TITLE
12419 Removed name change checkbox + some NAICS fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.1.10",
+      "version": "3.1.11",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Conversion/ConversionNOB.vue
+++ b/src/components/Conversion/ConversionNOB.vue
@@ -105,6 +105,7 @@ export default class NatureOfBusiness extends Vue {
   protected naicsText = ''
 
   readonly naicsRules = [
+    (v: string) => !!v || 'A NAICS description is required',
     (v: string) => (v?.length <= 300) || 'Maximum 300 characters reached'
   ]
 
@@ -145,7 +146,6 @@ export default class NatureOfBusiness extends Vue {
 
   /** Called when user has clicked the Cancel button. */
   protected onCancelClicked (): void {
-    this.setNaics(this.getSnapshotNaics)
     this.onEditMode = false
   }
 
@@ -165,7 +165,18 @@ export default class NatureOfBusiness extends Vue {
   /** Called when this edit mode has changed. */
   @Watch('onEditMode', { immediate: true })
   private onIsEditModeChanged (): void {
-    this.setValidComponent({ key: 'isValidNatureOfBusiness', value: !this.onEditMode })
+    this.updateValidity()
+  }
+
+  /** Called when NAICS Description has changed. */
+  @Watch('getCurrentNaics.naicsDescription', { immediate: true })
+  private onNaicsDescriptionChanged (): void {
+    this.updateValidity()
+  }
+
+  private updateValidity (): void {
+    const isValid = !this.onEditMode && !!this.getCurrentNaics.naicsDescription
+    this.setValidComponent({ key: 'isValidNatureOfBusiness', value: isValid })
   }
 }
 </script>

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -116,7 +116,7 @@
               </template>
 
               <!-- Firm Name Change confirmation -->
-              <template v-if="isProprietor || isPartner && !isNaN(activeIndex)">
+              <template v-if="(isProprietor || isPartner) && !isNaN(activeIndex) && !isConversionFiling">
                 <article class="mt-4">
                   <v-checkbox
                     class="legal-confirm-label"

--- a/src/resources/Conversion/SoleProprietorshipResource.ts
+++ b/src/resources/Conversion/SoleProprietorshipResource.ts
@@ -24,12 +24,7 @@ export const SoleProprietorshipResource: ResourceIF = {
       subtitle: 'You can change the legal name, mailing and delivery addresses and the email address of the ' +
         'proprietor. To change to a different proprietor, you must form a new business with that proprietor ' +
         'and dissolve this registration.',
-      helpSection: {
-        header: 'Need Help? Contact Us',
-        helpText: [
-          'If your require assistance with changes to the business proprietor please contact us.'
-        ]
-      }
+      helpSection: null
     }
   },
   certifyClause: null

--- a/src/store/actions/actions-model.ts
+++ b/src/store/actions/actions-model.ts
@@ -1,5 +1,5 @@
 import { ActionIF, ActionKvIF, AddressesIF, BusinessInformationIF, CertifyIF, EntitySnapshotIF, NameRequestIF,
-  NameTranslationIF, OrgPersonIF, ShareClassIF, FeesIF, ResourceIF } from '@/interfaces/'
+  NameTranslationIF, OrgPersonIF, ShareClassIF, FeesIF, ResourceIF, FilingDataIF } from '@/interfaces/'
 import { CompletingPartyIF, ContactPointIF, NaicsIF } from '@bcrs-shared-components/interfaces/'
 import { FilingTypes } from '@/enums/'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
@@ -192,7 +192,7 @@ export const setStaffPaymentValidity: ActionIF = ({ commit }, validity: boolean)
   commit('mutateStaffPaymentValidity', validity)
 }
 
-export const setFilingData: ActionIF = ({ commit }, filingData): void => {
+export const setFilingData: ActionIF = ({ commit }, filingData: FilingDataIF): void => {
   commit('mutateFilingData', filingData)
 }
 

--- a/tests/unit/ConversionNatureOfBusiness.spec.ts
+++ b/tests/unit/ConversionNatureOfBusiness.spec.ts
@@ -20,7 +20,11 @@ const businessInformation = {
   naicsDescription: 'food'
 }
 
-const updatedBusinessInfo = { ...businessInformation, naicsCode: '', naicsDescription: '100001 - cake' }
+const updatedBusinessInfo = {
+  ...businessInformation,
+  naicsCode: null,
+  naicsDescription: '100001 - cake'
+}
 
 const entitySnapShot = {
   businessInfo: businessInformation,
@@ -32,16 +36,9 @@ const entitySnapShot = {
   resolutions: null
 }
 
-// const updatedEntitySnapShot = { ...entitySnapShot, businessInfo: updatedBusinessInfo }
-
 const initialProps = {
   onEditMode: false,
   naicsText: ''
-}
-
-const updatedProps = {
-  onEditMode: false,
-  dropdown: false
 }
 
 describe('ConversionNatureOfBusiness without update', () => {
@@ -117,9 +114,9 @@ describe('ConversionNatureOfBusiness without update', () => {
     await doneBtn.trigger('click')
 
     expect(wrapper.vm.$data.naicsText).toBe('')
-    expect(wrapper.vm.$data.onEditMode).toBeFalsy()
-    expect(wrapper.find('#naics-summary').exists()).toBeTruthy()
-    expect(wrapper.find('#naics-summary').text()).toBe('(Not entered)')
+    expect(wrapper.vm.$data.onEditMode).toBe(true)
+    expect(wrapper.find('#naics-summary').exists()).toBe(false)
+    expect(wrapper.find('.v-textarea').text()).toContain('A NAICS description is required')
   })
 
   it('simulates error for over 300 characters length', async () => {
@@ -169,7 +166,10 @@ describe('ConversionNatureOfBusiness after the update', () => {
         vuetify
       })
     }
-    wrapper = wrapperFactory(updatedProps)
+    wrapper = wrapperFactory({
+      onEditMode: false,
+      dropdown: false
+    })
   })
 
   afterEach(() => {
@@ -182,8 +182,8 @@ describe('ConversionNatureOfBusiness after the update', () => {
   })
 
   it('renders the text field and texts', async () => {
-    const changeBtn = wrapper.find('#nob-change-btn')
-    await changeBtn.trigger('click')
+    await wrapper.find('#nob-menu-btn').trigger('click')
+    await wrapper.find('#more-changes-btn').trigger('click')
 
     expect(wrapper.vm.$data.onEditMode).toBeTruthy()
     expect(wrapper.find('p').text()).toContain('Provide a brief description')
@@ -195,8 +195,8 @@ describe('ConversionNatureOfBusiness after the update', () => {
   })
 
   it('simulates input text and the done button', async () => {
-    const changeBtn = wrapper.find('#nob-change-btn')
-    await changeBtn.trigger('click')
+    await wrapper.find('#nob-menu-btn').trigger('click')
+    await wrapper.find('#more-changes-btn').trigger('click')
 
     expect(wrapper.vm.$data.onEditMode).toBeTruthy()
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12419

*Description of changes:*
- removed name change confirmation checkbox in conversion filing
- added check for required NAICS description
- don't revert NAICS on cancel
- use NAICS value when computing validity
- fixed unit tests
- app version = 3.1.11
- removed help section from SP conversion

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).