### PR TITLE
12419 Make Business Contact Info email required + misc fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.1.16",
+      "version": "3.1.17",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/YourCompany/BusinessContactInfo.vue
+++ b/src/components/common/YourCompany/BusinessContactInfo.vue
@@ -10,13 +10,13 @@
     :disableActionTooltip="isChangeRegFiling || isConversionFiling"
     :invalidSection="invalidSection"
     :optionalPhone="isAlterationFiling || isChangeRegFiling || isConversionFiling"
-    @isEditingContact="onIsEditingContact($event)"
+    @isEditingContact="isEditingContact = $event"
     @contactInfoChange="onContactInfoChange($event)"
   />
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { ContactInfo as ContactInfoShared } from '@bcrs-shared-components/contact-info/'
 import { AuthServices } from '@/services/'
@@ -45,6 +45,8 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
   /** Whether to show invalid section styling. */
   @Prop({ default: false })
   readonly invalidSection: boolean
+
+  private isEditingContact = null as boolean
 
   /** Get the original Contact info dependant on filing type. */
   get originalContact (): ContactPointIF {
@@ -85,9 +87,17 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
     }
   }
 
-  /** Keep the store in sync with components state of validity. */
-  private onIsEditingContact (isEditing: boolean): void {
-    this.setValidComponent({ key: 'isValidContactInfo', value: !isEditing })
+  /**
+   * Keep the store in sync with this component's state of validity.
+   * Use "immediate" to pick up all validity conditions
+   */
+  @Watch('isEditingContact', { immediate: true })
+  private onIsEditingContact (): void {
+    const isValid = (
+      !this.isEditingContact &&
+      this.getBusinessContact?.email
+    )
+    this.setValidComponent({ key: 'isValidContactInfo', value: isValid })
   }
 }
 </script>

--- a/src/components/common/YourCompany/OfficeAddresses.vue
+++ b/src/components/common/YourCompany/OfficeAddresses.vue
@@ -161,7 +161,7 @@
         </v-col>
       </v-row>
 
-      <!-- Business mailing address -->
+      <!-- Mailing address -->
       <v-row no-gutters class="pr-1">
         <v-col cols="3"></v-col>
         <v-col cols="9" class="pt-4">
@@ -177,6 +177,7 @@
         </v-col>
       </v-row>
 
+      <!-- "Same as" checkbox -->
       <v-row no-gutters>
         <v-col cols="3"></v-col>
         <v-col cols="9">
@@ -192,7 +193,7 @@
         </v-col>
       </v-row>
 
-      <!-- Business delivery address -->
+      <!-- Delivery address -->
       <template v-if="!inheritMailingAddress || disableSameDeliveryAddress">
         <v-row no-gutters class="pt-4">
           <v-col cols="3"></v-col>
@@ -303,6 +304,7 @@
           </li>
         </div>
 
+        <!-- "Same as" checkbox -->
         <div id="edit-records-address" v-if="isTypeBcomp">
           <div class="address-edit-header" :class="{'mt-8': inheritMailingAddress}">
             <label class="address-edit-title">Records Office</label>
@@ -486,6 +488,9 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   private recMailingAddressValid = true
   private recDeliveryAddressValid = true
 
+  /** Whether to disable "same as" checkbox. */
+  private disableSameDeliveryAddress = false
+
   /** Model value for "same as (registered) mailing address" checkbox. */
   private inheritMailingAddress = true
 
@@ -495,9 +500,14 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   /** Model value for "same as (records) mailing address" checkbox. */
   private inheritRecMailingAddress = true
 
-  /** Is true when the mailing address is not in BC, Canada. */
-  get disableSameDeliveryAddress (): boolean {
-    return (
+  /**
+   * Sets the "disableSameDeliveryAddress" flag.
+   * Needed because "this.mailingAddress" doesn't seem to be reactive.
+   */
+  private setDisableSameAsFlag (): void {
+    // cannot make delivery address same as mailing address
+    // if mailing address is not in BC, Canada
+    this.disableSameDeliveryAddress = (
       this.mailingAddress.addressRegion !== REGION_BC ||
       this.mailingAddress.addressCountry !== COUNTRY_CA
     )
@@ -522,6 +532,8 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
       // assign registered office addresses (may be {})
       this.mailingAddress = { ...this.getOfficeAddresses?.registeredOffice?.mailingAddress }
       this.deliveryAddress = { ...this.getOfficeAddresses?.registeredOffice?.deliveryAddress }
+
+      this.setDisableSameAsFlag()
 
       // set initial validity states
       // these will be updated by the BaseAddress sub-components
@@ -571,6 +583,8 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
       // assign business office addresses (may be {})
       this.mailingAddress = { ...this.getOfficeAddresses?.businessOffice?.mailingAddress }
       this.deliveryAddress = { ...this.getOfficeAddresses?.businessOffice?.deliveryAddress }
+
+      this.setDisableSameAsFlag()
 
       // set initial validity states
       // these will be updated by the BaseAddress sub-components
@@ -644,6 +658,8 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
     Object.assign(baseAddress, newAddress)
     switch (addressToUpdate) {
       case AddressTypes.MAILING_ADDRESS:
+        this.setDisableSameAsFlag()
+
         if (this.inheritMailingAddress) {
           this.deliveryAddress = { ...newAddress, addressType: 'delivery', id: this.deliveryAddress.id }
         }

--- a/src/interfaces/stepper-interfaces/YourCompany/address-interfaces.ts
+++ b/src/interfaces/stepper-interfaces/YourCompany/address-interfaces.ts
@@ -11,7 +11,7 @@ export interface AddressIF {
   postalCode: string
   streetAddress: string
   streetAddressAdditional?: string
-  addressType?: string
+  addressType?: string // 'mailing' or 'delivery'
 }
 
 /**

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -105,7 +105,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     // if filing...
     if (!isDraft) {
       // Filter out removed parties and delete "actions" property
-      parties = parties.filter(x => !x.actions.includes(ActionTypes.REMOVED))
+      parties = parties.filter(x => !x.actions?.includes(ActionTypes.REMOVED))
         .map((x) => { const { actions, ...rest } = x; return rest })
 
       // Filter out removed classes and delete "action" property
@@ -432,7 +432,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
           identifier: this.getBusinessId
         },
         contactPoint: {
-          email: this.getBusinessContact.email || 'unknown@example.com',
+          email: this.getBusinessContact.email,
           phone: this.getBusinessContact.phone || undefined, // don't include if empty
           extension: +this.getBusinessContact.extension || undefined // don't include if empty
         },


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12419

*Description of changes:*
- made BusinessContactInfo invalid when email is empty
- implemented workaround so office address "same as" is disabled when mailing address is not in BC, Canada
- added conditional chaining to avoid error when saving correction parties without actions
- removed empty contact point email workaround
- app version = 3.1.17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).