### PR TITLE
12504 for non-staff users the certify section in alteration filings is prefilled and uneditable.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.1.14",
+      "version": "3.1.15",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -61,6 +61,7 @@
           class="mt-10"
           :sectionNumber="showTransactionalFolioNumber ? '3.' : '2.'"
           :validate="getAppValidate"
+          :disableEdit="!isRoleStaff"
         />
 
         <!-- STAFF ONLY: Court Order and Plan of Arrangement -->
@@ -162,6 +163,8 @@ export default class Alteration extends Mixins(
 ) {
   // Global getters
   @Getter getFlagsReviewCertify!: FlagsReviewCertifyIF
+  @Getter getUserFirstName!: string
+  @Getter getUserLastName!: string
   @Getter isSummaryMode!: boolean
   @Getter isRoleStaff!: boolean
   @Getter isPremiumAccount!: boolean
@@ -302,6 +305,18 @@ export default class Alteration extends Mixins(
     } catch (err) {
       console.log(err) // eslint-disable-line no-console
       this.emitFetchError(err)
+    }
+
+    // set current profile name to store for field pre population
+    // do this only if we are not staff
+    if (!this.isRoleStaff) {
+      // pre-populate Certified By name
+      this.setCertifyState(
+        {
+          valid: this.getCertifyState.valid,
+          certifiedBy: `${this.getUserFirstName} ${this.getUserLastName}`
+        }
+      )
     }
 
     // now that all data is loaded, wait for things to stabilize and reset flag


### PR DESCRIPTION
*Issue #:* /bcgov/entity[12504](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/12504)


*Description of changes:*
1) The certify section in alteration filings is now prefilled and uneditable for non-staff users.
2) The certify section in alteration filings is empty and editable for staff users.
3) App version = 3.1.15


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
