### PR TITLE
12169 Prefill Certify component for non-staff user. Updated certify component to latest version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.11",
+  "version": "3.1.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.1.11",
+      "version": "3.1.14",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",
         "@bcrs-shared-components/breadcrumb": "2.0.1",
-        "@bcrs-shared-components/certify": "1.0.18",
+        "@bcrs-shared-components/certify": "2.0.4",
         "@bcrs-shared-components/completing-party": "2.0.0",
         "@bcrs-shared-components/confirm-dialog": "1.1.0",
         "@bcrs-shared-components/contact-info": "1.1.2",
@@ -1848,11 +1848,11 @@
       }
     },
     "node_modules/@bcrs-shared-components/certify": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/certify/-/certify-1.0.18.tgz",
-      "integrity": "sha512-+qqWffUUVnPSUHdR8h2Q0kJsbUZ6PmDHVIsqy2JbDoZaEySO4qizkgfpqdQ1Thtyz802td2eb0SLKk0wvaSrfg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/certify/-/certify-2.0.4.tgz",
+      "integrity": "sha512-pyVoQ3Mel5kqlviZOgoWjig0G7DeWw+Lo6N7PyTQnWYJExv1buqBggy/TJ4X2bL93/JLHXgjxT2M/hKbE0mJGQ==",
       "dependencies": {
-        "@bcrs-shared-components/interfaces": "^1.0.19",
+        "@bcrs-shared-components/interfaces": "^1.0.36",
         "vue-property-decorator": "^8.4.0"
       }
     },
@@ -7680,7 +7680,7 @@
     "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
       "dev": true,
       "dependencies": {
         "is-glob": "^3.1.0",
@@ -10129,15 +10129,12 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
-      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "dev": true,
-      "dependencies": {
-        "original": "^1.0.0"
-      },
       "engines": {
-        "node": ">=0.12.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/evp_bytestokey": {
@@ -10542,7 +10539,7 @@
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
       "dev": true,
       "dependencies": {
         "is-glob": "^3.1.0",
@@ -10574,9 +10571,9 @@
       "dev": true
     },
     "node_modules/faye-websocket": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "dev": true,
       "dependencies": {
         "websocket-driver": ">=0.5.1"
@@ -15321,12 +15318,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "node_modules/json3": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
-      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
-      "dev": true
-    },
     "node_modules/json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
@@ -17093,15 +17084,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "dev": true,
-      "dependencies": {
-        "url-parse": "^1.4.3"
       }
     },
     "node_modules/os-browserify": {
@@ -19921,17 +19903,22 @@
       }
     },
     "node_modules/sockjs-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
-      "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
       "dev": true,
       "dependencies": {
-        "debug": "^3.2.6",
-        "eventsource": "^1.0.7",
-        "faye-websocket": "^0.11.3",
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
         "inherits": "^2.0.4",
-        "json3": "^3.3.3",
-        "url-parse": "^1.4.7"
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
       }
     },
     "node_modules/sockjs-client/node_modules/debug": {
@@ -22370,7 +22357,7 @@
     "node_modules/watchpack-chokidar2/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -22792,7 +22779,7 @@
     "node_modules/webpack-dev-server/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
       "dev": true,
       "dependencies": {
         "is-glob": "^3.1.0",
@@ -24672,11 +24659,11 @@
       }
     },
     "@bcrs-shared-components/certify": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/certify/-/certify-1.0.18.tgz",
-      "integrity": "sha512-+qqWffUUVnPSUHdR8h2Q0kJsbUZ6PmDHVIsqy2JbDoZaEySO4qizkgfpqdQ1Thtyz802td2eb0SLKk0wvaSrfg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/certify/-/certify-2.0.4.tgz",
+      "integrity": "sha512-pyVoQ3Mel5kqlviZOgoWjig0G7DeWw+Lo6N7PyTQnWYJExv1buqBggy/TJ4X2bL93/JLHXgjxT2M/hKbE0mJGQ==",
       "requires": {
-        "@bcrs-shared-components/interfaces": "^1.0.19",
+        "@bcrs-shared-components/interfaces": "^1.0.36",
         "vue-property-decorator": "^8.4.0"
       }
     },
