### PR TITLE
12399 Firm correction framework cont.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -526,8 +526,8 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
       console.log('Launch Darkly update error =', error) // eslint-disable-line no-console
     }
 
-    // since correction is a single page, enable component validation right away
-    // FUTURE: remove this when correction filing becomes 2 pages like the others
+    // since corrections are a single page, enable component validation right away
+    // FUTURE: remove this when correction filings becomes 2 pages like the others
     if (this.isCorrectionFiling) {
       this.setComponentValidate(true)
       this.setAppValidate(true)

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -314,7 +314,7 @@ ul.list {
   font-size: 0.9rem; // 14.4 px
 }
 
-.hasConflict {
+.has-conflict {
   color: $app-red;
 }
 

--- a/src/components/Change/ChangeSummary.vue
+++ b/src/components/Change/ChangeSummary.vue
@@ -57,7 +57,7 @@
       <article id="org-person-summary-section" class="section-container pb-0">
         <v-row no-gutters>
           <v-col cols="12" sm="3">
-            <label>{{ isTypeSoleProp ? 'Proprietor' : 'Partner' }} Information</label>
+            <label>{{ isEntityTypeSP ? 'Proprietor' : 'Partner' }} Information</label>
           </v-col>
         </v-row>
         <v-row no-gutters class="mt-4">
@@ -94,7 +94,7 @@ export default class ChangeSummary extends Vue {
   @Getter getResource!: ResourceIF
   @Getter getApprovedName!: string
   @Getter getBusinessNumber!: string
-  @Getter isTypeSoleProp!: boolean
+  @Getter isEntityTypeSP!: boolean
 
   // Global actions
   @Action setSummaryMode!: ActionBindingIF

--- a/src/components/Conversion/ConversionSummary.vue
+++ b/src/components/Conversion/ConversionSummary.vue
@@ -40,7 +40,7 @@
       <article id="org-person-summary-section" class="section-container pb-0">
         <v-row no-gutters>
           <v-col cols="12" sm="3">
-            <label>{{ isTypeSoleProp ? 'Proprietor' : 'Partner' }} Information</label>
+            <label>{{ isEntityTypeSP ? 'Proprietor' : 'Partner' }} Information</label>
           </v-col>
         </v-row>
         <v-row no-gutters class="mt-4">
@@ -74,7 +74,7 @@ export default class ConversionSummary extends Vue {
   @Getter hasPeopleAndRolesChanged!: boolean
   @Getter getResource!: ResourceIF
   @Getter getCurrentNaics!: NaicsIF
-  @Getter isTypeSoleProp!: boolean
+  @Getter isEntityTypeSP!: boolean
 
   // Global actions
   @Action setSummaryMode!: ActionBindingIF

--- a/src/components/Correction/CompletingParty.vue
+++ b/src/components/Correction/CompletingParty.vue
@@ -55,11 +55,11 @@ export default class CompletingParty extends Mixins(CommonMixin) {
 
   /** The original Completing Party if found, otherwise undefined. */
   get originalCompletingParty () : OrgPersonIF {
-    if (this.isCorrectionFiling && this.getOriginalIA?.incorporationApplication) {
+    if (this.getOriginalIA?.incorporationApplication) {
       return this.getCompletingParty(this.getOriginalIA.incorporationApplication.parties)
-    } else if (this.isCorrectionFiling && this.getOriginalChgRegistration?.changeOfRegistration) {
+    } else if (this.getOriginalChgRegistration?.changeOfRegistration) {
       return this.getCompletingParty(this.getOriginalChgRegistration.changeOfRegistration.parties)
-    } else if (this.isCorrectionFiling && this.getOriginalRegistration?.registration) {
+    } else if (this.getOriginalRegistration?.registration) {
       return this.getCompletingParty(this.getOriginalRegistration.registration.parties)
     } else {
       return null

--- a/src/components/common/EntityInfo.vue
+++ b/src/components/common/EntityInfo.vue
@@ -52,10 +52,12 @@ export default class EntityInfo extends Mixins(CommonMixin, SharedMixin) {
 
   /** Get original entity type. */
   get originalEntityType (): string {
-    if (this.isCorrectionFiling && this.getCorrectedFiling?.business) {
+    if (this.getCorrectedFiling?.business) {
       return this.getCorpTypeDescription(this.getCorrectedFiling.business.legalType)
+    } else if (this.getEntitySnapshot?.businessInfo) {
+      return this.getCorpTypeDescription(this.getEntitySnapshot.businessInfo.legalType)
     } else {
-      return this.getCorpTypeDescription(this.getEntitySnapshot?.businessInfo?.legalType)
+      return 'Unknown'
     }
   }
 }

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -136,7 +136,7 @@
 
           <!-- Roles -->
           <v-col cols="12" sm="2" :class="{ 'removed': wasRemoved(orgPerson)}">
-            <template v-if="isCorrectionFiling">
+            <template v-if="isCorrectionFiling && isTypeBcomp">
               <!-- Warning if orgPerson has no roles -->
               <div v-if="orgPerson.roles.length > 0">
                 <v-col v-for="(role, index) in orgPerson.roles" :key="index" class="col-roles">
@@ -327,6 +327,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
 
   // Store getter
   @Getter getPeopleAndRoles!: OrgPersonIF[]
+  @Getter isTypeBcomp!: boolean
 
   // declaration for template
   readonly isSame = isSame

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -136,7 +136,7 @@
 
           <!-- Roles -->
           <v-col cols="12" sm="2" :class="{ 'removed': wasRemoved(orgPerson)}">
-            <template v-if="isCorrectionFiling && isTypeBcomp">
+            <template v-if="isBenIaCorrectionFiling">
               <!-- Warning if orgPerson has no roles -->
               <div v-if="orgPerson.roles.length > 0">
                 <v-col v-for="(role, index) in orgPerson.roles" :key="index" class="col-roles">
@@ -327,7 +327,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
 
   // Store getter
   @Getter getPeopleAndRoles!: OrgPersonIF[]
-  @Getter isTypeBcomp!: boolean
+  @Getter isBenIaCorrectionFiling!: boolean
 
   // declaration for template
   readonly isSame = isSame

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -207,7 +207,7 @@
               </template>
 
               <!-- Roles (BEN corrections only) -->
-              <template v-if="isCorrectionFiling && isTypeBcomp">
+              <template v-if="isBenIaCorrectionFiling">
                 <article class="mt-6">
                   <label class="sub-header">Roles</label>
                   <v-row class="roles-row mt-4">
@@ -366,9 +366,8 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
   // Global getter
   @Getter getCurrentDate!: string
   @Getter getResource!: ResourceIF
-  @Getter isTypeBcomp!: boolean
-  @Getter isTypeSoleProp!: boolean
-  @Getter isTypePartnership!: boolean
+  @Getter isBenIaCorrectionFiling!: boolean
+  @Getter isEntityTypeFirm!: boolean
   @Getter isRoleStaff!: boolean
 
   /** The current org/person being added/edited. */
@@ -745,7 +744,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
     if (this.isDirector || this.isProprietor || this.isPartner || isNaN(this.activeIndex)) {
       person.deliveryAddress = this.setPersonDeliveryAddress()
     }
-    if (this.isCorrectionFiling && this.isTypeBcomp) {
+    if (this.isBenIaCorrectionFiling) {
       person.roles = this.setPersonRoles(this.orgPerson)
     } else {
       person.roles = this.orgPerson.roles
@@ -849,14 +848,14 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
     ]
 
     // NB: this only applies to firm orgs
-    if ((this.isTypeSoleProp || this.isTypePartnership) && this.isOrg) {
+    if ((this.isEntityTypeFirm) && this.isOrg) {
       this.confirmBusinessRules = [(v: string) => !!v]
     } else {
       this.confirmBusinessRules = []
     }
 
     // NB: this only applies to firm orgs/persons
-    if ((this.isTypeSoleProp || this.isTypePartnership) && this.hasOrgPersonNameChanged(this.orgPerson)) {
+    if ((this.isEntityTypeFirm) && this.hasOrgPersonNameChanged(this.orgPerson)) {
       this.confirmNameChangeRules = [(v: string) => !!v]
     } else {
       this.confirmNameChangeRules = []

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -206,8 +206,8 @@
                 </article>
               </template>
 
-              <!-- Roles -->
-              <template v-if="isCorrectionFiling">
+              <!-- Roles (BEN corrections only) -->
+              <template v-if="isCorrectionFiling && isTypeBcomp">
                 <article class="mt-6">
                   <label class="sub-header">Roles</label>
                   <v-row class="roles-row mt-4">
@@ -366,6 +366,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
   // Global getter
   @Getter getCurrentDate!: string
   @Getter getResource!: ResourceIF
+  @Getter isTypeBcomp!: boolean
   @Getter isTypeSoleProp!: boolean
   @Getter isTypePartnership!: boolean
   @Getter isRoleStaff!: boolean
@@ -744,7 +745,11 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
     if (this.isDirector || this.isProprietor || this.isPartner || isNaN(this.activeIndex)) {
       person.deliveryAddress = this.setPersonDeliveryAddress()
     }
-    person.roles = this.isCorrectionFiling ? this.setPersonRoles(this.orgPerson) : this.orgPerson.roles
+    if (this.isCorrectionFiling && this.isTypeBcomp) {
+      person.roles = this.setPersonRoles(this.orgPerson)
+    } else {
+      person.roles = this.orgPerson.roles
+    }
     return person
   }
 

--- a/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
@@ -13,7 +13,7 @@
       </div>
 
       <!-- Instructional people and roles text (BEN corrections only)-->
-      <article v-if="isCorrectionFiling && isTypeBcomp" class="section-container">
+      <article v-if="isBenIaCorrectionFiling" class="section-container">
         This application must include the following:
         <ul>
           <li>
@@ -36,7 +36,7 @@
 
       <!-- Change or conversion or firm correction section -->
       <article
-        v-if="isChangeRegFiling || isConversionFiling || (isCorrectionFiling && isTypeFirm)"
+        v-if="isChangeRegFiling || isConversionFiling || isFirmCorrectionFiling"
         class="section-container pb-0"
       >
         <p v-if="orgPersonSubtitle" class="info-text mt-2">{{ orgPersonSubtitle }}</p>
@@ -49,7 +49,7 @@
 
         <!-- SP add buttons (conversion or correction filing only) -->
         <div
-          v-if="isTypeSoleProp && (isConversionFiling || isCorrectionFiling) && !hasMinimumProprietor"
+          v-if="isEntityTypeSP && (isConversionFiling || isCorrectionFiling) && !hasMinimumProprietor"
           class="mt-8"
         >
           <v-btn
@@ -88,7 +88,7 @@
         </div>
 
         <!-- GP add buttons (change or conversion or correction filing)-->
-        <div v-if="isTypePartnership" class="mt-8">
+        <div v-if="isEntityTypeGP" class="mt-8">
           <v-btn
             id="gp-btn-add-person"
             outlined
@@ -126,7 +126,7 @@
       </article>
 
       <!-- Correction section (BEN corrections only) -->
-      <article v-if="isCorrectionFiling && isTypeBcomp" class="section-container">
+      <article v-if="isBenIaCorrectionFiling" class="section-container">
         <v-btn
           id="btn-add-person"
           outlined
@@ -231,10 +231,12 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
   @Getter getComponentValidate!: boolean
   @Getter hasMinimumProprietor!: boolean
   @Getter hasMinimumPartners!: boolean
-  @Getter isTypeBcomp!: boolean
-  @Getter isTypeSoleProp!: boolean
-  @Getter isTypePartnership!: boolean
-  @Getter isTypeFirm!: boolean
+  @Getter isBenIaCorrectionFiling!: boolean
+  @Getter isFirmCorrectionFiling!: boolean
+  @Getter isEntityTypeBEN!: boolean
+  @Getter isEntityTypeSP!: boolean
+  @Getter isEntityTypeGP!: boolean
+  @Getter isEntityTypeFirm!: boolean
 
   // Global actions
   @Action setPeopleAndRoles!: ActionBindingIF
@@ -255,11 +257,11 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
 
   /** The list of original parties. */
   get originalParties (): OrgPersonIF[] {
-    if (this.isCorrectionFiling && this.getOriginalIA?.incorporationApplication) {
+    if (this.getOriginalIA?.incorporationApplication) {
       return this.getOriginalIA.incorporationApplication.parties
-    } else if (this.isCorrectionFiling && this.getOriginalChgRegistration?.changeOfRegistration) {
+    } else if (this.getOriginalChgRegistration?.changeOfRegistration) {
       return this.getOriginalChgRegistration.changeOfRegistration.parties
-    } else if (this.isCorrectionFiling && this.getOriginalRegistration?.registration) {
+    } else if (this.getOriginalRegistration?.registration) {
       return this.getOriginalRegistration.registration.parties
     } else {
       return this.getEntitySnapshot?.orgPersons || []
@@ -289,19 +291,19 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
         return false
       }
       case (this.isChangeRegFiling): {
-        if (this.isTypeSoleProp) return this.hasMinimumProprietor
-        if (this.isTypePartnership) return this.hasMinimumPartners
+        if (this.isEntityTypeSP) return this.hasMinimumProprietor
+        if (this.isEntityTypeGP) return this.hasMinimumPartners
         return false
       }
       case (this.isConversionFiling): {
-        if (this.isTypeSoleProp) return this.hasMinimumProprietor
-        if (this.isTypePartnership) return this.hasMinimumPartners
+        if (this.isEntityTypeSP) return this.hasMinimumProprietor
+        if (this.isEntityTypeGP) return this.hasMinimumPartners
         return false
       }
       case (this.isCorrectionFiling): {
-        if (this.isTypeBcomp) return (this.cpValid && this.incorpValid && this.dirValid)
-        if (this.isTypeSoleProp) return this.hasMinimumProprietor
-        if (this.isTypePartnership) return this.hasMinimumPartners
+        if (this.isEntityTypeBEN) return (this.cpValid && this.incorpValid && this.dirValid)
+        if (this.isEntityTypeSP) return this.hasMinimumProprietor
+        if (this.isEntityTypeGP) return this.hasMinimumPartners
         return false
       }
     }

--- a/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
@@ -12,8 +12,8 @@
         <label class="font-weight-bold pl-2">{{ orgPersonLabel }}</label>
       </div>
 
-      <!-- Instructional people and roles text -->
-      <article v-if="isCorrectionFiling" class="section-container">
+      <!-- Instructional people and roles text (BEN corrections only)-->
+      <article v-if="isCorrectionFiling && isTypeBcomp" class="section-container">
         This application must include the following:
         <ul>
           <li>
@@ -34,18 +34,24 @@
         </ul>
       </article>
 
-      <!-- Change or conversion section -->
-      <article v-if="isChangeRegFiling || isConversionFiling" class="section-container">
-        <span class="info-text">{{ orgPersonSubtitle }}</span>
+      <!-- Change or conversion or firm correction section -->
+      <article
+        v-if="isChangeRegFiling || isConversionFiling || (isCorrectionFiling && isTypeFirm)"
+        class="section-container pb-0"
+      >
+        <p v-if="orgPersonSubtitle" class="info-text mt-2">{{ orgPersonSubtitle }}</p>
 
         <HelpSection
           v-if="!isRoleStaff && orgPersonHelp"
-          class="mt-5"
+          class="my-5"
           :helpSection="orgPersonHelp"
         />
 
-        <!-- SP add buttons (conversion filing only) -->
-        <div v-if="isTypeSoleProp && isConversionFiling && !hasMinimumProprietor" class="mt-8">
+        <!-- SP add buttons (conversion or correction filing only) -->
+        <div
+          v-if="isTypeSoleProp && (isConversionFiling || isCorrectionFiling) && !hasMinimumProprietor"
+          class="mt-8"
+        >
           <v-btn
             id="sp-btn-add-person"
             outlined
@@ -81,7 +87,7 @@
           </p>
         </div>
 
-        <!-- GP add buttons (change or conversion filing)-->
+        <!-- GP add buttons (change or conversion or correction filing)-->
         <div v-if="isTypePartnership" class="mt-8">
           <v-btn
             id="gp-btn-add-person"
@@ -119,8 +125,8 @@
         </div>
       </article>
 
-      <!-- Correction section -->
-      <article v-if="isCorrectionFiling" class="section-container">
+      <!-- Correction section (BEN corrections only) -->
+      <article v-if="isCorrectionFiling && isTypeBcomp" class="section-container">
         <v-btn
           id="btn-add-person"
           outlined
@@ -228,6 +234,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
   @Getter isTypeBcomp!: boolean
   @Getter isTypeSoleProp!: boolean
   @Getter isTypePartnership!: boolean
+  @Getter isTypeFirm!: boolean
 
   // Global actions
   @Action setPeopleAndRoles!: ActionBindingIF
@@ -293,6 +300,8 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
       }
       case (this.isCorrectionFiling): {
         if (this.isTypeBcomp) return (this.cpValid && this.incorpValid && this.dirValid)
+        if (this.isTypeSoleProp) return this.hasMinimumProprietor
+        if (this.isTypePartnership) return this.hasMinimumPartners
         return false
       }
     }

--- a/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
@@ -37,7 +37,7 @@
       <!-- Change or conversion or firm correction section -->
       <article
         v-if="isChangeRegFiling || isConversionFiling || isFirmCorrectionFiling"
-        class="section-container pb-0"
+        class="section-container"
       >
         <p v-if="orgPersonSubtitle" class="info-text mt-2">{{ orgPersonSubtitle }}</p>
 

--- a/src/components/common/YourCompany/BusinessContactInfo.vue
+++ b/src/components/common/YourCompany/BusinessContactInfo.vue
@@ -40,6 +40,7 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
   @Getter getSnapshotBusinessContact!: ContactPointIF
   @Getter getResource!: ResourceIF
   @Getter getBusinessId!: string
+  @Getter isTypeFirm!: boolean
 
   // Global setters
   @Action setBusinessContact!: ActionBindingIF
@@ -68,6 +69,9 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
 
   /** Check for changes between current contact and original contact. */
   get hasBusinessContactInfoChange (): boolean {
+    // cannot change business contact info in firm corrections
+    if (this.isCorrectionFiling && this.isTypeFirm) return false
+
     return this.getBusinessContact?.email !== this.originalContact?.email ||
       this.getBusinessContact?.phone !== this.originalContact?.phone ||
       this.getBusinessContact?.extension !== this.originalContact?.extension

--- a/src/components/common/YourCompany/BusinessContactInfo.vue
+++ b/src/components/common/YourCompany/BusinessContactInfo.vue
@@ -40,7 +40,8 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
   @Getter getSnapshotBusinessContact!: ContactPointIF
   @Getter getResource!: ResourceIF
   @Getter getBusinessId!: string
-  @Getter isTypeFirm!: boolean
+  @Getter isEntityTypeFirm!: boolean
+  @Getter isFirmCorrectionFiling!: boolean
 
   // Global setters
   @Action setBusinessContact!: ActionBindingIF
@@ -54,24 +55,19 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
 
   /** Get the original Contact info dependant on filing type. */
   get originalContact (): ContactPointIF {
-    if (this.isCorrectionFiling && this.getOriginalIA?.incorporationApplication) {
+    if (this.getOriginalIA?.incorporationApplication) {
       return this.getOriginalIA.incorporationApplication.contactPoint
-    } else if (this.isCorrectionFiling && this.getOriginalChgRegistration?.changeOfRegistration) {
+    } else if (this.getOriginalChgRegistration?.changeOfRegistration) {
       return this.getOriginalChgRegistration.changeOfRegistration.contactPoint
-    } else if (this.isCorrectionFiling && this.getOriginalRegistration?.registration) {
+    } else if (this.getOriginalRegistration?.registration) {
       return this.getOriginalRegistration.registration.contactPoint
-    } else if (this.isAlterationFiling || this.isChangeRegFiling || this.isConversionFiling) {
-      return this.getSnapshotBusinessContact
     } else {
-      return null
+      return this.getSnapshotBusinessContact
     }
   }
 
   /** Check for changes between current contact and original contact. */
   get hasBusinessContactInfoChange (): boolean {
-    // cannot change business contact info in firm corrections
-    if (this.isCorrectionFiling && this.isTypeFirm) return false
-
     return this.getBusinessContact?.email !== this.originalContact?.email ||
       this.getBusinessContact?.phone !== this.originalContact?.phone ||
       this.getBusinessContact?.extension !== this.originalContact?.extension

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -175,7 +175,7 @@
             <span>Undo</span>
           </v-btn>
           <v-btn
-            v-else-if="isTypeBcCompany"
+            v-else-if="isEntityTypeBC"
             text color="primary"
             id="btn-correct-business-type"
             @click="isEditingType = true"
@@ -240,7 +240,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin, SharedMixin)
   @Getter getResource!: ResourceIF
   @Getter hasBusinessTypeChanged!: boolean
   @Getter isConflictingLegalType!: boolean
-  @Getter isTypeBcCompany!: boolean
+  @Getter isEntityTypeBC!: boolean
 
   @Action setEntityType!: ActionBindingIF
 

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="business-type">
+  <div id="change-business-type">
     <v-row no-gutters>
       <!-- Row Title -->
       <v-col cols="3">
@@ -13,48 +13,46 @@
 
       <!-- Display Mode -->
       <v-col cols="7" v-if="!isEditingType">
-        <template>
-          <span class="info-text" :class="{ 'hasConflict': isConflictingLegalType && isNewName}">
-            {{getCorpTypeDescription(getEntityType)}}
-          </span>
+        <span class="info-text" :class="{ 'has-conflict': isConflictingLegalType && isNewName}">
+          {{getCorpTypeDescription(getEntityType)}}
+        </span>
 
-          <!-- Firm info tooltip -->
-          <v-tooltip v-if="isChangeRegFiling || isConversionFiling"
-                     top
-                     content-class="top-tooltip"
-                     transition="fade-transition"
-                     nudge-right="3"
-          >
-            <template v-slot:activator="{ on }">
-              <v-icon v-on="on" class="info-icon">mdi-information-outline</v-icon>
-            </template>
-            <span>{{ typeChangeInfo }}</span>
-          </v-tooltip>
-
-          <!-- Type mismatch tooltip -->
-          <v-tooltip v-if="isConflictingLegalType && isNewName"
-                     top
-                     content-class="top-tooltip"
-                     transition="fade-transition"
-                     nudge-right="3"
-          >
-            <template v-slot:activator="{ on }">
-              <v-icon v-on="on" color="error" small>mdi-alert</v-icon>
-            </template>
-            <span>
-              Business Types do not match. The Name Request type must match the business type before you can continue.
-            </span>
-          </v-tooltip>
-          <template v-if="hasBusinessTypeChanged">
-            <p class="subtitle mt-2 pt-2">Benefit Company Articles</p>
-            <div class="confirmed-msg">
-              <v-icon color="success" class="confirmed-icon">mdi-check</v-icon>
-              <span class="info-text text-body-3 confirmed-icon ml-2">
-              The company has completed a set Benefit Company Articles containing a benefit provision, and a copy of
-              these articles has been added to the company's record book.
-              </span>
-            </div>
+        <!-- Firm info tooltip -->
+        <v-tooltip v-if="isChangeRegFiling || isConversionFiling"
+                    top
+                    content-class="top-tooltip"
+                    transition="fade-transition"
+                    nudge-right="3"
+        >
+          <template v-slot:activator="{ on }">
+            <v-icon v-on="on" class="info-icon">mdi-information-outline</v-icon>
           </template>
+          <span>{{ typeChangeInfo }}</span>
+        </v-tooltip>
+
+        <!-- Type mismatch tooltip -->
+        <v-tooltip v-if="isConflictingLegalType && isNewName"
+                    top
+                    content-class="top-tooltip"
+                    transition="fade-transition"
+                    nudge-right="3"
+        >
+          <template v-slot:activator="{ on }">
+            <v-icon v-on="on" color="error" small>mdi-alert</v-icon>
+          </template>
+          <span>
+            Business Types do not match. The Name Request type must match the business type before you can continue.
+          </span>
+        </v-tooltip>
+        <template v-if="hasBusinessTypeChanged">
+          <p class="subtitle mt-2 pt-2">Benefit Company Articles</p>
+          <div class="confirmed-msg">
+            <v-icon color="success" class="confirmed-icon">mdi-check</v-icon>
+            <span class="info-text text-body-3 confirmed-icon ml-2">
+            The company has completed a set Benefit Company Articles containing a benefit provision, and a copy of
+            these articles has been added to the company's record book.
+            </span>
+          </div>
         </template>
       </v-col>
 

--- a/src/components/common/YourCompany/OfficeAddresses.vue
+++ b/src/components/common/YourCompany/OfficeAddresses.vue
@@ -522,7 +522,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * Sets local address data and "inherit" flags from store.
    */
   private setLocalProperties (): void {
-    if (this.isCorrectionFiling || this.isAlterationFiling) {
+    if ((this.isCorrectionFiling && this.isTypeBcomp) || this.isAlterationFiling) {
       // assign registered office addresses (may be {})
       this.mailingAddress = { ...this.getOfficeAddresses?.registeredOffice?.mailingAddress }
       this.deliveryAddress = { ...this.getOfficeAddresses?.registeredOffice?.deliveryAddress }
@@ -571,7 +571,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
       )
     }
 
-    if (this.isChangeRegFiling || this.isConversionFiling) {
+    if (this.isChangeRegFiling || this.isConversionFiling || (this.isCorrectionFiling && this.isTypeFirm)) {
       // assign business office addresses (may be {})
       this.mailingAddress = { ...this.getOfficeAddresses?.businessOffice?.mailingAddress }
       this.deliveryAddress = { ...this.getOfficeAddresses?.businessOffice?.deliveryAddress }

--- a/src/components/common/YourCompany/OfficeAddresses.vue
+++ b/src/components/common/YourCompany/OfficeAddresses.vue
@@ -103,8 +103,8 @@
         </template>
       </v-row>
 
-      <!-- Records office (BComp only) -->
-      <v-row v-if="isTypeBcomp" id="summary-records-address" class="mt-4 mx-0" no-gutters>
+      <!-- Records office (BEN only) -->
+      <v-row v-if="isEntityTypeBEN" id="summary-records-address" class="mt-4 mx-0" no-gutters>
         <v-col cols="3">
           <label class>Records Office</label>
         </v-col>
@@ -305,7 +305,7 @@
         </div>
 
         <!-- "Same as" checkbox -->
-        <div id="edit-records-address" v-if="isTypeBcomp">
+        <div id="edit-records-address" v-if="isEntityTypeBEN">
           <div class="address-edit-header" :class="{'mt-8': inheritMailingAddress}">
             <label class="address-edit-title">Records Office</label>
             <v-checkbox
@@ -444,8 +444,10 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   @Getter hasDeliveryChanged!: boolean
   @Getter hasRecMailingChanged!: boolean
   @Getter hasRecDeliveryChanged!: boolean
-  @Getter isTypeBcomp!: boolean
-  @Getter isTypeFirm!: boolean
+  @Getter isEntityTypeBEN!: boolean
+  @Getter isEntityTypeFirm!: boolean
+  @Getter isBenIaCorrectionFiling!: boolean
+  @Getter isFirmCorrectionFiling!: boolean
 
   // Global actions
   @Action setOfficeAddresses!: ActionBindingIF
@@ -522,7 +524,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * Sets local address data and "inherit" flags from store.
    */
   private setLocalProperties (): void {
-    if ((this.isCorrectionFiling && this.isTypeBcomp) || this.isAlterationFiling) {
+    if (this.isBenIaCorrectionFiling || this.isAlterationFiling) {
       // assign registered office addresses (may be {})
       this.mailingAddress = { ...this.getOfficeAddresses?.registeredOffice?.mailingAddress }
       this.deliveryAddress = { ...this.getOfficeAddresses?.registeredOffice?.deliveryAddress }
@@ -571,7 +573,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
       )
     }
 
-    if (this.isChangeRegFiling || this.isConversionFiling || (this.isCorrectionFiling && this.isTypeFirm)) {
+    if (this.isChangeRegFiling || this.isConversionFiling || this.isFirmCorrectionFiling) {
       // assign business office addresses (may be {})
       this.mailingAddress = { ...this.getOfficeAddresses?.businessOffice?.mailingAddress }
       this.deliveryAddress = { ...this.getOfficeAddresses?.businessOffice?.deliveryAddress }
@@ -725,25 +727,23 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * Sets updated office addresses in store.
    */
   private storeAddresses (): void {
-    if (this.isCorrectionFiling) {
+    if (this.isBenIaCorrectionFiling) {
       // at the moment, only BEN IA corrections are supported
-      if (this.isTypeBcomp) {
-        this.setOfficeAddresses({
-          registeredOffice: {
-            deliveryAddress: this.deliveryAddress,
-            mailingAddress: this.mailingAddress
-          },
-          recordsOffice: {
-            deliveryAddress: this.recDeliveryAddress,
-            mailingAddress: this.recMailingAddress
-          }
-        })
-      }
+      this.setOfficeAddresses({
+        registeredOffice: {
+          deliveryAddress: this.deliveryAddress,
+          mailingAddress: this.mailingAddress
+        },
+        recordsOffice: {
+          deliveryAddress: this.recDeliveryAddress,
+          mailingAddress: this.recMailingAddress
+        }
+      })
     }
 
-    if (this.isChangeRegFiling || this.isConversionFiling) {
-      // at the moment, only SP and GP changes and conversion are supported
-      if (this.isTypeFirm) {
+    if (this.isEntityTypeFirm) {
+      if (this.isChangeRegFiling || this.isConversionFiling || this.isCorrectionFiling) {
+      // at the moment, only firm changes, conversions and corrections are supported
         this.setOfficeAddresses({
           businessOffice: {
             deliveryAddress: this.deliveryAddress,
@@ -812,10 +812,13 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * When the component is mounted or stored office addresses change (ie, when data is loaded/updated/reset),
    * sets local properties and emits state events.
    *
-   * Called on mount to init data in the event the component is destroyed and there is no changes to trigger the Watcher
-   * This happens in Alterations when navigating between views and where office addresses are not editable.
+   * Called immediately to init data when office addresses are not editable.
+   *
+   * Also called when we know what kind of correction this is.
    */
   @Watch('getOfficeAddresses', { deep: true, immediate: true })
+  @Watch('isBenIaCorrectionFiling')
+  @Watch('isFirmCorrectionFiling')
   private updateAddresses (): void {
     // set local properties from store
     this.setLocalProperties()

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -194,7 +194,7 @@
     </div>
 
     <!-- Business Type (firm corrections only) -->
-    <template v-if="isCorrectionFiling && isTypeFirm">
+    <template v-if="isFirmCorrectionFiling">
       <v-divider class="mx-4 my-1" />
 
       <div class="section-container">
@@ -211,7 +211,7 @@
     </template>
 
     <!-- Name Translation(s) (alterations and BEN corrections only)-->
-    <div v-if="isAlterationFiling || (isCorrectionFiling && isTypeBcomp)"
+    <div v-if="isAlterationFiling || isBenIaCorrectionFiling"
       id="name-translate-section"
       class="section-container"
       :class="{'invalid-section': invalidTranslationSection}"
@@ -225,8 +225,8 @@
 
     <v-divider class="mx-4 my-1" />
 
-    <!-- Business Start Date -->
-    <template v-if="isChangeRegFiling || isConversionFiling || (isCorrectionFiling && isTypeFirm)">
+    <!-- Business Start Date (changes, conversions and firm corrections only -->
+    <template v-if="isChangeRegFiling || isConversionFiling || isFirmCorrectionFiling">
       <section class="section-container">
         <v-row no-gutters>
           <v-col cols="3">
@@ -251,7 +251,7 @@
     </template>
 
     <!-- Nature of Business (firm change filings only) -->
-    <template v-if="isTypeFirm && isChangeRegFiling">
+    <template v-if="isEntityTypeFirm && isChangeRegFiling">
       <v-divider class="mx-4 my-1" />
 
       <NatureOfBusiness
@@ -262,7 +262,7 @@
     </template>
 
     <!-- Nature of Business (firm conversion and correction filings only) -->
-    <template v-if="isTypeFirm && (isConversionFiling || isCorrectionFiling)">
+    <template v-if="isEntityTypeFirm && (isConversionFiling || isCorrectionFiling)">
       <v-divider class="mx-4 my-1" />
 
       <ConversionNOB
@@ -273,7 +273,7 @@
     </template>
 
     <!-- Recognition Date and Time (alterations and BEN corrections only) -->
-    <div class="section-container" v-if="isAlterationFiling || (isCorrectionFiling && isTypeBcomp)">
+    <div class="section-container" v-if="isAlterationFiling || isBenIaCorrectionFiling">
       <v-row no-gutters>
         <v-col cols="3">
           <label><strong>Recognition Date and Time</strong></label>
@@ -305,7 +305,7 @@
     </div>
 
     <!-- Folio Information (all except SP or GP) -->
-    <template v-if="isPremiumAccount && !isTypeFirm">
+    <template v-if="isPremiumAccount && !isEntityTypeFirm">
       <v-divider class="mx-4 my-1" />
 
       <div id="folio-number-section" class="section-container" :class="{'invalid-section': invalidFolioSection}">
@@ -370,8 +370,10 @@ export default class YourCompany extends Mixins(
   @Getter getEntitySnapshot!: EntitySnapshotIF
   @Getter getBusinessContact!: ContactPointIF
   @Getter getResource!: ResourceIF
-  @Getter isTypeBcomp!: boolean
-  @Getter isTypeFirm!: boolean
+  @Getter isEntityTypeBEN!: boolean
+  @Getter isEntityTypeFirm!: boolean
+  @Getter isBenIaCorrectionFiling!: boolean
+  @Getter isFirmCorrectionFiling!: boolean
 
   // Alteration flag getters
   @Getter hasBusinessNameChanged!: boolean
@@ -461,12 +463,12 @@ export default class YourCompany extends Mixins(
 
   /** The recognition/founding (aka effective or start date) datetime. */
   get recognitionDateTime (): string {
-    if (this.isCorrectionFiling && this.isTypeBcomp) {
+    if (this.isBenIaCorrectionFiling) {
       if (this.getOriginalEffectiveDateTime) {
         return (this.apiToPacificDateLong(this.getOriginalEffectiveDateTime))
       }
     }
-    if (this.isCorrectionFiling && this.isTypeFirm) {
+    if (this.isFirmCorrectionFiling) {
       if (this.getBusinessFoundingDate) {
         return (this.apiToPacificDateLong(this.getBusinessFoundingDate))
       }
@@ -483,11 +485,11 @@ export default class YourCompany extends Mixins(
   get isNewName () {
     let currentName
 
-    if (this.isCorrectionFiling && this.getOriginalIA?.incorporationApplication) {
+    if (this.getOriginalIA?.incorporationApplication) {
       currentName = this.getOriginalIA.incorporationApplication.nameRequest.legalName
-    } else if (this.isCorrectionFiling && this.getOriginalChgRegistration?.changeOfRegistration) {
+    } else if (this.getOriginalChgRegistration?.changeOfRegistration) {
       currentName = this.getOriginalChgRegistration.changeOfRegistration.nameRequest.legalName
-    } else if (this.isCorrectionFiling && this.getOriginalRegistration?.registration) {
+    } else if (this.getOriginalRegistration?.registration) {
       currentName = this.getOriginalRegistration.registration.nameRequest.legalName
     } else {
       currentName = this.getEntitySnapshot.businessInfo.legalName
@@ -513,11 +515,11 @@ export default class YourCompany extends Mixins(
     )
 
     // reset name request
-    if (this.isCorrectionFiling && this.getOriginalIA?.incorporationApplication) {
+    if (this.getOriginalIA?.incorporationApplication) {
       this.setNameRequest(this.getOriginalIA.incorporationApplication.nameRequest)
-    } else if (this.isCorrectionFiling && this.getOriginalChgRegistration?.changeOfRegistration) {
+    } else if (this.getOriginalChgRegistration?.changeOfRegistration) {
       this.setNameRequest(this.getOriginalChgRegistration.changeOfRegistration.nameRequest)
-    } else if (this.isCorrectionFiling && this.getOriginalRegistration?.registration) {
+    } else if (this.getOriginalRegistration?.registration) {
       this.setNameRequest(this.getOriginalRegistration.registration.nameRequest)
     } else {
       this.setNameRequest(this.getEntitySnapshot.businessInfo)

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -12,7 +12,7 @@
           <label :class="{'error-text': invalidNameSection}">
             <strong>{{ getResource.entityReference }} Name</strong>
           </label>
-          <v-flex md1 class="mt-1">
+          <v-flex md1>
             <v-chip
               v-if="companyNameChanges ||
                 (hasBusinessNameChanged && (isAlterationFiling || isChangeRegFiling || isConversionFiling))"

--- a/src/enums/componentsCompanyInfo.ts
+++ b/src/enums/componentsCompanyInfo.ts
@@ -6,7 +6,7 @@
  */
 export enum ComponentsCompanyInfo {
   'company-name-section',
-  'business-type',
+  'change-business-type',
   'name-translation',
   'nature-of-business',
   'office-addresses',

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -55,10 +55,10 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
   @Getter hasOfficeAddressesChanged!: boolean
   @Getter hasPeopleAndRolesChanged!: boolean
   @Getter getCompletingParty!: CompletingPartyIF
-  @Getter isTypeBcomp!: boolean
-  @Getter isTypeCoop!: boolean
-  @Getter isTypeSoleProp!: boolean
-  @Getter isTypePartnership!: boolean
+  @Getter isEntityTypeBEN!: boolean
+  @Getter isEntityTypeCP!: boolean
+  @Getter isEntityTypeSP!: boolean
+  @Getter isEntityTypeGP!: boolean
   @Getter getCorrectedFilingType!: FilingTypes
 
   // Global actions

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -526,6 +526,8 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
    * @param filing the correction filing
    */
   parseCorrectionFiling (filing: CorrectionFilingIF): void {
+    // console.log('*** correction filing =', filing)
+
     // Store business information
     this.setBusinessInformation(filing.business)
 
@@ -834,7 +836,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
       legalName: entitySnapshot.businessInfo.legalName
     })
 
-    // Store people and roles
+    // Store people and roles (aka parties)
     this.setPeopleAndRoles(entitySnapshot.orgPersons || [])
 
     // Store the business contact
@@ -842,7 +844,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
 
     // Handle entity specific values
     switch (entitySnapshot.businessInfo.legalType) {
-      case CorpTypeCd.BENEFIT_COMPANY:
+      case CorpTypeCd.BENEFIT_COMPANY: {
         // Store name translations
         this.setNameTranslations(
           entitySnapshot.nameTranslations?.map(x => {
@@ -866,11 +868,14 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
         this.setResolutionDates([])
         this.setOriginalResolutionDates(entitySnapshot.resolutions)
         break
+      }
+
       case CorpTypeCd.SOLE_PROP:
-      case CorpTypeCd.PARTNERSHIP:
+      case CorpTypeCd.PARTNERSHIP: {
         // Store business addresses
         this.setOfficeAddresses(entitySnapshot.addresses)
         break
+      }
     }
   }
 

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -526,8 +526,6 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
    * @param filing the correction filing
    */
   parseCorrectionFiling (filing: CorrectionFilingIF): void {
-    // console.log('*** correction filing =', filing)
-
     // Store business information
     this.setBusinessInformation(filing.business)
 
@@ -542,7 +540,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     //     Due to missing props, change event was not triggering if the action value is changed (at
     //     the time of Delete there is no other prop change except action). To handle this scenario,
     //     this structure needs to be kept.
-    if (filing.incorporationApplication) { // *** TODO: expand for other filing types
+    if (filing.incorporationApplication) { // *** FUTURE: expand for other filing types
       this.setNameTranslations(
         filing.incorporationApplication.nameTranslations?.map(x => {
           return {
@@ -556,12 +554,12 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     }
 
     // Store office addresses
-    if (filing.incorporationApplication) { // *** TODO: expand for other filing types
+    if (filing.incorporationApplication) { // *** FUTURE: expand for other filing types
       this.setOfficeAddresses(filing.incorporationApplication.offices)
     }
 
     // Store business contact
-    if (filing.incorporationApplication) { // *** TODO: expand for other filing types
+    if (filing.incorporationApplication) { // *** FUTURE: expand for other filing types
       this.setBusinessContact({
         ...filing.incorporationApplication.contactPoint,
         confirmEmail: filing.incorporationApplication.contactPoint.email
@@ -569,12 +567,12 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     }
 
     // Store people and roles
-    if (filing.incorporationApplication) { // *** TODO: expand for other filing types
+    if (filing.incorporationApplication) { // *** FUTURE: expand for other filing types
       this.setPeopleAndRoles(filing.incorporationApplication.parties || [])
     }
 
     // Store share classes
-    if (filing.incorporationApplication) { // *** TODO: expand for other filing types
+    if (filing.incorporationApplication) { // *** FUTURE: expand for other filing types
       if (filing.incorporationApplication.shareStructure) {
         this.setShareClasses(filing.incorporationApplication.shareStructure.shareClasses)
       } else {
@@ -590,7 +588,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     }
 
     // Store incorporation agreement type
-    if (filing.incorporationApplication) { // *** TODO: expand for other filing types
+    if (filing.incorporationApplication) { // *** FUTURE: expand for other filing types
       this.setIncorporationAgreementStepData({
         agreementType: filing.incorporationApplication.incorporationAgreement?.agreementType
       })

--- a/src/resources/Conversion/SoleProprietorshipResource.ts
+++ b/src/resources/Conversion/SoleProprietorshipResource.ts
@@ -25,8 +25,7 @@ export const SoleProprietorshipResource: ResourceIF = {
       orgTypesLabel: 'Business or Corporation',
       subtitle: 'You can change the legal name, mailing and delivery addresses and the email address of the ' +
         'individual proprietor. To change to a different proprietor, you must form a new business with that ' +
-        'proprietor and dissolve this registration.',
-      helpSection: null
+        'proprietor and dissolve this registration.'
     }
   },
   certifyClause: null

--- a/src/resources/Correction/GeneralPartnershipResource.ts
+++ b/src/resources/Correction/GeneralPartnershipResource.ts
@@ -2,17 +2,20 @@ import { CorrectionTypes } from '@/enums/'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
 
 export const GeneralPartnershipResource: any = {
-  addressLabel: 'Business Office',
+  addressLabel: 'Business Addresses',
   entityType: CorpTypeCd.PARTNERSHIP,
   entityReference: 'Business',
-  contactLabel: 'Business Office',
+  contactLabel: 'Business',
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR
     ],
     orgPersonInfo: {
       orgPersonLabel: 'Partners',
-      orgTypesLabel: 'Corporation or Firm'
+      orgTypesLabel: 'Business or Corporation',
+      subtitle: 'You must have a minimum of two partners. You can add or remove partners (individual person or ' +
+        'business) as well as change the mailing and delivery addresses and email address of individual people and ' +
+        'business partners.'
     }
   },
   certifyClause: 'Note: It is an offence to make or assist in making a false or misleading statement in a record ' +

--- a/src/resources/Correction/SoleProprietorshipResource.ts
+++ b/src/resources/Correction/SoleProprietorshipResource.ts
@@ -2,17 +2,20 @@ import { CorrectionTypes } from '@/enums/'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
 
 export const SoleProprietorshipResource: any = {
-  addressLabel: 'Business Office',
+  addressLabel: 'Business Addresses',
   entityType: CorpTypeCd.SOLE_PROP,
   entityReference: 'Business',
-  contactLabel: 'Business Office',
+  contactLabel: 'Business',
   changeData: {
     nameChangeOptions: [
       CorrectionTypes.CORRECT_NEW_NR
     ],
     orgPersonInfo: {
       orgPersonLabel: 'Proprietor',
-      orgTypesLabel: 'Corporation or Firm'
+      orgTypesLabel: 'Business or Corporation',
+      subtitle: 'You can change the legal name, mailing and delivery addresses and the email address of the ' +
+        'individual proprietor. To change to a different proprietor, you must form a new business with that ' +
+        'proprietor and dissolve this registration.'
     }
   },
   certifyClause: 'Note: It is an offence to make or assist in making a false or misleading statement in a record ' +

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -223,8 +223,8 @@ export default class Alteration extends Mixins(
 
   /** The resource file for an alteration filing. */
   get alterationResource (): ResourceIF {
-    if (this.isTypeBcomp) return BenefitCompanyResource
-    if (this.isTypeCoop) return CooperativeResource
+    if (this.isEntityTypeBEN) return BenefitCompanyResource
+    if (this.isEntityTypeCP) return CooperativeResource
     return null
   }
 

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -145,8 +145,8 @@ export default class Change extends Mixins(
 
   /** The resource file for a firm change filing. */
   get firmChangeResource (): ResourceIF {
-    if (this.isTypeSoleProp) return SoleProprietorshipResource
-    if (this.isTypePartnership) return GeneralPartnershipResource
+    if (this.isEntityTypeSP) return SoleProprietorshipResource
+    if (this.isEntityTypeGP) return GeneralPartnershipResource
     return null
   }
 

--- a/src/views/Conversion.vue
+++ b/src/views/Conversion.vue
@@ -82,8 +82,6 @@ export default class Conversion extends Mixins(
   @Getter getFilingData!: FilingDataIF
   @Getter getAppValidate!: boolean
   @Getter showFeeSummary!: boolean
-  @Getter isTypeSoleProp!: boolean
-  @Getter isTypePartnership!: boolean
 
   // Global actions
   @Action setHaveUnsavedChanges!: ActionBindingIF
@@ -111,8 +109,8 @@ export default class Conversion extends Mixins(
 
   /** The resource file for a firm conversion filing. */
   get firmConversionResource (): any {
-    if (this.isTypeSoleProp) return SoleProprietorshipResource
-    if (this.isTypePartnership) return GeneralPartnershipResource
+    if (this.isEntityTypeSP) return SoleProprietorshipResource
+    if (this.isEntityTypeGP) return GeneralPartnershipResource
     return null
   }
 

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <BenCorrection
-      v-if="isTypeBcomp"
+      v-if="isEntityTypeBEN"
       :correctionFiling="correctionFiling"
       @fetchError="emitFetchError($event)"
       @haveData="emitHaveData($event)"
     />
     <FmCorrection
-      v-if="isTypeFirm"
+      v-if="isEntityTypeFirm"
       :correctionFiling="correctionFiling"
       @fetchError="emitFetchError($event)"
       @haveData="emitHaveData($event)"
@@ -39,8 +39,8 @@ export default class Correction extends Mixins(CommonMixin, LegalApiMixin) {
 
   // Global getters
   @Getter isRoleStaff!: boolean
-  @Getter isTypeBcomp!: boolean
-  @Getter isTypeFirm!: boolean
+  @Getter isEntityTypeBEN!: boolean
+  @Getter isEntityTypeFirm!: boolean
 
   // Global actions
   @Action setFilingId!: ActionBindingIF
@@ -102,7 +102,7 @@ export default class Correction extends Mixins(CommonMixin, LegalApiMixin) {
 
       // do not proceed if this isn't a BEN or SP/GP correction
       this.setEntityType(filing.business?.legalType)
-      if (!this.isTypeBcomp && !this.isTypeFirm) {
+      if (!this.isEntityTypeBEN && !this.isEntityTypeFirm) {
         throw new Error('Invalid correction type')
       }
 

--- a/src/views/Correction/BenCorrection.vue
+++ b/src/views/Correction/BenCorrection.vue
@@ -99,6 +99,9 @@ export default class BenCorrection extends Mixins(CommonMixin, DateMixin, Filing
   private async onCorrectionFiling (): Promise<void> {
     // fetch the rest of the data
     try {
+      // safety check
+      if (!this.correctionFiling) throw (new Error('Missing correction filing'))
+
       // parse correction filing into store
       this.parseCorrectionFiling(this.correctionFiling)
 

--- a/src/views/Correction/FmCorrection.vue
+++ b/src/views/Correction/FmCorrection.vue
@@ -15,15 +15,27 @@
 
     <PeopleAndRoles class="mt-10" />
 
-    <CompletingParty class="mt-10" sectionNumber="1." />
+    <template v-if="isClientErrorCorrection">
+      <CompletingParty class="mt-10" sectionNumber="1." validate="true" />
+    </template>
 
-    <Detail class="mt-10" sectionNumber="2." validate="true" />
+    <Detail
+      class="mt-10"
+      :sectionNumber="isClientErrorCorrection ? '2.' : '1.'"
+      validate="true"
+    />
 
-    <CertifySection class="mt-10" sectionNumber="3." validate="true" />
+    <template v-if="isClientErrorCorrection">
+      <CertifySection
+        class="mt-10"
+        :sectionNumber="isClientErrorCorrection ? '3.' : '2.'"
+        validate="true"
+      />
+    </template>
 
     <StaffPayment
       class="mt-10"
-      sectionNumber="4."
+      :sectionNumber="isClientErrorCorrection ? '4.' : '2.'"
       @haveChanges="onStaffPaymentChanges()"
     />
   </section>
@@ -32,8 +44,8 @@
 <script lang="ts">
 import { Component, Emit, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
-import { CompletingParty } from '@/components/Correction/'
-import { CertifySection, Detail, PeopleAndRoles, StaffPayment, YourCompany } from '@/components/common/'
+import { CertifySection, CompletingParty, Detail, PeopleAndRoles, StaffPayment, YourCompany }
+  from '@/components/common/'
 import { CommonMixin, DateMixin, FilingTemplateMixin, LegalApiMixin } from '@/mixins/'
 import { ActionBindingIF, CorrectionFilingIF, EntitySnapshotIF, FilingDataIF } from '@/interfaces/'
 import { FilingCodes } from '@/enums/'
@@ -55,12 +67,10 @@ import { GeneralPartnershipResource, SoleProprietorshipResource } from '@/resour
 export default class FmCorrection extends Mixins(CommonMixin, DateMixin, FilingTemplateMixin, LegalApiMixin) {
   // Global getters
   @Getter getFilingData!: FilingDataIF
-  @Getter getOriginalFilingName!: string
 
   // Global actions
   @Action setCorrectedFilingId!: ActionBindingIF
   @Action setHaveUnsavedChanges!: ActionBindingIF
-  @Action setCorrectedFiling!: ActionBindingIF
   @Action setFilingData!: ActionBindingIF
   @Action setCertifyStatementResource!: ActionBindingIF
   @Action setResource!: ActionBindingIF
@@ -71,9 +81,14 @@ export default class FmCorrection extends Mixins(CommonMixin, DateMixin, FilingT
 
   readonly getCorpTypeDescription = GetCorpFullDescription
 
+  /** Whether this is a client error correction (vs. a staff error correction). */
+  get isClientErrorCorrection (): boolean {
+    return true // FUTURE: implement this according to schema changes
+  }
+
   /** The original filing name. */
   get originalFilingName (): string {
-    return `${this.getCorpTypeDescription(this.getEntityType)} ${this.getOriginalFilingName}`
+    return `${this.getCorpTypeDescription(this.getEntityType)} Registration`
   }
 
   /** The original filing date, in Pacific time. */
@@ -94,10 +109,11 @@ export default class FmCorrection extends Mixins(CommonMixin, DateMixin, FilingT
    */
   @Watch('correctionFiling', { immediate: true })
   private async onCorrectionFiling (): Promise<void> {
-    // console.log('*** correctionFiling =', this.correctionFiling)
-
     // fetch the rest of the data
     try {
+      // safety check
+      if (!this.correctionFiling) throw (new Error('Missing correction filing'))
+
       // parse correction filing into store
       this.parseCorrectionFiling(this.correctionFiling)
 
@@ -106,16 +122,9 @@ export default class FmCorrection extends Mixins(CommonMixin, DateMixin, FilingT
       const correctedFilingId: number = +this.correctionFiling.correction?.correctedFilingId
       this.setCorrectedFilingId(correctedFilingId)
 
-      // *** TODO: remove this if not needed
-      // fetch and store original filing
-      const correctedFiling = await this.fetchFilingById(correctedFilingId)
-      this.setCorrectedFiling(correctedFiling)
-      // console.log('*** correctedFiling', correctedFiling)
-
-      // fetch and store business snapshot
+      // we don't care about the original filing
+      // instead, fetch and store business snapshot
       const businessSnapshot = await this.fetchBusinessSnapshot()
-      // console.log('*** businessSnapshot', businessSnapshot)
-      // parse business data into store
       await this.parseEntitySnapshot(businessSnapshot)
 
       // set the resources
@@ -146,22 +155,16 @@ export default class FmCorrection extends Mixins(CommonMixin, DateMixin, FilingT
       this.fetchBusinessInfo(),
       AuthServices.fetchAuthInfo(this.getBusinessId),
       this.fetchAddresses(),
-      this.fetchNameTranslations(),
-      this.fetchDirectors(),
-      this.fetchShareStructure(),
-      this.fetchResolutions()
+      this.fetchParties()
     ])
 
-    if (items.length !== 7) throw new Error('Failed to fetch entity snapshot')
+    if (items.length !== 4) throw new Error('Failed to fetch entity snapshot')
 
     return {
       businessInfo: items[0],
       authInfo: items[1],
       addresses: items[2],
-      nameTranslations: items[3],
-      orgPersons: items[4],
-      shareStructure: items[5],
-      resolutions: items[6]
+      orgPersons: items[3]
     } as EntitySnapshotIF
   }
 

--- a/src/views/Correction/FmCorrection.vue
+++ b/src/views/Correction/FmCorrection.vue
@@ -98,8 +98,8 @@ export default class FmCorrection extends Mixins(CommonMixin, DateMixin, FilingT
 
   /** The resource file for a correction filing. */
   get correctionResource (): any {
-    if (this.isTypeSoleProp) return SoleProprietorshipResource
-    if (this.isTypePartnership) return GeneralPartnershipResource
+    if (this.isEntityTypeSP) return SoleProprietorshipResource
+    if (this.isEntityTypeGP) return GeneralPartnershipResource
     throw new Error(`Invalid Correction Resource entity type = ${this.getEntityType}`)
   }
 

--- a/tests/unit/Alteration.spec.ts
+++ b/tests/unit/Alteration.spec.ts
@@ -237,7 +237,7 @@ describe('Alteration component', () => {
         data: {
           contacts: [
             {
-              email: 'mock@email.com',
+              email: 'mock@example.com',
               phone: '123-456-7890'
             }
           ]
@@ -317,7 +317,7 @@ describe('Alteration component', () => {
       .toBe('Series 2 Shares')
 
     // Validate Contact Info
-    expect(store.state.stateModel.businessContact.email).toBe('mock@email.com')
+    expect(store.state.stateModel.businessContact.email).toBe('mock@example.com')
     expect(store.state.stateModel.businessContact.phone).toBe('123-456-7890')
 
     expect(store.state.stateModel.currentFees.filingFees).toBe(100)

--- a/tests/unit/BenCorrection.spec.ts
+++ b/tests/unit/BenCorrection.spec.ts
@@ -96,14 +96,32 @@ describe('Benefit Company Correction component', () => {
         }
       }))
 
-    // FUTURE: mock GET correction filing
+    // GET corrected filing
+    get.withArgs('businesses/BC1234567/filings/123')
+      .returns(Promise.resolve({
+        data: {
+          business: {},
+          header: {},
+          incorporationApplication: {}
+        }
+      }))
 
     // create a Local Vue and install router on it
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
     await router.push({ name: 'correction' })
-    wrapper = shallowMount(BenCorrection, { localVue, store, router, vuetify })
+    wrapper = shallowMount(BenCorrection, { localVue,
+      store,
+      router,
+      vuetify,
+      propsData: {
+        correctionFiling: {
+          business: {},
+          correction: { correctedFilingId: 123 },
+          header: {}
+        }
+      } })
 
     // wait for all queries to complete
     await flushPromises()
@@ -155,7 +173,7 @@ describe('Benefit Company Correction component', () => {
       .toBe('Series 2 Shares')
 
     // Validate Contact Info
-    expect(store.state.stateModel.businessContact.email).toBe('mock@email.com')
+    expect(store.state.stateModel.businessContact.email).toBe('mock@example.com')
     expect(store.state.stateModel.businessContact.phone).toBe('123-456-7890')
 
     expect(store.state.stateModel.currentFees.filingFees).toBe(100)

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -14,8 +14,8 @@ const store = getVuexStore()
 const mockUpdateContactInfo = jest.spyOn((AuthServices as any), 'updateContactInfo').mockImplementation()
 
 const contactInfo = {
-  email: 'mock@email.com',
-  confirmEmail: 'mock@email.com',
+  email: 'mock@example.com',
+  confirmEmail: 'mock@example.com',
   phone: '250-123-4567'
 }
 
@@ -130,8 +130,8 @@ describe('BusinessContactInfo for a Change of Registration', () => {
   let wrapper: any
 
   const originalContact = {
-    email: 'mock@email.com',
-    confirmEmail: 'mock@email.com',
+    email: 'mock@example.com',
+    confirmEmail: 'mock@example.com',
     phone: '250-123-4567',
     extension: '123'
   }

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -19,7 +19,7 @@ const contactInfo = {
   phone: '250-123-4567'
 }
 
-describe('BusinessContactInfo for a Correction', () => {
+describe('Business Contact Info for a Correction', () => {
   let wrapper: any
 
   const originalCorrectionContact = {
@@ -28,7 +28,7 @@ describe('BusinessContactInfo for a Correction', () => {
     phone: '250-123-4567'
   }
 
-  beforeAll(async () => {
+  beforeAll(() => {
     store.state.stateModel.tombstone.filingType = 'correction'
     store.state.stateModel.businessContact = contactInfo
     store.state.stateModel.correctedFiling = {
@@ -36,6 +36,10 @@ describe('BusinessContactInfo for a Correction', () => {
         contactPoint: originalCorrectionContact
       }
     }
+  })
+
+  afterAll(() => {
+    store.state.stateModel.correctedFiling = null
   })
 
   beforeEach(async () => {
@@ -46,7 +50,7 @@ describe('BusinessContactInfo for a Correction', () => {
     wrapper.destroy()
   })
 
-  it('renders the CorrectBusinessContactInfo Component', async () => {
+  it('renders the CorrectBusinessContactInfo component', async () => {
     expect(wrapper.findComponent(BusinessContactInfo).exists()).toBe(true)
   })
 
@@ -68,7 +72,7 @@ describe('BusinessContactInfo for a Correction', () => {
   })
 })
 
-describe('BusinessContactInfo for an Alteration', () => {
+describe('Business Contact Info for an Alteration', () => {
   let wrapper: any
 
   const originalAlterationContact = {
@@ -94,7 +98,7 @@ describe('BusinessContactInfo for an Alteration', () => {
     wrapper.destroy()
   })
 
-  it('renders the BusinessContactInfo Component', async () => {
+  it('renders the BusinessContactInfo component', async () => {
     expect(wrapper.findComponent(BusinessContactInfo).exists()).toBe(true)
   })
 
@@ -126,7 +130,7 @@ describe('BusinessContactInfo for an Alteration', () => {
   })
 })
 
-describe('BusinessContactInfo for a Change of Registration', () => {
+describe('Business Contact Info for a Change of Registration', () => {
   let wrapper: any
 
   const originalContact = {
@@ -152,7 +156,7 @@ describe('BusinessContactInfo for a Change of Registration', () => {
     wrapper.destroy()
   })
 
-  it('renders the BusinessContactInfo Component', async () => {
+  it('renders the BusinessContactInfo component', async () => {
     expect(wrapper.findComponent(BusinessContactInfo).exists()).toBe(true)
   })
 

--- a/tests/unit/Change.spec.ts
+++ b/tests/unit/Change.spec.ts
@@ -201,7 +201,7 @@ describe('Change component', () => {
         data: {
           contacts: [
             {
-              email: 'mock@email.com',
+              email: 'mock@example.com',
               phone: '123-456-7890'
             }
           ]
@@ -282,7 +282,7 @@ describe('Change component', () => {
       .toBe('Series 2 Shares')
 
     // Validate Contact Info
-    expect(store.state.stateModel.businessContact.email).toBe('mock@email.com')
+    expect(store.state.stateModel.businessContact.email).toBe('mock@example.com')
     expect(store.state.stateModel.businessContact.phone).toBe('123-456-7890')
 
     expect(store.state.stateModel.currentFees.filingFees).toBe(100)

--- a/tests/unit/CompletingParty.spec.ts
+++ b/tests/unit/CompletingParty.spec.ts
@@ -118,6 +118,8 @@ describe('Completing Party', () => {
     expect(wrapper.findAll('.flex').at(0).find('.v-chip').exists()).toBe(false)
     expect(wrapper.findAll('.flex').at(1).find('span').text()).toBe('Original  Person')
 
+    // cleanup
+    store.state.stateModel.correctedFiling = null
     wrapper.destroy()
   })
 
@@ -143,6 +145,8 @@ describe('Completing Party', () => {
     expect(wrapper.findAll('.flex').at(0).find('.v-chip').exists()).toBe(true)
     expect(wrapper.findAll('.flex').at(1).find('span').text()).toBe('New  Person')
 
+    // cleanup
+    store.state.stateModel.correctedFiling = null
     wrapper.destroy()
   })
 })

--- a/tests/unit/Conversion.spec.ts
+++ b/tests/unit/Conversion.spec.ts
@@ -201,7 +201,7 @@ describe('Conversion component', () => {
         data: {
           contacts: [
             {
-              email: 'mock@email.com',
+              email: 'mock@example.com',
               phone: '123-456-7890'
             }
           ]
@@ -282,7 +282,7 @@ describe('Conversion component', () => {
       .toBe('Series 2 Shares')
 
     // Validate Contact Info
-    expect(store.state.stateModel.businessContact.email).toBe('mock@email.com')
+    expect(store.state.stateModel.businessContact.email).toBe('mock@example.com')
     expect(store.state.stateModel.businessContact.phone).toBe('123-456-7890')
 
     expect(store.state.stateModel.currentFees.filingFees).toBe(100)

--- a/tests/unit/CorrectBusinessType.spec.ts
+++ b/tests/unit/CorrectBusinessType.spec.ts
@@ -57,7 +57,7 @@ describe('ChangeBusinessType in an Alteration', () => {
   })
 
   it('displays the Business Type row for Alterations', async () => {
-    expect(wrapper.find('#business-type').exists()).toBe(true)
+    expect(wrapper.find('#change-business-type').exists()).toBe(true)
   })
 
   it('displays the title and entity type in display mode', async () => {

--- a/tests/unit/CorrectNameRequest.spec.ts
+++ b/tests/unit/CorrectNameRequest.spec.ts
@@ -69,7 +69,7 @@ describe('CorrectNameRequest', () => {
 
     wrapper.vm.nameRequestNumber = 'NR 1234567'
     wrapper.vm.applicantPhone = '123 456 7890'
-    wrapper.vm.applicantEmail = 'mock@email.com'
+    wrapper.vm.applicantEmail = 'mock@example.com'
 
     await flushPromises()
 
@@ -83,7 +83,7 @@ describe('CorrectNameRequest', () => {
     expect(wrapper.vm.isFormValid).toBe(false)
 
     wrapper.vm.nameRequestNumber = '123123NR'
-    wrapper.vm.applicantEmail = 'mock@email.com'
+    wrapper.vm.applicantEmail = 'mock@example.com'
 
     await flushPromises()
 
@@ -187,7 +187,7 @@ describe('CorrectNameRequest', () => {
             entity_type_cd: 'CR',
             applicants: {
               phoneNumber: '250 516 8257',
-              emailAddress: 'mock@email.com'
+              emailAddress: 'mock@example.com'
             }
           }
       }))
@@ -226,7 +226,7 @@ describe('CorrectNameRequest', () => {
             requestTypeCd: 'BC',
             applicants: {
               phoneNumber: '250 516 8257',
-              emailAddress: 'mock@email.com'
+              emailAddress: 'mock@example.com'
             }
           }
       }))
@@ -268,7 +268,7 @@ describe('CorrectNameRequest', () => {
             requestTypeCd: 'BC',
             applicants: {
               phoneNumber: '250 516 8257',
-              emailAddress: 'mock@email.com'
+              emailAddress: 'mock@example.com'
             }
           }
       }))
@@ -313,7 +313,7 @@ describe('CorrectNameRequest', () => {
             entity_type_cd: 'BC',
             applicants: {
               phoneNumber: '250 516 8257',
-              emailAddress: 'mock@email.com'
+              emailAddress: 'mock@example.com'
             }
           }
       }))

--- a/tests/unit/EntityInfo.spec.ts
+++ b/tests/unit/EntityInfo.spec.ts
@@ -27,7 +27,7 @@ describe('Entity Info component in a Correction as a named company', () => {
     },
     incorporationApplication: {
       contactPoint: {
-        email: 'mock@email.com',
+        email: 'mock@example.com',
         phone: '123-456-7890'
       },
       nameRequest: {
@@ -83,7 +83,7 @@ describe('Entity Info component in a Correction as a named company', () => {
   })
 
   it('renders the business contact information', () => {
-    expect(wrapper.find('#entity-business-email').text()).toBe('mock@email.com')
+    expect(wrapper.find('#entity-business-email').text()).toBe('mock@example.com')
     expect(wrapper.find('#entity-business-phone').text()).toBe('123-456-7890')
   })
 })
@@ -102,7 +102,7 @@ describe('Entity Info component in a Correction as a numbered company', () => {
     },
     incorporationApplication: {
       contactPoint: {
-        email: 'mock@email.com',
+        email: 'mock@example.com',
         phone: '321-456-7890'
       },
       nameRequest: {},
@@ -154,7 +154,7 @@ describe('Entity Info component in a Correction as a numbered company', () => {
   })
 
   it('renders the business contact information', () => {
-    expect(wrapper.find('#entity-business-email').text()).toBe('mock@email.com')
+    expect(wrapper.find('#entity-business-email').text()).toBe('mock@example.com')
     expect(wrapper.find('#entity-business-phone').text()).toBe('321-456-7890')
   })
 })

--- a/tests/unit/ListPeopleAndRoles.spec.ts
+++ b/tests/unit/ListPeopleAndRoles.spec.ts
@@ -306,6 +306,7 @@ describe('List People And Roles component for Corrections', () => {
 
   beforeAll(() => {
     store.state.stateModel.tombstone.filingType = FilingTypes.CORRECTION
+    store.state.stateModel.tombstone.entityType = 'BEN'
     store.state.resourceModel = BenefitCompanyStatementResource
     wrapperFactory = (orgPeople, propsData: any) => {
       store.state.stateModel.peopleAndRoles.orgPeople = orgPeople

--- a/tests/unit/ListPeopleAndRoles.spec.ts
+++ b/tests/unit/ListPeopleAndRoles.spec.ts
@@ -4,7 +4,6 @@ import Vuetify from 'vuetify'
 import { mount } from '@vue/test-utils'
 import ListPeopleAndRoles from '@/components/common/PeopleAndRoles/ListPeopleAndRoles.vue'
 import { getVuexStore } from '@/store/'
-import { FilingTypes } from '@/enums/'
 import { GeneralPartnershipResource } from '@/resources/Change/GeneralPartnershipResource'
 import { BenefitCompanyStatementResource } from '@/resources/Correction/BenefitCompanyStatementResource'
 
@@ -305,8 +304,9 @@ describe('List People And Roles component for Corrections', () => {
   let wrapperFactory: any
 
   beforeAll(() => {
-    store.state.stateModel.tombstone.filingType = FilingTypes.CORRECTION
+    store.state.stateModel.tombstone.filingType = 'correction'
     store.state.stateModel.tombstone.entityType = 'BEN'
+    store.state.stateModel.correctedFiling = {}
     store.state.resourceModel = BenefitCompanyStatementResource
     wrapperFactory = (orgPeople, propsData: any) => {
       store.state.stateModel.peopleAndRoles.orgPeople = orgPeople
@@ -497,7 +497,7 @@ describe('List People And Roles component for Change of Registration', () => {
   let wrapperFactory: any
 
   beforeAll(() => {
-    store.state.stateModel.tombstone.filingType = FilingTypes.CHANGE_OF_REGISTRATION
+    store.state.stateModel.tombstone.filingType = 'changeOfRegistration'
     store.state.resourceModel = GeneralPartnershipResource
     wrapperFactory = (orgPeople, propsData: any) => {
       store.state.stateModel.peopleAndRoles.orgPeople = orgPeople

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -186,7 +186,12 @@ describe('Org/Person component for a Correction filing', () => {
     store.state.stateModel.tombstone.filingType = 'correction'
     store.state.stateModel.tombstone.entityType = 'BEN'
     store.state.stateModel.tombstone.currentDate = '2020-03-30'
+    store.state.stateModel.correctedFiling = {}
     store.state.resourceModel = CorrectionBenefitCompanyResource
+  })
+
+  afterAll(() => {
+    store.state.stateModel.correctedFiling = null
   })
 
   it('Loads the component and sets data for person', async () => {

--- a/tests/unit/OrgPerson.spec.ts
+++ b/tests/unit/OrgPerson.spec.ts
@@ -184,7 +184,7 @@ function createComponent (
 describe('Org/Person component for a Correction filing', () => {
   beforeAll(() => {
     store.state.stateModel.tombstone.filingType = 'correction'
-    store.state.stateModel.nameRequest.entityType = 'BEN'
+    store.state.stateModel.tombstone.entityType = 'BEN'
     store.state.stateModel.tombstone.currentDate = '2020-03-30'
     store.state.resourceModel = CorrectionBenefitCompanyResource
   })

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -108,6 +108,7 @@ describe('People And Roles component for Correction', () => {
     const router = mockRouter.mock()
     store.state.stateModel.tombstone.entityType = 'BEN'
     store.state.stateModel.tombstone.filingType = 'correction'
+    store.state.stateModel.correctedFiling = {}
     store.state.resourceModel = BenefitCompanyStatementResource
 
     wrapperFactory = () => {
@@ -118,6 +119,10 @@ describe('People And Roles component for Correction', () => {
         vuetify
       })
     }
+  })
+
+  afterAll(() => {
+    store.state.stateModel.correctedFiling = null
   })
 
   it('shows all 3 add buttons when people list is empty', () => {
@@ -328,6 +333,8 @@ describe('People And Roles component for Correction', () => {
     // verify that popup is now displayed
     expect(wrapper.find('.confirm-dialog').exists()).toBe(true)
 
+    // cleanup
+    store.state.stateModel.correctedFiling = null
     wrapper.destroy()
   })
 })

--- a/tests/unit/YourCompany.spec.ts
+++ b/tests/unit/YourCompany.spec.ts
@@ -21,7 +21,7 @@ Vue.use(Vuetify)
 const localVue = createLocalVue()
 const vuetify = new Vuetify({})
 
-describe('YourCompany in a Correction', () => {
+describe('YourCompany in a BEN correction', () => {
   let wrapper: any
   let store: any = getVuexStore()
 
@@ -72,14 +72,14 @@ describe('YourCompany in a Correction', () => {
   })
 })
 
-describe('YourCompany in an Alteration', () => {
+describe('YourCompany in a SP alteration', () => {
   let wrapper: any
   let store: any = getVuexStore()
 
   const entitySnapshot = {
     businessInfo: {
       legalName: 'Mock Original Name',
-      legalType: 'BEN'
+      legalType: 'SP'
     }
   }
 
@@ -90,6 +90,7 @@ describe('YourCompany in an Alteration', () => {
     store.state.stateModel.tombstone.entityType = entitySnapshot.businessInfo.legalType
     store.state.stateModel.entitySnapshot = entitySnapshot
     store.state.stateModel.tombstone.filingType = 'alteration'
+    store.state.stateModel.tombstone.entityType = 'SP'
     store.state.resourceModel = BenefitCompanyResource
 
     wrapper = mount(YourCompany, { vuetify, store, localVue })
@@ -125,13 +126,13 @@ describe('YourCompany in an Alteration', () => {
     expect(wrapper.find('.company-name').text()).toBe('Mock Original Name')
 
     // Set new Name
-    store.state.stateModel.nameRequest.legalName = 'BC1234567 B.C. Ltd.'
+    store.state.stateModel.nameRequest.legalName = 'My Sole Prop'
     await Vue.nextTick()
 
     const companyInfo = wrapper.findAll('.info-text')
 
-    expect(wrapper.find('.company-name').text()).toBe('BC1234567 B.C. Ltd.')
-    expect(companyInfo.at(0).text()).toBe('BC Benefit Company')
+    expect(wrapper.find('.company-name').text()).toBe('My Sole Prop')
+    expect(companyInfo.at(0).text()).toBe('BC Sole Proprietorship')
     expect(companyInfo.at(1).text()).toBe('The name of this business will be the current Incorporation ' +
       'Number followed by "B.C. Ltd."')
   })
@@ -197,7 +198,7 @@ describe('YourCompany in an Alteration', () => {
   })
 })
 
-describe('YourCompany in an Conversion', () => {
+describe('YourCompany in a SP conversion', () => {
   let wrapper: any
   let store: any = getVuexStore()
 
@@ -238,6 +239,7 @@ describe('YourCompany in an Conversion', () => {
   beforeEach(() => {
     // Set Original business Data
     store.state.stateModel.summaryMode = false
+    store.state.stateModel.tombstone.entityType = 'SP'
     store.state.stateModel.tombstone.filingType = 'conversion'
     store.state.resourceModel = BenefitCompanyResource
     store.state.stateModel.validationFlags.componentValidate = true


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12399

*Description of changes:*

Commit 1:
- app version = 3.2.1
- renamed hasConflict to has-conflict to match classname standards
- updated ListPeopleAndRoles roles logic
- updated OrgPerson roles logic
- changed P&R instructional text to BEN corrections only
- added firm corrections to P&R subtitle
- added firm corrections to P&R add buttons
- changed P&R correction section to BEN corrections only
- add firm correction required parties rules
- updated business contact info logic
- updated business addresses logic
- updated changeable businss business type logic
- added readonly firm correction business type section
- updated name translation logic
- updated business start date logic
- updated nature of business logic
- updated ConversionNOB logic
- updated recognition date and time logic
- updated GP + SP correction resources
- added safety checks
- added "client error correction" logic to sections
- removed firm correction original filing fetch
- removed unneeded name translation, share structure and resolution fetches
- changed mock email to non-routable domain in unit tests
- added missing mocks and prop to BEN correction unit tests
- added missing mocks and prop to Firm correction unit tests
- fixed misc unit tests

Commit 2:
- renamed entity type getters for clarity
- simplified "get correction" statements
- added some safety checks and fallbacks
- added getter for "BEN IA correction" to better keep things separate
- added getter for "firm correction" to better keep things separate
- used new getters to simplify logic
- fixed firm business addresses error (in component + getters)
- fixed some unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).