### PR TITLE
12529 Edit UI: get account id from CURRENT_ACCOUNT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/resources/BreadCrumbResources.ts
+++ b/src/resources/BreadCrumbResources.ts
@@ -5,7 +5,7 @@ const store = getVuexStore()
 
 /** Returns URL param string with Account ID if present, else empty string. */
 function getParams (): string {
-  const accountId = sessionStorage.getItem('ACCOUNT_ID')
+  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
   return accountId ? `?accountid=${accountId}` : ''
 }
 

--- a/src/utils/fetchConfig.ts
+++ b/src/utils/fetchConfig.ts
@@ -14,17 +14,9 @@ export async function fetchConfig (): Promise<any> {
   const processEnvBaseUrl = process.env.BASE_URL
   const windowLocationPathname = window.location.pathname // eg, /basePath/BC1218875/correction/
   const windowLocationOrigin = window.location.origin // eg, http://localhost:8080
-  const windowLocationSearch = window.location.search // eg, ?accountid=2288
 
   if (!origin || !processEnvVueAppPath || !processEnvBaseUrl || !windowLocationPathname || !windowLocationOrigin) {
     return Promise.reject(new Error('Missing environment variables'))
-  }
-
-  // get and store account id, if present
-  const accountId = new URLSearchParams(windowLocationSearch).get('accountid')
-  if (accountId) {
-    sessionStorage.setItem('ACCOUNT_ID', accountId)
-    console.log('Set Account ID to: ' + accountId)
   }
 
   // fetch config from API

--- a/src/utils/navigate.ts
+++ b/src/utils/navigate.ts
@@ -5,7 +5,7 @@
 export function navigate (url: string): boolean {
   try {
     // get account id and set in params
-    const accountId = sessionStorage.getItem('ACCOUNT_ID')
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     if (accountId) {
       if (url.includes('?')) {
         url += `&accountid=${accountId}`

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -567,7 +567,7 @@ describe.skip('App component', () => {
     expect(dialog.exists()).toBe(false)
 
     // verify redirection
-    const baseUrl = 'myhost/business/T1234567'
+    const baseUrl = 'myhost/business/T1234567?accountid=668'
     expect(window.location.assign).toHaveBeenCalledWith(baseUrl)
   })
 })
@@ -580,6 +580,7 @@ describe('App component - other', () => {
     sessionStorage.setItem('AUTH_API_URL', 'https://auth.api.url/')
     sessionStorage.setItem('KEYCLOAK_TOKEN', KEYCLOAK_TOKEN_USER)
     sessionStorage.setItem('BUSINESS_ID', 'BC0007291')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": 668 }')
   })
 
   beforeEach(async () => {


### PR DESCRIPTION
*Issue #:* [/bcgov/entity#12529](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/12529)

*Description of changes:*
- get account id from CURRENT_ACCOUNT
  - BreadCrumbResource.ts
  - business-lookup.services.ts
  - navigate.ts
- removed ACCOUNT_ID from fetchConfig.ts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
