### PR TITLE
12427 Removed staff payment component from conversion filing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.1.11",
+      "version": "3.1.12",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.1.12",
+      "version": "3.1.13",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/interfaces/resource-interfaces/resource-interface.ts
+++ b/src/interfaces/resource-interfaces/resource-interface.ts
@@ -1,6 +1,5 @@
-import { CorrectionTypes, FilingCodes, NameRequestEntityTypes } from '@/enums/'
-import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
-import { HelpSectionIF } from '@/interfaces/'
+import { CorrectionTypes, NameRequestEntityTypes } from '@/enums/'
+import { HelpSectionIF, FilingDataIF } from '@/interfaces/'
 
 /** Interface to define the resource model example */
 export interface ResourceIF {
@@ -9,11 +8,7 @@ export interface ResourceIF {
   displayName: string
   nameRequestType: NameRequestEntityTypes
   addressLabel: string
-  filingData: {
-    entityType: CorpTypeCd
-    filingTypeCode: FilingCodes
-    priority?: boolean
-  }
+  filingData: Array<FilingDataIF>
   changeData?: {
     nameChangeOptions?: Array<CorrectionTypes>
     typeChangeInfo?: string

--- a/src/interfaces/resource-interfaces/resource-interface.ts
+++ b/src/interfaces/resource-interfaces/resource-interface.ts
@@ -8,7 +8,7 @@ export interface ResourceIF {
   displayName: string
   nameRequestType: NameRequestEntityTypes
   addressLabel: string
-  filingData: Array<FilingDataIF>
+  filingData: FilingDataIF
   changeData?: {
     nameChangeOptions?: Array<CorrectionTypes>
     typeChangeInfo?: string

--- a/src/resources/Alteration/BenefitCompanyResource.ts
+++ b/src/resources/Alteration/BenefitCompanyResource.ts
@@ -8,11 +8,11 @@ export const BenefitCompanyResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.BENEFIT_COMPANY),
   nameRequestType: NameRequestEntityTypes.BC,
   addressLabel: 'Registered Office',
-  filingData: [{
-    filingTypeCode: FilingCodes.CONVERSION,
-    entityType: CorpTypeCd.PARTNERSHIP,
+  filingData: {
+    filingTypeCode: FilingCodes.ALTERATION,
+    entityType: CorpTypeCd.BENEFIT_COMPANY,
     priority: false
-  }],
+  },
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR,

--- a/src/resources/Alteration/BenefitCompanyResource.ts
+++ b/src/resources/Alteration/BenefitCompanyResource.ts
@@ -8,11 +8,11 @@ export const BenefitCompanyResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.BENEFIT_COMPANY),
   nameRequestType: NameRequestEntityTypes.BC,
   addressLabel: 'Registered Office',
-  filingData: {
-    entityType: CorpTypeCd.BENEFIT_COMPANY,
-    filingTypeCode: FilingCodes.ALTERATION,
+  filingData: [{
+    filingTypeCode: FilingCodes.CONVERSION,
+    entityType: CorpTypeCd.PARTNERSHIP,
     priority: false
-  },
+  }],
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR,

--- a/src/resources/Alteration/CooperativeResource.ts
+++ b/src/resources/Alteration/CooperativeResource.ts
@@ -8,11 +8,11 @@ export const CooperativeResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.COOP),
   nameRequestType: NameRequestEntityTypes.CP,
   addressLabel: 'Registered Office',
-  filingData: {
-    entityType: CorpTypeCd.COOP,
-    filingTypeCode: FilingCodes.ALTERATION,
+  filingData: [{
+    filingTypeCode: FilingCodes.CONVERSION,
+    entityType: CorpTypeCd.PARTNERSHIP,
     priority: false
-  },
+  }],
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR,

--- a/src/resources/Alteration/CooperativeResource.ts
+++ b/src/resources/Alteration/CooperativeResource.ts
@@ -8,11 +8,11 @@ export const CooperativeResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.COOP),
   nameRequestType: NameRequestEntityTypes.CP,
   addressLabel: 'Registered Office',
-  filingData: [{
-    filingTypeCode: FilingCodes.CONVERSION,
-    entityType: CorpTypeCd.PARTNERSHIP,
+  filingData: {
+    filingTypeCode: FilingCodes.ALTERATION,
+    entityType: CorpTypeCd.COOP,
     priority: false
-  }],
+  },
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR,

--- a/src/resources/Change/GeneralPartnershipResource.ts
+++ b/src/resources/Change/GeneralPartnershipResource.ts
@@ -8,10 +8,11 @@ export const GeneralPartnershipResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.PARTNERSHIP),
   nameRequestType: NameRequestEntityTypes.GP,
   addressLabel: 'Business Addresses',