@@ -29537,7 +29524,7 @@
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
           "dev": true,
           "requires": {
             "is-glob": "^3.1.0",
@@ -31507,13 +31494,10 @@
       "dev": true
     },
     "eventsource": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
-      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
-      "dev": true,
-      "requires": {
-        "original": "^1.0.0"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -31857,7 +31841,7 @@
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
           "dev": true,
           "requires": {
             "is-glob": "^3.1.0",
@@ -31890,9 +31874,9 @@
       "dev": true
     },
     "faye-websocket": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
@@ -35718,12 +35702,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json3": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
-      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
-      "dev": true
-    },
     "json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
@@ -37199,15 +37177,6 @@
             "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "dev": true,
-      "requires": {
-        "url-parse": "^1.4.3"
       }
     },
     "os-browserify": {
@@ -39562,17 +39531,16 @@
       }
     },
     "sockjs-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
-      "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
       "dev": true,
       "requires": {
-        "debug": "^3.2.6",
-        "eventsource": "^1.0.7",
-        "faye-websocket": "^0.11.3",
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
         "inherits": "^2.0.4",
-        "json3": "^3.3.3",
-        "url-parse": "^1.4.7"
+        "url-parse": "^1.5.10"
       },
       "dependencies": {
         "debug": {
@@ -41556,7 +41524,7 @@
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -41911,7 +41879,7 @@
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
           "dev": true,
           "requires": {
             "is-glob": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.11",
+  "version": "3.1.14",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",
@@ -16,7 +16,7 @@
     "@babel/compat-data": "^7.11.0",
     "@bcrs-shared-components/action-chip": "1.0.6",
     "@bcrs-shared-components/breadcrumb": "2.0.1",
-    "@bcrs-shared-components/certify": "1.0.18",
+    "@bcrs-shared-components/certify": "2.0.4",
     "@bcrs-shared-components/completing-party": "2.0.0",
     "@bcrs-shared-components/confirm-dialog": "1.1.0",
     "@bcrs-shared-components/contact-info": "1.1.2",

--- a/src/components/common/CertifySection.vue
+++ b/src/components/common/CertifySection.vue
@@ -56,10 +56,7 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
   @Prop({ default: false }) readonly validate: boolean
 
   /** To determine whether user input is enabled. */
-  @Prop({ required: true }) readonly disableEdit!: boolean
-
-  /** To determine if user is staff. */
-  @Prop({ required: true }) readonly isStaff!: boolean
+  @Prop({ default: true }) readonly disableEdit: boolean
 
   /** Called when component is mounted. */
   mounted (): void {

--- a/src/components/common/CertifySection.vue
+++ b/src/components/common/CertifySection.vue
@@ -56,7 +56,7 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
   @Prop({ default: false }) readonly validate: boolean
 
   /** To determine whether user input is enabled. */
-  @Prop({ default: true }) readonly disableEdit: boolean
+  @Prop({ default: false }) readonly disableEdit: boolean
 
   /** Called when component is mounted. */
   mounted (): void {

--- a/src/components/common/CertifySection.vue
+++ b/src/components/common/CertifySection.vue
@@ -56,7 +56,7 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
   @Prop({ default: false }) readonly validate: boolean
 
   /** To determine whether user input is enabled. */
-  @Prop({ required: false }) readonly disableEdit: boolean
+  @Prop({ required: true }) readonly disableEdit!: boolean
 
   /** To determine if user is staff. */
   @Prop({ required: true }) readonly isStaff!: boolean

--- a/src/components/common/CertifySection.vue
+++ b/src/components/common/CertifySection.vue
@@ -44,8 +44,6 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
   @Getter getCertifyState!: CertifyIF
   @Getter getCurrentDate!: string
   @Getter getResource!: ResourceIF
-  @Getter getUserFirstName!: string
-  @Getter getUserLastName!: string
   @Getter isRoleStaff!: boolean
 
   @Action setCertifyState!: ActionBindingIF
@@ -81,11 +79,6 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
   /** Get the certify resource message */
   get certifyMessage (): string {
     return this.getResource?.certifyClause
-  }
-
-  /** Get if the user is not staff and is doing a change filing */
-  get notStaffChange (): boolean {
-    return (!this.isRoleStaff && this.isChangeFiling)
   }
 
   /** Handler for Valid change event. */

--- a/src/components/common/CertifySection.vue
+++ b/src/components/common/CertifySection.vue
@@ -7,20 +7,23 @@
     </div>
 
     <div :class="{ 'invalid-section': invalidSection }">
-      <CertifyShared
-        :currentDate="getCurrentDate"
-        :certifiedBy="getCertifyState.certifiedBy"
-        :isCertified="getCertifyState.valid"
-        :entityDisplay="readableEntityType"
-        :message="certifyMessage"
-        :isStaff="isRoleStaff"
-        :firstColumn="3"
-        :secondColumn="9"
-        :validate="validate"
-        :invalidSection="invalidSection"
-        @update:certifiedBy="onCertifiedBy($event)"
-        @update:isCertified="onIsCertified($event)"
-      />
+      <v-card flat class="section-container py-6">
+        <CertifyShared
+          :currentDate="getCurrentDate"
+          :certifiedBy="getCertifyState.certifiedBy"
+          :isCertified="getCertifyState.valid"
+          :entityDisplay="readableEntityType"
+          :message="certifyMessage"
+          :isStaff="isRoleStaff"
+          :firstColumn="3"
+          :secondColumn="9"
+          :validate="validate"
+          :invalidSection="invalidSection"
+          :disableEdit="disableEdit"
+          @update:certifiedBy="onCertifiedBy($event)"
+          @update:isCertified="onIsCertified($event)"
+        />
+      </v-card>
     </div>
   </section>
 </template>
@@ -41,6 +44,8 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
   @Getter getCertifyState!: CertifyIF
   @Getter getCurrentDate!: string
   @Getter getResource!: ResourceIF
+  @Getter getUserFirstName!: string
+  @Getter getUserLastName!: string
   @Getter isRoleStaff!: boolean
 
   @Action setCertifyState!: ActionBindingIF
@@ -51,6 +56,12 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
 
   /** Whether to perform validation. */
   @Prop({ default: false }) readonly validate: boolean
+
+  /** To determine whether user input is enabled. */
+  @Prop({ required: false }) readonly disableEdit: boolean
+
+  /** To determine if user is staff. */
+  @Prop({ required: true }) readonly isStaff!: boolean
 
   /** Called when component is mounted. */
   mounted (): void {
@@ -72,8 +83,13 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
     return this.getResource?.certifyClause
   }
 
+  /** Get if the user is not staff and is doing a change filing */
+  get notStaffChange (): boolean {
+    return (!this.isRoleStaff && this.isChangeFiling)
+  }
+
   /** Handler for Valid change event. */
-  private onIsCertified (val: boolean): void {
+  protected onIsCertified (val: boolean): void {
     this.setCertifyState(
       {
         valid: val,
@@ -84,7 +100,7 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
   }
 
   /** Handler for CertifiedBy change event. */
-  private onCertifiedBy (val: string): void {
+  protected onCertifiedBy (val: string): void {
     this.setCertifyState(
       {
         valid: this.getCertifyState.valid,
@@ -111,21 +127,5 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
 
 .invalid-label {
   color: $BCgovInputError;
-}
-
-// fix hard-coded whitespace inside shared component
-// we want the same padding as "section-container py-6"
-::v-deep {
-  #AR-step-4-container {
-    margin-top: 0 !important;
-    padding-top: 0.75rem !important;
-    padding-right: 1.125rem !important;
-    padding-bottom: 0 !important;
-    padding-left: 0.625rem !important;
-  }
-
-  #certify-form {
-    margin-top: 0 !important;
-  }
 }
 </style>

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -54,7 +54,6 @@
           class="mt-10"
           sectionNumber="3."
           :validate="getAppValidate"
-          :invalidSection="isCertifyInvalid"
           :disableEdit="!isRoleStaff"
         />
         <template v-if="isRoleStaff">
@@ -85,8 +84,8 @@ import { CertifySection, CompletingParty, DocumentsDelivery, PeopleAndRoles, You
   CourtOrderPoa } from '@/components/common/'
 import { AuthServices } from '@/services/'
 import { CommonMixin, FilingTemplateMixin, LegalApiMixin, PayApiMixin } from '@/mixins/'
-import { ActionBindingIF, EmptyFees, EntitySnapshotIF, FilingDataIF, ResourceIF, FlagsReviewCertifyIF }
-  from '@/interfaces/'
+import { ActionBindingIF, EmptyFees, EntitySnapshotIF, FilingDataIF,
+  ResourceIF } from '@/interfaces/'
 import { FilingCodes, FilingStatus, OrgPersonTypes } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { cloneDeep } from 'lodash'
@@ -132,7 +131,6 @@ export default class Change extends Mixins(
   @Action setCurrentFees!: ActionBindingIF
   @Action setFeePrices!: ActionBindingIF
   @Action setResource!: ActionBindingIF
-  @Action setCertifyStateValidity!: ActionBindingIF
 
   /** Whether App is ready. */
   @Prop({ default: false })

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -116,7 +116,6 @@ export default class Change extends Mixins(
   @Getter getAppValidate!: boolean
   @Getter getUserFirstName!: string
   @Getter getUserLastName!: string
-  @Getter getValidateSteps!: boolean
   @Getter showFeeSummary!: boolean
   @Getter isTypeSoleProp!: boolean
   @Getter isTypePartnership!: boolean

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -253,17 +253,6 @@ export default class Change extends Mixins(
     Vue.nextTick(() => this.setHaveUnsavedChanges(false))
   }
 
-  /** Handler for Valid change event. */
-  protected onIsCertified (val: boolean): void {
-    this.setCertifyState(
-      {
-        valid: val,
-        certifiedBy: this.getCertifyState.certifiedBy
-      }
-    )
-    this.setCertifyStateValidity(Boolean(val && this.getCertifyState.certifiedBy))
-  }
-
   /** Called when staff payment data has changed. */
   protected onStaffPaymentChanges (): void {
     // update filing data with staff payment fields

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -153,11 +153,6 @@ export default class Change extends Mixins(
     return null
   }
 
-  /** Is true when the certify conditions are not met. */
-  get isCertifyInvalid (): boolean {
-    return this.getValidateSteps && !(this.getCertifyState.certifiedBy && this.getCertifyState.valid)
-  }
-
   /** Called when App is ready and this component can load its data. */
   @Watch('appReady')
   private async onAppReady (val: boolean): Promise<void> {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#[12169](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/12169)

*Description of changes:*
Commit 1:
- Updated bcrs-shared-components/certify version 1.0.18 => 2.0.4
- Removed CSS from certify common component as it is now covered by updated certify component
- Non-staff users now cannot edit the certify field, and it is prefilled based on the users login name
- App version = 3.1.14

Commit 2-3:
- Resolving merge conflicts

Commit 4:
- Removing code that I added that was unneeded

Commit 5-7:
- Applying requested fixes.

Test notes:
-Alteration, Change and Conversion filings all use the certify component

Tested locally that the changes were not applied to other views that use the CertifySection component, specifically alteration and conversion filings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).