### PR TITLE
13059 Updated correction filing + misc fixes + cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.5.4",
+      "version": "3.5.5",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -161,7 +161,8 @@ import * as Dialogs from '@/dialogs/'
 import { AuthServices, LegalServices } from '@/services/'
 import { CommonMixin, DateMixin, FilingTemplateMixin } from '@/mixins/'
 import { FilingDataIF, ActionBindingIF, ConfirmDialogType, FlagsReviewCertifyIF, FlagsCompanyInfoIF,
-  AlterationFilingIF, ChgRegistrationFilingIF, ConversionFilingIF } from '@/interfaces/'
+  AlterationFilingIF, ChgRegistrationFilingIF, ConversionFilingIF, SpecialResolutionFilingIF }
+  from '@/interfaces/'
 import { BreadcrumbIF, CompletingPartyIF } from '@bcrs-shared-components/interfaces/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { ComponentsCompanyInfo, ComponentsReviewCertify, RouteNames } from '@/enums/'
@@ -764,7 +765,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
 
     let filingComplete: any
     try {
-      let filing: AlterationFilingIF | ChgRegistrationFilingIF | ConversionFilingIF
+      let filing: AlterationFilingIF | ChgRegistrationFilingIF | ConversionFilingIF | SpecialResolutionFilingIF
       if (this.isAlterationFiling) filing = this.buildAlterationFiling(isDraft)
       if (this.isChangeRegFiling) filing = this.buildChangeRegFiling(isDraft)
       if (this.isFirmConversionFiling) filing = this.buildConversionFiling(isDraft)

--- a/src/components/Change/ChangeSummary.vue
+++ b/src/components/Change/ChangeSummary.vue
@@ -28,7 +28,7 @@
     </template>
 
     <!-- Nature of Business -->
-    <template v-if="hasNatureOfBusinessChanged">
+    <template v-if="hasNaicsChanged">
       <v-divider class="mx-8" />
       <article id="nob-summary-section" class="section-container">
         <v-row no-gutters>
@@ -87,7 +87,7 @@ export default class ChangeSummary extends Vue {
   // Global getters
   @Getter hasBusinessNameChanged!: boolean
   @Getter getNameRequest!: NameRequestIF
-  @Getter hasNatureOfBusinessChanged!: boolean
+  @Getter hasNaicsChanged!: boolean
   @Getter getCurrentNaics!: NaicsIF
   @Getter haveOfficeAddressesChanged!: boolean
   @Getter havePeopleAndRolesChanged!: boolean

--- a/src/components/Conversion/ConversionNOB.vue
+++ b/src/components/Conversion/ConversionNOB.vue
@@ -4,7 +4,7 @@
       <v-col cols="12" sm="3" class="pr-4">
         <label :class="{'error-text': invalidSection}">Nature of Business</label>
         <v-chip
-          v-if="hasNatureOfBusinessChanged"
+          v-if="hasNaicsChanged"
           id="changed-chip"
           x-small label
           color="primary"
@@ -49,7 +49,7 @@
         <div v-if="!onEditMode" class="d-flex justify-space-between align-start">
           <span id="naics-summary">{{ naicsSummary }}</span>
 
-          <div v-if="!hasNatureOfBusinessChanged" class="mt-n2 mr-n3">
+          <div v-if="!hasNaicsChanged" class="mt-n2 mr-n3">
             <v-btn text color="primary" id="nob-change-btn" @click="onChangeClicked()">
               <v-icon small>mdi-pencil</v-icon>
               <span>{{ editLabel }}</span>
@@ -89,14 +89,14 @@ import { NaicsIF } from '@bcrs-shared-components/interfaces/'
 import { isEqual } from 'lodash'
 
 @Component({})
-export default class NatureOfBusiness extends Mixins(CommonMixin) {
+export default class ConversionNOB extends Mixins(CommonMixin) {
   /** Whether to show invalid section styling. */
   @Prop({ default: false })
   readonly invalidSection: boolean
 
   @Getter getCurrentNaics!: NaicsIF
   @Getter getSnapshotNaics!: NaicsIF
-  @Getter hasNatureOfBusinessChanged!: boolean
+  @Getter hasNaicsChanged!: boolean
 
   @Action setNaics!: ActionBindingIF
   @Action setValidComponent!: ActionBindingIF
@@ -117,7 +117,7 @@ export default class NatureOfBusiness extends Mixins(CommonMixin) {
     const desc = this.getCurrentNaics.naicsDescription
 
     if (code && desc) {
-      this.naicsText = this.hasNatureOfBusinessChanged ? this.naicsText : `${code} - ${desc}`
+      this.naicsText = this.hasNaicsChanged ? this.naicsText : `${code} - ${desc}`
       return `${code} - ${desc}`
     } else if (desc) {
       this.naicsText = desc
@@ -157,7 +157,7 @@ export default class NatureOfBusiness extends Mixins(CommonMixin) {
     const desc = this.getSnapshotNaics.naicsDescription
     this.naicsText = null
     if (code && desc) {
-      this.naicsText = this.hasNatureOfBusinessChanged ? this.naicsText : `${code} - ${desc}`
+      this.naicsText = this.hasNaicsChanged ? this.naicsText : `${code} - ${desc}`
     } else if (desc) {
       this.naicsText = desc
     }

--- a/src/components/Conversion/ConversionSummary.vue
+++ b/src/components/Conversion/ConversionSummary.vue
@@ -11,7 +11,7 @@
     </section>
 
     <!-- Nature of Business -->
-    <template v-if="hasNatureOfBusinessChanged">
+    <template v-if="hasNaicsChanged">
       <v-divider class="mx-8" />
       <article id="nob-summary-section" class="section-container">
         <v-row no-gutters>
@@ -20,7 +20,7 @@
           </v-col>
 
           <v-col cols="12" sm="8">
-            <span class="info-text">{{ naicsSummary }}</span>
+            <span class="info-text">{{naicsSummary || '(Not entered)'}}</span>
           </v-col>
         </v-row>
       </article>
@@ -69,7 +69,7 @@ import { NaicsIF } from '@bcrs-shared-components/interfaces/'
 })
 export default class ConversionSummary extends Vue {
   // Global getters
-  @Getter hasNatureOfBusinessChanged!: boolean
+  @Getter hasNaicsChanged!: boolean
   @Getter haveOfficeAddressesChanged!: boolean
   @Getter havePeopleAndRolesChanged!: boolean
   @Getter getResource!: ResourceIF
@@ -82,7 +82,7 @@ export default class ConversionSummary extends Vue {
   /** Whether to perform validation. */
   @Prop() readonly validate: boolean
 
-  /** Show naics value, description or (Not entered) */
+  /** The NAICS code, description or null. */
   get naicsSummary (): string {
     const naics = this.getCurrentNaics
     if (naics.naicsCode && naics.naicsDescription) {
@@ -90,7 +90,7 @@ export default class ConversionSummary extends Vue {
     } else if (naics.naicsDescription) {
       return naics.naicsDescription
     }
-    return '(Not entered)'
+    return null
   }
 }
 </script>

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -91,15 +91,14 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
    * Called when Save button is clicked.
    * @returns a promise (ie, this is an async method)
    */
-  private async onClickSave (): Promise<void> {
+  protected async onClickSave (): Promise<void> {
     // prevent double saving
     if (this.isBusySaving) return
     this.setIsSaving(true)
 
-    let filingComplete: any
     try {
       const filing = this.buildCorrectionFiling(true)
-      filingComplete = await LegalServices.updateFiling(this.getBusinessId, this.getFilingId, filing, true)
+      await LegalServices.updateFiling(this.getBusinessId, this.getFilingId, filing, true)
       // clear flag
       this.setHaveUnsavedChanges(false)
     } catch (error) {
@@ -115,15 +114,14 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
    * Called when Save and Resume Later button is clicked.
    * @returns a promise (ie, this is an async method)
    */
-  private async onClickSaveResume (): Promise<void> {
+  protected async onClickSaveResume (): Promise<void> {
     // prevent double saving
     if (this.isBusySaving) return
     this.setIsSavingResuming(true)
 
-    let filingComplete: any
     try {
       const filing = this.buildCorrectionFiling(true)
-      filingComplete = await LegalServices.updateFiling(this.getBusinessId, this.getFilingId, filing, true)
+      await LegalServices.updateFiling(this.getBusinessId, this.getFilingId, filing, true)
       // clear flag
       this.setHaveUnsavedChanges(false)
     } catch (error) {
@@ -140,7 +138,7 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
    * Called when File and Pay button is clicked.
    * @returns a promise (ie, this is an async method)
    */
-  private async onClickFilePay (): Promise<void> {
+  protected async onClickFilePay (): Promise<void> {
     // prevent double saving
     if (this.isBusySaving) return
     this.setIsFilingPaying(true)
@@ -195,7 +193,7 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
   }
 
   /** Called when Cancel button is clicked. */
-  private onClickCancel (): void {
+  protected onClickCancel (): void {
     this.$root.$emit('go-to-dashboard')
   }
 }

--- a/src/components/common/CertifySection.vue
+++ b/src/components/common/CertifySection.vue
@@ -34,6 +34,7 @@ import { Action, Getter } from 'vuex-class'
 import { Certify as CertifyShared } from '@bcrs-shared-components/certify/'
 import { DateMixin, SharedMixin } from '@/mixins/'
 import { ActionBindingIF, CertifyIF, ResourceIF } from '@/interfaces/'
+import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
 
 @Component({
   components: {
@@ -45,6 +46,7 @@ export default class CertifySection extends Mixins(DateMixin, SharedMixin) {
   @Getter getCurrentDate!: string
   @Getter getResource!: ResourceIF
   @Getter isRoleStaff!: boolean
+  @Getter getEntityType!: CorpTypeCd
 
   @Action setCertifyState!: ActionBindingIF
   @Action setCertifyStateValidity!: ActionBindingIF

--- a/src/components/common/EffectiveDateTime.vue
+++ b/src/components/common/EffectiveDateTime.vue
@@ -97,7 +97,7 @@ export default class EffectiveDateTime extends Mixins(DateMixin) {
   // Add element types to refs
   $refs!: {
     form: FormIF,
-    datePickerRef: DatePickerShared,
+    datePickerRef: any, // should be DatePickerShared but public methods can't be found
     hourSelector: FormFieldType, // used in unit tests
     minuteSelector: FormFieldType // used in unit tests
   }

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -242,6 +242,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin, SharedMixin)
   @Getter isConflictingLegalType!: boolean
   @Getter isEntityTypeBC!: boolean
   @Getter isEntityTypeFirm!: boolean
+  @Getter getEntityType!: CorpTypeCd
 
   @Action setEntityType!: ActionBindingIF
 

--- a/src/components/common/YourCompany/CompanyName/CorrectNameRequest.vue
+++ b/src/components/common/YourCompany/CompanyName/CorrectNameRequest.vue
@@ -67,6 +67,7 @@ import { ConfirmDialog as ConfirmDialogShared } from '@bcrs-shared-components/co
 import { CommonMixin, SharedMixin, NameRequestMixin } from '@/mixins/'
 import { ActionBindingIF, ConfirmDialogType, NameRequestIF, NrCorrectionIF, NrResponseIF } from '@/interfaces/'
 import { CorrectionTypes } from '@/enums/'
+import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
 
 @Component({
   components: {
@@ -91,6 +92,7 @@ export default class CorrectNameRequest extends Mixins(CommonMixin, SharedMixin,
   @Action setNameRequest!: ActionBindingIF
 
   @Getter getNameRequest!: NameRequestIF
+  @Getter getEntityType!: CorpTypeCd
 
   // V-model properties
   protected formValid = false

--- a/src/components/common/YourCompany/NatureOfBusiness.vue
+++ b/src/components/common/YourCompany/NatureOfBusiness.vue
@@ -3,7 +3,7 @@
     :showErrors="invalidSection"
     :naics="getCurrentNaics"
     :NaicsServices="NaicsServices"
-    :hasNaicsChanges="hasNatureOfBusinessChanged"
+    :hasNaicsChanges="hasNaicsChanged"
     @valid="onValidChanged($event)"
     @undoNaics="setNaics(getSnapshotNaics)"
     @setNaics="setNaics($event)"
@@ -32,7 +32,7 @@ export default class NatureOfBusiness extends Vue {
 
   @Getter getCurrentNaics!: NaicsIF
   @Getter getSnapshotNaics!: NaicsIF
-  @Getter hasNatureOfBusinessChanged!: boolean
+  @Getter hasNaicsChanged!: boolean
 
   @Action setNaics!: ActionBindingIF
   @Action setValidComponent!: ActionBindingIF

--- a/src/components/common/YourCompany/OfficeAddresses.vue
+++ b/src/components/common/YourCompany/OfficeAddresses.vue
@@ -106,7 +106,7 @@
       <!-- Records office (BEN only) -->
       <v-row v-if="isEntityTypeBEN" id="summary-records-address" class="mt-4 mx-0" no-gutters>
         <v-col cols="3" class="pr-2">
-          <label class>Records Office</label>
+          <label :class="{'error-text': invalidSection}">Records Office</label>
         </v-col>
 
         <!-- Records mailing address -->

--- a/src/components/common/YourCompany/SummaryDefineCompany.vue
+++ b/src/components/common/YourCompany/SummaryDefineCompany.vue
@@ -75,6 +75,7 @@ export default class SummaryDefineCompany extends Mixins(CommonMixin) {
   @Getter isPremiumAccount!: boolean
   @Getter getNameTranslations!: Array<string>
   @Getter isDefineCompanyStepValid!: boolean
+  @Getter getEntityType!: CorpTypeCd
 
   @Prop({ default: false })
   readonly isSummary: boolean

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -46,7 +46,7 @@
 
             <!-- Name Request Info -->
             <template v-if="hasNewNr && (isAlterationFiling || isChangeRegFiling)">
-              <div class="company-name mt-2">{{ getNameRequest.nrNumber }}</div>
+              <div class="company-name mt-2">{{getNameRequestNumber || 'Unknown'}}</div>
               <div class="company-info mt-4">
                 <span class="subtitle">Business Type: </span>
                 <span :class="{ 'has-conflict': isConflictingLegalType}"
@@ -74,7 +74,7 @@
               </div>
               <div class="company-info">
                 <span class="subtitle">Expiry Date: </span>
-                <span class="info-text">{{expiryDate}}</span>
+                <span class="info-text">{{expiryDate || 'Unknown'}}</span>
               </div>
               <div class="company-info">
                 <span class="subtitle">Status: </span>
@@ -218,7 +218,7 @@
           </v-col>
 
           <v-col cols="9">
-            <span class="info-text mr-1">{{ recognitionDateTime }}</span>
+            <span class="info-text mr-1">{{recognitionDateTime || 'Unknown'}}</span>
             <v-tooltip top
                        content-class="top-tooltip"
                        transition="fade-transition"
@@ -264,7 +264,7 @@
         </v-col>
 
         <v-col cols="9">
-          <div class="info-text">{{ recognitionDateTime }}</div>
+          <div class="info-text">{{recognitionDateTime || 'Unknown'}}</div>
         </v-col>
       </v-row>
     </div>
@@ -301,8 +301,8 @@
 <script lang="ts">
 import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
-import { ActionBindingIF, EntitySnapshotIF, FlagsCompanyInfoIF, NameRequestApplicantIF, NameRequestIF,
-  ResourceIF } from '@/interfaces/'
+import { ActionBindingIF, EntitySnapshotIF, FlagsCompanyInfoIF, NameRequestApplicantIF, NameRequestIF }
+  from '@/interfaces/'
 import { ContactPointIF } from '@bcrs-shared-components/interfaces/'
 import { BusinessContactInfo, ChangeBusinessType, FolioInformation, CorrectNameTranslation, CorrectNameOptions,
   NatureOfBusiness, OfficeAddresses } from './'
@@ -345,6 +345,7 @@ export default class YourCompany extends Mixins(
   @Getter isEntityTypeFirm!: boolean
   @Getter isBenIaCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
+  @Getter getEntityType!: CorpTypeCd
 
   // Alteration flag getters
   @Getter hasBusinessNameChanged!: boolean
@@ -424,8 +425,13 @@ export default class YourCompany extends Mixins(
 
   /** Name Request expiry */
   get expiryDate (): string {
-    const date = new Date(this.getNameRequest.expiry)
-    return this.dateToPacificDateTime(date)
+    const expiry = this.getNameRequest?.expiry
+    if (expiry) {
+      // FUTURE: use date mixin method to create date
+      const date = new Date(expiry)
+      return this.dateToPacificDateTime(date)
+    }
+    return null
   }
 
   /** Name Request phone number */
@@ -450,7 +456,7 @@ export default class YourCompany extends Mixins(
         return this.apiToPacificDateTime(this.getBusinessFoundingDate)
       }
     }
-    return 'Unknown'
+    return null
   }
 
   /** Whether a new business legal name was entered.. */

--- a/src/dialogs/FileAndPayInvalidNameRequestDialog.vue
+++ b/src/dialogs/FileAndPayInvalidNameRequestDialog.vue
@@ -7,8 +7,8 @@
         <div class="genErr mb-4">
           <p>
             <b>
-              The Name Request {{ getNameRequestNumber }} and the Incorporation Application for
-              {{ getNameRequestLegalName }} are no longer valid.
+              The Name Request {{getNameRequestNumber || 'Unknown'}} and the Incorporation Application for
+              {{getNameRequestLegalName || 'Unknown'}} are no longer valid.
             </b>
           </p>
           <p>If you still wish to incorporate a Benefit Company, please contact Registry Staff as soon as possible.</p>

--- a/src/interfaces/filing-interfaces/chg-registration-interfaces.ts
+++ b/src/interfaces/filing-interfaces/chg-registration-interfaces.ts
@@ -8,13 +8,12 @@ export interface ChgRegistrationIF {
   business: {
     identifier: string
     naics?: NaicsIF
-    natureOfBusiness?: string
   }
-  offices?: AddressesIF
+  courtOrder?: string
   contactPoint: ContactPointIF
   nameRequest?: NameRequestIF
+  offices?: AddressesIF
   parties?: Array<OrgPersonIF>
-  courtOrder?: string
 }
 
 /** Interface for data object UI sends to API. */

--- a/src/interfaces/filing-interfaces/conversion-interfaces.ts
+++ b/src/interfaces/filing-interfaces/conversion-interfaces.ts
@@ -1,26 +1,20 @@
-import { AddressesIF, FilingBusinessIF, FilingHeaderIF, NameRequestIF, OrgPersonIF, ShareStructureIF }
-  from '@/interfaces/'
-import { ContactPointIF } from '@bcrs-shared-components/interfaces/'
+import { AddressesIF, FilingBusinessIF, FilingHeaderIF, NameRequestIF, OrgPersonIF } from '@/interfaces/'
+import { ContactPointIF, NaicsIF } from '@bcrs-shared-components/interfaces/'
 
 //
 // Ref: https://github.com/bcgov/business-schemas/blob/main/src/registry_schemas/schemas/conversion.json
 //
 interface ConversionIF {
   business: {
-    natureOfBusiness?: string
-    naics?: {
-      naicsCode: string
-      naicsDescription: string
-    }
     identifier: string
+    naics?: NaicsIF
   }
-  startDate?: string
+  contactPoint: ContactPointIF
+  courtOrder?: string
   nameRequest?: NameRequestIF
   offices: AddressesIF
   parties: Array<OrgPersonIF>
-  shareStructure?: ShareStructureIF
-  contactPoint: ContactPointIF
-  courtOrder?: string
+  startDate?: string // YYYY-MM-DD
 }
 
 /** Interface for data object UI sends to API. */

--- a/src/interfaces/filing-interfaces/index.ts
+++ b/src/interfaces/filing-interfaces/index.ts
@@ -7,6 +7,7 @@ export * from './filing-data-interface'
 export * from './filing-header-interface'
 export * from './incorporation-interfaces'
 export * from './registration-filing-interface'
+export * from './special-resolution-filing-interface'
 
 // Alias for Shared Components that import IncorporationAddressIf
 export { AddressesIF as IncorporationAddressIf }

--- a/src/interfaces/filing-interfaces/registration-filing-interface.ts
+++ b/src/interfaces/filing-interfaces/registration-filing-interface.ts
@@ -9,13 +9,12 @@ export interface RegistrationIF {
   business: {
     identifier: string
     naics?: NaicsIF
-    natureOfBusiness?: string
   }
   businessType?: BusinessTypes // SP only
   contactPoint: ContactPointIF
+  courtOrder?: string
   nameRequest: NameRequestIF
   offices: AddressesIF
   parties: Array<OrgPersonIF>
-  courtOrder?: string
-  startDate?: string
+  startDate?: string // YYYY-MM-DD
 }

--- a/src/interfaces/filing-interfaces/special-resolution-filing-interface.ts
+++ b/src/interfaces/filing-interfaces/special-resolution-filing-interface.ts
@@ -5,6 +5,6 @@ import { SpecialResolutionIF, FilingBusinessIF, FilingHeaderIF, AlterationIF } f
 export interface SpecialResolutionFilingIF {
   header: FilingHeaderIF
   business: FilingBusinessIF
-  alteration: AlterationIF
+  alteration?: AlterationIF
   specialResolution?: SpecialResolutionIF
 }

--- a/src/interfaces/store-interfaces/state-interfaces/correction-information-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/correction-information-interface.ts
@@ -16,12 +16,13 @@ export interface CorrectionInformationIF {
   correctedFilingId: number
   correctedFilingDate: string // API format
   correctedFilingType: FilingTypes
-  type?: CorrectionErrorTypes
+  type: CorrectionErrorTypes
 
   //
   // optional objects with new correction data:
   //
   business?: {
+    identifier: string
     naicsCode: string
     naicsDescription: string
   }
@@ -38,5 +39,5 @@ export interface CorrectionInformationIF {
     shareClasses: ShareClassIF[]
     resolutionDates?: string[]
   }
-  startDate?: string // API format
+  startDate?: string // YYYY-MM-DD
 }

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -9,14 +9,10 @@ import { ConfirmDialogType } from '@/interfaces/'
  */
 @Component({})
 export default class CommonMixin extends Vue {
-  @Getter getEntityType!: CorpTypeCd
   @Getter isAlterationFiling!: boolean
   @Getter isChangeRegFiling!: boolean
   @Getter isFirmConversionFiling!: boolean
   @Getter isCorrectionFiling!: boolean
-  @Getter isCorrectedIncorporationApplication!: boolean
-  @Getter isCorrectedRegistration!: boolean
-  @Getter isCorrectedChangeReg!: boolean
   @Getter isSpecialResolutionFiling!: boolean
 
   /** True if Jest is running the code. */

--- a/src/services/legal-services.ts
+++ b/src/services/legal-services.ts
@@ -1,6 +1,7 @@
 import { axios } from '@/utils/'
 import { AddressesIF, AlterationFilingIF, BusinessInformationIF, ChgRegistrationFilingIF, ConversionFilingIF,
-  CorrectionFilingIF, NameTranslationIF, OrgPersonIF, ResolutionsIF, ShareStructureIF } from '@/interfaces/'
+  CorrectionFilingIF, NameTranslationIF, OrgPersonIF, ResolutionsIF, ShareStructureIF, SpecialResolutionFilingIF }
+  from '@/interfaces/'
 import { RoleTypes } from '@/enums'
 
 /**
@@ -51,7 +52,8 @@ export default class LegalServices {
   static async updateFiling (
     businessId: string,
     filingId: number,
-    filing: CorrectionFilingIF | AlterationFilingIF | ChgRegistrationFilingIF | ConversionFilingIF,
+    // eslint-disable-next-line max-len
+    filing: CorrectionFilingIF | AlterationFilingIF | ChgRegistrationFilingIF | ConversionFilingIF | SpecialResolutionFilingIF,
     isDraft: boolean
   ): Promise<any> {
     // put updated filing to filings endpoint
@@ -81,7 +83,7 @@ export default class LegalServices {
    */
   static async createFiling (
     businessId: string,
-    filing: AlterationFilingIF | ChgRegistrationFilingIF | ConversionFilingIF,
+    filing: AlterationFilingIF | ChgRegistrationFilingIF | ConversionFilingIF | SpecialResolutionFilingIF,
     isDraft: boolean
   ): Promise<any> {
     // put updated filing to filings endpoint

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -1,5 +1,5 @@
-import { AccountTypes, ActionTypes, CorrectionErrorTypes, FilingCodes, FilingNames, FilingTypes }
-  from '@/enums/'
+import { AccountTypes, ActionTypes, CorrectionErrorTypes, FilingCodes, FilingNames, FilingTypes,
+  PartyTypes } from '@/enums/'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
 import { AddressesIF, OrgPersonIF, ShareClassIF, NameRequestIF, BusinessInformationIF, CertifyIF,
   NameTranslationIF, FilingDataIF, StateIF, EffectiveDateTimeIF, FlagsReviewCertifyIF, FlagsCompanyInfoIF,
@@ -7,7 +7,6 @@ import { AddressesIF, OrgPersonIF, ShareClassIF, NameRequestIF, BusinessInformat
   from '@/interfaces/'
 import { CompletingPartyIF, ContactPointIF, NaicsIF, StaffPaymentIF }
   from '@bcrs-shared-components/interfaces/'
-import { isEqual } from 'lodash'
 import { isSame } from '@/utils/'
 
 /** Whether the user has "staff" keycloak role. */
@@ -171,6 +170,11 @@ export const getCorrectionErrorType = (state: StateIF): CorrectionErrorTypes => 
   return getCorrectionInformation(state).type
 }
 
+/** The correction (business) start date. */
+export const getCorrectionStartDate = (state: StateIF): string => {
+  return getCorrectionInformation(state).startDate
+}
+
 /** True if the correction is due to a client error. */
 export const isClientErrorCorrection = (state: StateIF): boolean => {
   return (getCorrectionErrorType(state) === CorrectionErrorTypes.CLIENT)
@@ -274,12 +278,12 @@ export const getNameRequest = (state: StateIF): NameRequestIF => {
 
 /** The Name Request Number. */
 export const getNameRequestNumber = (state: StateIF): string => {
-  return getNameRequest(state).nrNumber
+  return getNameRequest(state)?.nrNumber
 }
 
 /** The Name Request Legal Name (approved name). */
 export const getNameRequestLegalName = (state: StateIF): string => {
-  return getNameRequest(state).legalName
+  return getNameRequest(state)?.legalName
 }
 
 /** The name translations. */
@@ -383,7 +387,7 @@ export const hasCorrectionDataChanged = (state: StateIF): boolean => {
   if (isFirmCorrectionFiling(state)) {
     return (
       hasBusinessNameChanged(state) ||
-      hasNatureOfBusinessChanged(state) ||
+      hasNaicsChanged(state) ||
       haveOfficeAddressesChanged(state) ||
       havePeopleAndRolesChanged(state)
     )
@@ -440,7 +444,7 @@ export const hasSpecialResolutionDataChanged = (state: StateIF): boolean => {
 export const hasChangeDataChanged = (state: StateIF): boolean => {
   return (
     hasBusinessNameChanged(state) ||
-    hasNatureOfBusinessChanged(state) ||
+    hasNaicsChanged(state) ||
     haveOfficeAddressesChanged(state) ||
     havePeopleAndRolesChanged(state)
   )
@@ -457,7 +461,7 @@ export const hasChangeDataChanged = (state: StateIF): boolean => {
  */
 export const hasConversionDataChanged = (state: StateIF): boolean => {
   return (
-    hasNatureOfBusinessChanged(state) ||
+    hasNaicsChanged(state) ||
     haveOfficeAddressesChanged(state) ||
     havePeopleAndRolesChanged(state)
   )
@@ -695,7 +699,17 @@ export const hasRecDeliveryChanged = (state: StateIF): boolean => {
 
 /** True if any people/roles have changed. */
 export const havePeopleAndRolesChanged = (state: StateIF): boolean => {
-  const currentOrgPersons = getPeopleAndRoles(state)
+  const currentOrgPersons = getPeopleAndRoles(state)?.map(op => {
+    const isOrg = (op.officer.partyType === PartyTypes.ORGANIZATION)
+
+    // add fields that are not in the snapshot
+    return {
+      deliveryAddress: { deliveryInstructions: null, streetAddressAdditional: null, ...op.deliveryAddress },
+      mailingAddress: { deliveryInstructions: null, streetAddressAdditional: null, ...op.mailingAddress },
+      officer: isOrg ? { identifier: null, taxId: null, ...op.officer } : { ...op.officer },
+      roles: [ ...op.roles ]
+    }
+  })
   const originalOrgPersons = getEntitySnapshot(state)?.orgPersons
 
   return !isSame(currentOrgPersons, originalOrgPersons, ['actions', 'confirmNameChange'])
@@ -739,15 +753,28 @@ export const hasShareStructureChanged = (state: StateIF): boolean => {
   currentShareClasses = currentShareClasses && removeNullProps(currentShareClasses)
   originalShareClasses = originalShareClasses && removeNullProps(originalShareClasses)
 
-  return !isEqual(originalShareClasses, currentShareClasses)
+  return !isSame(originalShareClasses, currentShareClasses)
 }
 
-/** Whether nature of business data has changed. */
-export const hasNatureOfBusinessChanged = (state: StateIF): boolean => {
-  const currentNatureOfBusiness = getBusinessInformation(state)?.naicsCode
-  const originalNatureOfBusiness = getEntitySnapshot(state)?.businessInfo?.naicsCode
+/** Whether NAICS data has changed. */
+export const hasNaicsChanged = (state: StateIF): boolean => {
+  const currentNaicsCode = getBusinessInformation(state)?.naicsCode
+  const originalNaicsCode = getEntitySnapshot(state)?.businessInfo?.naicsCode
 
-  return (currentNatureOfBusiness !== originalNatureOfBusiness)
+  // first try to compare codes
+  if (currentNaicsCode || originalNaicsCode) {
+    return (currentNaicsCode !== originalNaicsCode)
+  }
+
+  const currentNaicsDescription = getBusinessInformation(state)?.naicsDescription
+  const originalNaicsDescription = getEntitySnapshot(state)?.businessInfo?.naicsDescription
+
+  // then try to compare descriptions
+  if (currentNaicsDescription || originalNaicsDescription) {
+    return (currentNaicsDescription !== originalNaicsDescription)
+  }
+
+  return false
 }
 
 /** Whether the provisions are removed. */
@@ -828,7 +855,7 @@ export const showFeeSummary = (state: StateIF): boolean => {
     (isFirmConversionFiling(state) && hasConversionDataChanged(state)) ||
     (isSpecialResolutionFiling(state) && hasSpecialResolutionDataChanged(state))
   )
-  return (haveFilingChange && !isEqual(getFilingData(state), defaultFilingData))
+  return (haveFilingChange && !isSame(getFilingData(state), defaultFilingData))
 }
 
 /** The current fees. */

--- a/src/views/Correction/BenCorrection.vue
+++ b/src/views/Correction/BenCorrection.vue
@@ -4,6 +4,7 @@
       <h1>{{ entityTitle }}</h1>
     </header>
 
+    <!-- *** FUTURE: delete this when BEN corrections are not IA-centric -->
     <section id="original-filing-date" class="mt-6">
       <p>
         <span id="original-filing-date-label">Original Filing Date:</span>

--- a/tests/unit/ConversionNOB.spec.ts
+++ b/tests/unit/ConversionNOB.spec.ts
@@ -97,7 +97,7 @@ describe('ConversionNatureOfBusiness without update', () => {
     expect(wrapper.vm.$data.onEditMode).toBeFalsy()
     expect(wrapper.find('#naics-summary').exists()).toBeTruthy()
     expect(wrapper.find('#naics-summary').text()).toBe('100000 - food')
-    expect(wrapper.vm.$data.hasNatureOfBusinessChanged).toBeFalsy()
+    expect(wrapper.vm.$data.hasNaicsChanged).toBeFalsy()
   })
 
   it('simulates error for 0 characters length', async () => {

--- a/tests/unit/filing-template-mixin.spec.ts
+++ b/tests/unit/filing-template-mixin.spec.ts
@@ -24,9 +24,10 @@ describe('Change of Registration Filing', () => {
     wrapper.destroy()
   })
 
-  it('correctly builds a registration filing', () => {
+  it('correctly builds a change of registration filing', () => {
     store.state.stateModel.tombstone.businessId = 'BC1234567'
     store.state.stateModel.tombstone.filingType = 'changeOfRegistration'
+    store.state.stateModel.tombstone.entityType = 'SP'
     store.state.stateModel.completingParty = {
       firstName: 'First',
       lastName: 'Last',
@@ -43,7 +44,7 @@ describe('Change of Registration Filing', () => {
     store.state.stateModel.entitySnapshot = {
       businessInfo: {
         foundingDate: 'Jan 01, 2000',
-        legalType: '',
+        legalType: 'SP',
         identifier: 'BC1234567',
         legalName: 'SomeMockBusiness',
         naicsCode: '',
@@ -106,7 +107,7 @@ describe('Change of Registration Filing', () => {
           foundingDate: 'Jan 01, 2000',
           identifier: 'BC1234567',
           legalName: 'SomeMockBusiness',
-          legalType: ''
+          legalType: 'SP'
         },
         changeOfRegistration: {
           business: {
@@ -114,8 +115,7 @@ describe('Change of Registration Filing', () => {
             naics: {
               naicsCode: '123456',
               naicsDescription: 'Mock Description'
-            },
-            natureOfBusiness: ''
+            }
           },
           contactPoint: {
             email: '',

--- a/tests/unit/state-getters.spec.ts
+++ b/tests/unit/state-getters.spec.ts
@@ -301,7 +301,14 @@ describe('BEN IA correction getters', () => {
     expect(vm.haveOfficeAddressesChanged).toBe(false)
 
     // verify that people and roles changes are detected
-    store.state.stateModel.peopleAndRoles.orgPeople = [{}]
+    store.state.stateModel.peopleAndRoles.orgPeople = [
+      {
+        deliveryAddress: {},
+        mailingAddress: {},
+        officer: {},
+        roles: []
+      }
+    ]
     expect(vm.havePeopleAndRolesChanged).toBe(true)
     store.state.stateModel.peopleAndRoles.orgPeople = []
     expect(vm.havePeopleAndRolesChanged).toBe(false)
@@ -409,7 +416,14 @@ describe('SP/GP correction getters', () => {
     expect(vm.haveOfficeAddressesChanged).toBe(false)
 
     // verify that people and roles changes are detected
-    store.state.stateModel.peopleAndRoles.orgPeople = [{}]
+    store.state.stateModel.peopleAndRoles.orgPeople = [
+      {
+        deliveryAddress: {},
+        mailingAddress: {},
+        officer: {},
+        roles: []
+      }
+    ]
     expect(vm.havePeopleAndRolesChanged).toBe(true)
     store.state.stateModel.peopleAndRoles.orgPeople = []
     expect(vm.havePeopleAndRolesChanged).toBe(false)
@@ -420,14 +434,14 @@ describe('SP/GP correction getters', () => {
     store.state.stateModel.shareStructureStep.shareClasses = []
     expect(vm.hasShareStructureChanged).toBe(false)
 
-    // verify that the nature of business are detected
+    // verify that the nature of business changes are detected
     store.state.stateModel.businessInformation = {
       naicsCode: '',
       naicsDescription: 'NAICS description 2'
     }
-    expect(vm.hasNatureOfBusinessChanged).toBe(true)
+    expect(vm.hasNaicsChanged).toBe(true)
     store.state.stateModel.businessInformation = naics
-    expect(vm.hasNatureOfBusinessChanged).toBe(false)
+    expect(vm.hasNaicsChanged).toBe(false)
 
     // finally, this getter should be false
     expect(vm.hasCorrectionDataChanged).toBe(false)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13059

*Description of changes:*

- renamed hasNatureOfBusinessChanged to hasNaicsChanged
- add error bar to Records Office
- some NR cleanup
- some interface cleanup
- added undefined fallback to naicsCode in draft filings
- removed unnecessary destructuring in draft filings
- removed obsolete natureOfBusiness
- saved NR data in Conversion draft filings
- cloned entity snapshot to prevent object overlaps
- store business info when parsing Change and Conversion filings
- save and don't restore correction Completing Party
- added some filing template helpers
- added conditional chaining to some getters (and handling in components)
- fixed havePeopleAndRolesChanged
- fixed hasNatureOfBusinsesChanged
- fixed some typings
- fixed unit tests
- fixed some schema errors
- misc cleanup
- app version = 3.5.5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).