-  filingData: {
+  filingData: [{
+    filingTypeCode: FilingCodes.CONVERSION,
     entityType: CorpTypeCd.PARTNERSHIP,
-    filingTypeCode: FilingCodes.CHANGE_OF_REGISTRATION
-  },
+    priority: false
+  }],
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR

--- a/src/resources/Change/GeneralPartnershipResource.ts
+++ b/src/resources/Change/GeneralPartnershipResource.ts
@@ -8,11 +8,11 @@ export const GeneralPartnershipResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.PARTNERSHIP),
   nameRequestType: NameRequestEntityTypes.GP,
   addressLabel: 'Business Addresses',
-  filingData: [{
-    filingTypeCode: FilingCodes.CONVERSION,
+  filingData: {
+    filingTypeCode: FilingCodes.CHANGE_OF_REGISTRATION,
     entityType: CorpTypeCd.PARTNERSHIP,
     priority: false
-  }],
+  },
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR

--- a/src/resources/Change/SoleProprietorshipResource.ts
+++ b/src/resources/Change/SoleProprietorshipResource.ts
@@ -8,11 +8,11 @@ export const SoleProprietorshipResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.SOLE_PROP),
   nameRequestType: NameRequestEntityTypes.FR,
   addressLabel: 'Business Addresses',
-  filingData: [{
-    filingTypeCode: FilingCodes.CONVERSION,
-    entityType: CorpTypeCd.PARTNERSHIP,
+  filingData: {
+    filingTypeCode: FilingCodes.CHANGE_OF_REGISTRATION,
+    entityType: CorpTypeCd.SOLE_PROP,
     priority: false
-  }],
+  },
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR

--- a/src/resources/Change/SoleProprietorshipResource.ts
+++ b/src/resources/Change/SoleProprietorshipResource.ts
@@ -8,10 +8,11 @@ export const SoleProprietorshipResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.SOLE_PROP),
   nameRequestType: NameRequestEntityTypes.FR,
   addressLabel: 'Business Addresses',
-  filingData: {
-    entityType: CorpTypeCd.SOLE_PROP,
-    filingTypeCode: FilingCodes.CHANGE_OF_REGISTRATION
-  },
+  filingData: [{
+    filingTypeCode: FilingCodes.CONVERSION,
+    entityType: CorpTypeCd.PARTNERSHIP,
+    priority: false
+  }],
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR

--- a/src/resources/Conversion/GeneralPartnershipResource.ts
+++ b/src/resources/Conversion/GeneralPartnershipResource.ts
@@ -8,10 +8,12 @@ export const GeneralPartnershipResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.PARTNERSHIP),
   nameRequestType: NameRequestEntityTypes.GP,
   addressLabel: 'Business Addresses',
-  filingData: {
+  filingData: [{
+    filingTypeCode: FilingCodes.CONVERSION,
     entityType: CorpTypeCd.PARTNERSHIP,
-    filingTypeCode: FilingCodes.CONVERSION
-  },
+    priority: false,
+    waiveFees: true
+  }],
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR

--- a/src/resources/Conversion/GeneralPartnershipResource.ts
+++ b/src/resources/Conversion/GeneralPartnershipResource.ts
@@ -8,12 +8,12 @@ export const GeneralPartnershipResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.PARTNERSHIP),
   nameRequestType: NameRequestEntityTypes.GP,
   addressLabel: 'Business Addresses',
-  filingData: [{
+  filingData: {
     filingTypeCode: FilingCodes.CONVERSION,
     entityType: CorpTypeCd.PARTNERSHIP,
     priority: false,
     waiveFees: true
-  }],
+  },
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR

--- a/src/resources/Conversion/SoleProprietorshipResource.ts
+++ b/src/resources/Conversion/SoleProprietorshipResource.ts
@@ -8,12 +8,12 @@ export const SoleProprietorshipResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.SOLE_PROP),
   nameRequestType: NameRequestEntityTypes.FR,
   addressLabel: 'Business Addresses',
-  filingData: [{
+  filingData: {
     filingTypeCode: FilingCodes.CONVERSION,
-    entityType: CorpTypeCd.PARTNERSHIP,
+    entityType: CorpTypeCd.SOLE_PROP,
     priority: false,
     waiveFees: true
-  }],
+  },
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR

--- a/src/resources/Conversion/SoleProprietorshipResource.ts
+++ b/src/resources/Conversion/SoleProprietorshipResource.ts
@@ -8,10 +8,12 @@ export const SoleProprietorshipResource: ResourceIF = {
   displayName: GetCorpFullDescription(CorpTypeCd.SOLE_PROP),
   nameRequestType: NameRequestEntityTypes.FR,
   addressLabel: 'Business Addresses',
-  filingData: {
-    entityType: CorpTypeCd.SOLE_PROP,
-    filingTypeCode: FilingCodes.CONVERSION
-  },
+  filingData: [{
+    filingTypeCode: FilingCodes.CONVERSION,
+    entityType: CorpTypeCd.PARTNERSHIP,
+    priority: false,
+    waiveFees: true
+  }],
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR

--- a/src/views/Conversion.vue
+++ b/src/views/Conversion.vue
@@ -42,13 +42,6 @@
           sectionNumber="1."
           :validate="getAppValidate"
         />
-
-        <StaffPayment
-          class="mt-10"
-          sectionNumber="2."
-          :validate="getAppValidate"
-          @haveChanges="onStaffPaymentChanges()"
-        />
       </div>
     </v-slide-x-reverse-transition>
   </section>
@@ -65,7 +58,6 @@ import { CommonMixin, FilingTemplateMixin, LegalApiMixin, PayApiMixin } from '@/
 import { ActionBindingIF, EmptyFees, EntitySnapshotIF, FilingDataIF } from '@/interfaces/'
 import { FilingCodes, FilingStatus, OrgPersonTypes } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
-import { StaffPaymentOptions } from '@bcrs-shared-components/enums'
 import { SoleProprietorshipResource, GeneralPartnershipResource } from '@/resources/Conversion/'
 import { ConversionSummary } from '@/components/Conversion'
 import { NOT_FOUND } from 'http-status-codes'
@@ -75,7 +67,6 @@ import { NOT_FOUND } from 'http-status-codes'
     ConversionSummary,
     CompletingParty,
     PeopleAndRoles,
-    StaffPayment,
     YourCompany
   }
 })
@@ -254,17 +245,6 @@ export default class Conversion extends Mixins(
       orgPersons
     } as EntitySnapshotIF
   }
-
-  /** Called when staff payment data has changed. */
-  protected onStaffPaymentChanges (): void {
-    // update filing data with staff payment fields
-    this.setFilingData({
-      ...this.getFilingData,
-      priority: this.getStaffPayment.isPriority,
-      waiveFees: (this.getStaffPayment.option === StaffPaymentOptions.NO_FEE)
-    })
-  }
-
   /** Emits Fetch Error event. */
   @Emit('fetchError')
   private emitFetchError (err: unknown = null): void {}


### PR DESCRIPTION
*Issue #:* /bcgov/[entity12427](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/12427)

*Description of changes:*

- Removed staff payment component and associated methods from Conversion view.
- Updated ResourceIF to use FilingDataIF
- Hardcoded waive fees code to for a GP and SP conversion filing.
- Updated Alteration (BenefitCompanyResource, CooperativeResource), 
   Change (GeneralPartnershipResource, SoleProprietorshipResource) and
   Conversion (GeneralPartnershipRescource, SoleProprietorshipResource)
   to use the updated ResourceIF.
- App version = 3.1.13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
