### PR TITLE
13192 Clean up BEN IA correction to no longer save corrected IA object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.5.24",
+  "version": "3.5.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.5.24",
+      "version": "3.5.25",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.5.24",
+  "version": "3.5.25",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Detail.vue
+++ b/src/components/common/Detail.vue
@@ -55,7 +55,7 @@ export default class Detail extends Mixins(FilingTemplateMixin) {
   protected comment: string = null
 
   get maxLength (): number {
-    // = (max size in db) - (default comment length - (Carriage Return)
+    // = (max size in db) - (default comment length) - (Carriage Return)
     return (2000 - this.defaultCorrectionDetailComment.length - 1)
   }
 

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -126,7 +126,7 @@
 
           <!-- Roles -->
           <v-col cols="12" sm="2" :class="{ 'removed': wasRemoved(orgPerson)}">
-            <template v-if="isBenIaCorrectionFiling">
+            <template v-if="isBenCorrectionFiling">
               <!-- Warning if orgPerson has no roles -->
               <div v-if="orgPerson.roles.length > 0">
                 <v-col v-for="(role, index) in orgPerson.roles" :key="index" class="col-roles">
@@ -315,7 +315,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
 
   // Store getter
   @Getter getOrgPeople!: OrgPersonIF[]
-  @Getter isBenIaCorrectionFiling!: boolean
+  @Getter isBenCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
 
   /** V-model for dropdown menus. */
@@ -327,7 +327,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
       'Name',
       'Mailing Address',
       'Delivery Address',
-      this.isBenIaCorrectionFiling ? 'Roles' : ''
+      this.isBenCorrectionFiling ? 'Roles' : ''
     ]
   }
 
@@ -361,7 +361,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
     if (this.isFirmConversionFiling) {
       return true
     }
-    if (this.isBenIaCorrectionFiling) {
+    if (this.isBenCorrectionFiling) {
       return true
     }
     if (this.isFirmCorrectionFiling) {

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -237,7 +237,7 @@
               </article>
 
               <!-- Roles (BEN corrections only) -->
-              <article v-if="isBenIaCorrectionFiling" class="roles mt-6">
+              <article v-if="isBenCorrectionFiling" class="roles mt-6">
                 <label class="sub-header">Roles</label>
                 <v-row class="roles-row mt-4">
                   <v-col cols="4" class="mt-0" v-if="isPerson">
@@ -376,7 +376,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
   // Global getter
   @Getter getCurrentDate!: string
   @Getter getResource!: ResourceIF
-  @Getter isBenIaCorrectionFiling!: boolean
+  @Getter isBenCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
   @Getter isEntityTypeFirm!: boolean
   @Getter isRoleStaff!: boolean
@@ -516,7 +516,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
     if (this.isFirmConversionFiling) {
       return true
     }
-    if (this.isBenIaCorrectionFiling) {
+    if (this.isBenCorrectionFiling) {
       return true
     }
     if (this.isFirmCorrectionFiling) {
@@ -545,8 +545,8 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
       // can add proprietor or partner
       return (this.isNew && (this.isProprietor || this.isPartner))
     }
-    if (this.isBenIaCorrectionFiling) {
-      // BEN IA corrections don't use this component
+    if (this.isBenCorrectionFiling) {
+      // BEN corrections don't use this component
       return false
     }
     if (this.isFirmCorrectionFiling) {
@@ -698,7 +698,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
       }
       person.deliveryAddress = { ...this.inProgressDeliveryAddress }
     }
-    if (this.isBenIaCorrectionFiling) {
+    if (this.isBenCorrectionFiling) {
       person.roles = this.setPersonRoles(this.orgPerson)
     } else {
       person.roles = this.orgPerson.roles

--- a/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
@@ -8,7 +8,7 @@
       </div>
 
       <!-- Instructional people and roles text (BEN corrections only)-->
-      <article v-if="isBenIaCorrectionFiling" class="section-container">
+      <article v-if="isBenCorrectionFiling" class="section-container">
         This application must include the following:
         <ul>
           <li>
@@ -20,7 +20,7 @@
       </article>
 
       <!-- Correction section (BEN corrections only) -->
-      <article v-if="isBenIaCorrectionFiling" class="section-container">
+      <article v-if="isBenCorrectionFiling" class="section-container">
         <v-btn
           id="btn-add-person"
           outlined
@@ -172,7 +172,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
   @Getter getComponentValidate!: boolean
   @Getter hasMinimumProprietor!: boolean
   @Getter hasMinimumPartners!: boolean
-  @Getter isBenIaCorrectionFiling!: boolean
+  @Getter isBenCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
   @Getter isEntityTypeBEN!: boolean
   @Getter isEntityTypeSP!: boolean

--- a/src/components/common/YourCompany/OfficeAddresses.vue
+++ b/src/components/common/YourCompany/OfficeAddresses.vue
@@ -460,7 +460,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   @Getter hasRecDeliveryChanged!: boolean
   @Getter isEntityTypeBEN!: boolean
   @Getter isEntityTypeFirm!: boolean
-  @Getter isBenIaCorrectionFiling!: boolean
+  @Getter isBenCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
 
   // Global actions
@@ -542,7 +542,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * Sets local address data and "inherit" flags from store.
    */
   private setLocalProperties (): void {
-    if (this.isBenIaCorrectionFiling || this.isAlterationFiling) {
+    if (this.isBenCorrectionFiling || this.isAlterationFiling) {
       // assign registered office addresses (may be {})
       this.mailingAddress = { ...this.getOfficeAddresses?.registeredOffice?.mailingAddress }
       this.deliveryAddress = { ...this.getOfficeAddresses?.registeredOffice?.deliveryAddress }
@@ -746,8 +746,8 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * Sets updated office addresses in store.
    */
   private storeAddresses (): void {
-    if (this.isBenIaCorrectionFiling) {
-      // at the moment, only BEN IA corrections are supported
+    if (this.isBenCorrectionFiling) {
+      // at the moment, only BEN corrections are supported
       this.setOfficeAddresses({
         registeredOffice: {
           deliveryAddress: this.deliveryAddress,
@@ -760,16 +760,14 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
       })
     }
 
-    if (this.isEntityTypeFirm) {
-      if (this.isFirmChangeFiling || this.isFirmConversionFiling || this.isCorrectionFiling) {
+    if (this.isFirmChangeFiling || this.isFirmConversionFiling || this.isFirmCorrectionFiling) {
       // at the moment, only firm changes, conversions and corrections are supported
-        this.setOfficeAddresses({
-          businessOffice: {
-            deliveryAddress: this.deliveryAddress,
-            mailingAddress: this.mailingAddress
-          }
-        })
-      }
+      this.setOfficeAddresses({
+        businessOffice: {
+          deliveryAddress: this.deliveryAddress,
+          mailingAddress: this.mailingAddress
+        }
+      })
     }
   }
 
@@ -836,7 +834,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * Also called when we know what kind of correction this is.
    */
   @Watch('getOfficeAddresses', { deep: true, immediate: true })
-  @Watch('isBenIaCorrectionFiling')
+  @Watch('isBenCorrectionFiling')
   @Watch('isFirmCorrectionFiling')
   private updateAddresses (): void {
     // set local properties from store

--- a/src/components/common/YourCompany/StartDate.vue
+++ b/src/components/common/YourCompany/StartDate.vue
@@ -113,12 +113,10 @@ import { ActionBindingIF } from '@/interfaces'
 })
 export default class StartDate extends Mixins(CommonMixin, DateMixin) {
   // Global getters
-  @Getter isBenIaCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
   @Getter hasBusinessStartDateChanged!: boolean
   @Getter getCorrectionStartDate!: string
   @Getter getBusinessFoundingDate!: string // actually date-time
-  @Getter getCurrentDate!: string
   @Getter getCurrentJsDate!: Date
 
   // Global setter

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -199,7 +199,7 @@
     </div>
 
     <!-- Name Translation(s) (alterations and BEN corrections only) -->
-    <div v-if="isAlterationFiling || isBenIaCorrectionFiling"
+    <div v-if="isAlterationFiling || isBenCorrectionFiling"
       id="name-translate-section"
       class="section-container"
       :class="{'invalid-section': invalidTranslationSection}"
@@ -258,7 +258,7 @@
     </template>
 
     <!-- Recognition Date and Time (alterations and BEN corrections only) -->
-    <template v-if="isAlterationFiling || isBenIaCorrectionFiling">
+    <template v-if="isAlterationFiling || isBenCorrectionFiling">
       <v-divider class="mx-4 my-1" />
 
       <div class="section-container">
@@ -351,7 +351,7 @@ export default class YourCompany extends Mixins(
   @Getter getBusinessContact!: ContactPointIF
   @Getter isEntityTypeFirm!: boolean
   @Getter isEntityTypeCP!: boolean
-  @Getter isBenIaCorrectionFiling!: boolean
+  @Getter isBenCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
   @Getter getEntityType!: CorpTypeCd
   @Getter getAssociationType!: AssociationTypes
@@ -462,7 +462,7 @@ export default class YourCompany extends Mixins(
 
   /** The recognition date or business start date string. */
   get recognitionDateTime (): string {
-    if (this.isBenIaCorrectionFiling) {
+    if (this.isBenCorrectionFiling) {
       if (this.getBusinessFoundingDate) {
         return this.apiToPacificDateTime(this.getBusinessFoundingDate)
       } else if (this.getCorrectedFilingDate) {

--- a/src/interfaces/filing-interfaces/correction-filing-interface.ts
+++ b/src/interfaces/filing-interfaces/correction-filing-interface.ts
@@ -1,5 +1,4 @@
-import { ChgRegistrationIF, CorrectionInformationIF, FilingBusinessIF, FilingHeaderIF, IncorporationApplicationIF,
-  RegistrationIF } from '@/interfaces/'
+import { CorrectionInformationIF, FilingBusinessIF, FilingHeaderIF } from '@/interfaces/'
 
 //
 // Ref: https://github.com/bcgov/business-schemas/blob/main/src/registry_schemas/schemas/correction.json
@@ -10,7 +9,4 @@ export interface CorrectionFilingIF {
   header: FilingHeaderIF
   business: FilingBusinessIF
   correction: CorrectionInformationIF
-  incorporationApplication?: IncorporationApplicationIF
-  changeofRegistration?: ChgRegistrationIF
-  registration?: RegistrationIF
 }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -92,6 +92,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
   @Action setFileNumber!: ActionBindingIF
   @Action setHasPlanOfArrangement!: ActionBindingIF
 
+  /** The default (hard-coded first line) correction detail comment. */
   public get defaultCorrectionDetailComment (): string {
     const correctedFilingName = this.filingTypeToName(this.getCorrectedFilingType)
     return `Correction for ${correctedFilingName} filed on ${this.correctedFilingDate}`
@@ -107,7 +108,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
    * @returns the correction filing body
    */
   buildCorrectionFiling (isDraft: boolean): CorrectionFilingIF {
-    // Build correction filing (common data)
+    // build correction filing (common data)
     let filing: CorrectionFilingIF = {
       header: {
         name: FilingTypes.CORRECTION,
@@ -141,10 +142,13 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
       // make a copy so we don't change original array
       let parties = cloneDeep(this.getOrgPeople)
 
-      // add completing party (client error correction only)
+      // add completing party (client error corrections only)
       if (this.isClientErrorCorrection) {
         parties = this.addCompletingParty(parties)
       }
+
+      // prepare parties
+      parties = isDraft ? parties : this.prepareParties(parties)
 
       // fix schema issues
       parties = this.fixPartySchemaIssues(parties)
@@ -152,35 +156,16 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
       filing.correction.parties = parties
     }
 
-    // add in Incorporation Application data
+    // add in data specific to Incorporation Applications
     // *** FUTURE: change this to "if BEN correction"
     if (this.isCorrectedIncorporationApplication) {
-      const nameTranslations = isDraft ? this.getNameTranslations : this.prepareNameTranslations()
-      const shareClasses = isDraft ? this.getShareClasses : this.prepareShareClasses()
-      const parties = isDraft ? this.getOrgPeople : this.prepareParties()
-
-      filing.correction.nameTranslations = nameTranslations
-      filing.correction.shareStructure = { shareClasses }
-
-      // *** FUTURE: save this data in correction object instead
-      // populate the incorporation application object (for the Filer to process)
-      filing.incorporationApplication = {
-        contactPoint: this.getContactPoint,
-        nameRequest: {
-          legalType: this.getEntityType,
-          legalName: this.getNameRequestLegalName,
-          nrNumber: this.getNameRequestNumber
-        },
-        nameTranslations: nameTranslations,
-        offices: this.getOfficeAddresses,
-        parties,
-        shareStructure: { shareClasses }
+      filing.correction.nameTranslations = isDraft ? this.getNameTranslations : this.prepareNameTranslations()
+      filing.correction.shareStructure = {
+        shareClasses: isDraft ? this.getShareClasses : this.prepareShareClasses()
       }
-
-      // *** FUTURE: do we need a correction business object here?
     }
 
-    // add in Registration / Change of Registration data
+    // add in data specific to Registrations / Change of Registrations
     // *** FUTURE: change this to "if firm correction"
     if (this.isCorrectedRegistration || this.isCorrectedChangeReg) {
       filing.correction.business.naics = {
@@ -192,7 +177,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
       }
     }
 
-    // Include Staff Payment into the Correction filing
+    // build Staff Payment into the Correction filing
     filing = this.buildStaffPayment(filing)
 
     return filing
@@ -274,10 +259,10 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
       filing.header.documentOptionalEmail = this.getDocumentOptionalEmail
     }
 
-    // Include Staff Payment into the Alteration filing
+    // Build Staff Payment into the Alteration filing
     filing = this.buildStaffPayment(filing)
 
-    // Sets Folio number if a transactional folio number was entered
+    // Build Folio number if a transactional folio number was entered
     filing = this.buildFolioNumber(filing)
 
     return filing
@@ -472,7 +457,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
       filing.conversion.parties = parties
     }
 
-    // Include Staff Payment into the Conversion filing
+    // Build Staff Payment into the Conversion filing
     filing = this.buildStaffPayment(filing)
 
     return filing
@@ -491,8 +476,8 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
     // store Entity Snapshot
     this.setEntitySnapshot(entitySnapshot)
 
-    // *** FUTURE: remove this fallback when Filings UI provides this value
-    if (!filing.correction.type) filing.correction.type = CorrectionErrorTypes.STAFF
+    // safety check (should never happen)
+    if (!filing.correction.type) filing.correction.type = CorrectionErrorTypes.CLIENT
 
     // Ensures startDate isn't undefined, otherwise its getter is not reactive
     if (!filing.correction.startDate) {

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -49,9 +49,9 @@ export const isFirmChangeFiling = (state: StateIF): boolean => {
   )
 }
 
-/** Whether the current filing is a Benefit Company IA Correction. */
-export const isBenIaCorrectionFiling = (state: StateIF): boolean => {
-  return (isCorrectionFiling(state) && isEntityTypeBEN(state))
+/** Whether the current filing is a Benefit Company Correction. */
+export const isBenCorrectionFiling = (state: StateIF): boolean => {
+  return (isEntityTypeBEN(state) && isCorrectionFiling(state))
 }
 
 /** Whether the current filing is a firm Correction. */
@@ -372,7 +372,7 @@ export const isFilingPaying = (state: StateIF): boolean => {
  * - staff payment
  */
 export const hasCorrectionDataChanged = (state: StateIF): boolean => {
-  if (isBenIaCorrectionFiling(state)) {
+  if (isBenCorrectionFiling(state)) {
     return (
       hasBusinessNameChanged(state) ||
       hasBusinessTypeChanged(state) ||
@@ -489,7 +489,7 @@ export const hasConversionDataChanged = (state: StateIF): boolean => {
 
 /** Whether the subject correction filing is valid. */
 export const isCorrectionValid = (state: StateIF): boolean => {
-  if (isBenIaCorrectionFiling(state)) {
+  if (isBenCorrectionFiling(state)) {
     return (
       getFlagsCompanyInfo(state).isValidCompanyName &&
       getFlagsCompanyInfo(state).isValidNameTranslation &&
@@ -671,7 +671,7 @@ export const getOriginalOfficeAddresses = (state: StateIF): AddressesIF => {
 
 /** True if (registered) mailing address has changed. */
 export const hasMailingChanged = (state: StateIF): boolean => {
-  if (isAlterationFiling(state) || isBenIaCorrectionFiling(state)) {
+  if (isAlterationFiling(state) || isBenCorrectionFiling(state)) {
     return !isSame(
       getOfficeAddresses(state)?.registeredOffice?.mailingAddress,
       getOriginalOfficeAddresses(state)?.registeredOffice?.mailingAddress,
@@ -690,7 +690,7 @@ export const hasMailingChanged = (state: StateIF): boolean => {
 
 /** True if (registered) delivery address has changed. */
 export const hasDeliveryChanged = (state: StateIF): boolean => {
-  if (isAlterationFiling(state) || isBenIaCorrectionFiling(state)) {
+  if (isAlterationFiling(state) || isBenCorrectionFiling(state)) {
     return !isSame(
       getOfficeAddresses(state)?.registeredOffice?.deliveryAddress,
       getOriginalOfficeAddresses(state)?.registeredOffice?.deliveryAddress,

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -192,7 +192,7 @@ export const getOriginalLegalName = (state: StateIF): string => {
   return getEntitySnapshot(state)?.businessInfo?.legalName
 }
 
-/** The original business snapshot. */
+/** The original entity snapshot. */
 export const getEntitySnapshot = (state: StateIF): EntitySnapshotIF => {
   return state.stateModel.entitySnapshot
 }

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -227,8 +227,8 @@ export default class Alteration extends Mixins(
 
     // try to fetch data
     try {
-      // fetch business snapshot
-      const businessSnapshot = await this.fetchBusinessSnapshot()
+      // fetch entity snapshot
+      const entitySnapshot = await this.fetchEntitySnapshot()
 
       if (this.alterationId) {
         // store the filing ID
@@ -247,11 +247,11 @@ export default class Alteration extends Mixins(
           throw new Error('Invalid Alteration status')
         }
 
-        // parse draft alteration filing and business snapshot into store
-        this.parseAlterationFiling(alterationFiling, businessSnapshot)
+        // parse draft alteration filing and entity snapshot into store
+        this.parseAlterationFiling(alterationFiling, entitySnapshot)
       } else {
-        // parse just the business snapshot into store
-        this.parseEntitySnapshot(businessSnapshot)
+        // parse just the entity snapshot into store
+        this.parseEntitySnapshot(entitySnapshot)
       }
 
       if (this.alterationResource) {
@@ -298,8 +298,8 @@ export default class Alteration extends Mixins(
     this.$nextTick(() => this.setHaveUnsavedChanges(false))
   }
 
-  /** Fetches the business snapshot. */
-  private async fetchBusinessSnapshot (): Promise<EntitySnapshotIF> {
+  /** Fetches the entity snapshot. */
+  private async fetchEntitySnapshot (): Promise<EntitySnapshotIF> {
     const items = await Promise.all([
       LegalServices.fetchBusinessInfo(this.getBusinessId),
       AuthServices.fetchAuthInfo(this.getBusinessId),

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -177,8 +177,8 @@ export default class Change extends Mixins(
 
     // try to fetch data
     try {
-      // fetch business snapshot
-      const firmSnapshot = await this.fetchFirmSnapshot()
+      // fetch entity snapshot
+      const entitySnapshot = await this.fetchEntitySnapshot()
 
       if (this.changeId) {
         // store the filing ID
@@ -197,11 +197,11 @@ export default class Change extends Mixins(
           throw new Error('Invalid change status')
         }
 
-        // parse draft change filing and business snapshot into store
-        this.parseChangeRegFiling(changeFiling, firmSnapshot)
+        // parse draft change filing and entity snapshot into store
+        this.parseChangeRegFiling(changeFiling, entitySnapshot)
       } else {
-        // parse just the business snapshot into store
-        this.parseEntitySnapshot(firmSnapshot)
+        // parse just the entity snapshot into store
+        this.parseEntitySnapshot(entitySnapshot)
       }
 
       if (this.firmChangeResource) {
@@ -244,8 +244,8 @@ export default class Change extends Mixins(
     this.$nextTick(() => this.setHaveUnsavedChanges(false))
   }
 
-  /** Fetches the business snapshot. */
-  private async fetchFirmSnapshot (): Promise<EntitySnapshotIF> {
+  /** Fetches the entity snapshot. */
+  private async fetchEntitySnapshot (): Promise<EntitySnapshotIF> {
     const items = await Promise.all([
       LegalServices.fetchBusinessInfo(this.getBusinessId),
       AuthServices.fetchAuthInfo(this.getBusinessId),

--- a/src/views/Conversion.vue
+++ b/src/views/Conversion.vue
@@ -135,8 +135,8 @@ export default class Conversion extends Mixins(
 
     // try to fetch data
     try {
-      // fetch business snapshot
-      const firmSnapshot = await this.fetchFirmSnapshot()
+      // fetch entity snapshot
+      const entitySnapshot = await this.fetchEntitySnapshot()
 
       if (this.conversionId) {
         // store the filing ID
@@ -155,11 +155,11 @@ export default class Conversion extends Mixins(
           throw new Error('Invalid conversion status')
         }
 
-        // parse draft conversion filing and business snapshot into store
-        this.parseFirmConversionFiling(conversionFiling, firmSnapshot)
+        // parse draft conversion filing and entity snapshot into store
+        this.parseFirmConversionFiling(conversionFiling, entitySnapshot)
       } else {
-        // parse just the business snapshot into store
-        this.parseEntitySnapshot(firmSnapshot)
+        // parse just the entity snapshot into store
+        this.parseEntitySnapshot(entitySnapshot)
       }
 
       if (this.firmConversionResource) {
@@ -194,8 +194,8 @@ export default class Conversion extends Mixins(
     this.$nextTick(() => this.setHaveUnsavedChanges(false))
   }
 
-  /** Fetches the business snapshot. */
-  private async fetchFirmSnapshot (): Promise<EntitySnapshotIF> {
+  /** Fetches the entity snapshot. */
+  private async fetchEntitySnapshot (): Promise<EntitySnapshotIF> {
     const items = await Promise.all([
       LegalServices.fetchBusinessInfo(this.getBusinessId),
       AuthServices.fetchAuthInfo(this.getBusinessId),

--- a/src/views/Correction/BenCorrection.vue
+++ b/src/views/Correction/BenCorrection.vue
@@ -96,11 +96,11 @@ export default class BenCorrection extends Mixins(CommonMixin, DateMixin, FeeMix
       // safety check
       if (!this.correctionFiling) throw (new Error('Missing correction filing. Try reloading the page.'))
 
-      // fetch business snapshot
-      const businessSnapshot = await this.fetchBusinessSnapshot()
+      // fetch entity snapshot
+      const entitySnapshot = await this.fetchEntitySnapshot()
 
-      // parse draft correction filing and business snapshot into store
-      this.parseCorrectionFiling(this.correctionFiling, businessSnapshot)
+      // parse draft correction filing and entity snapshot into store
+      this.parseCorrectionFiling(this.correctionFiling, entitySnapshot)
 
       // set the resources
       this.setResource(this.correctionResource)
@@ -119,8 +119,8 @@ export default class BenCorrection extends Mixins(CommonMixin, DateMixin, FeeMix
     this.$nextTick(() => this.setHaveUnsavedChanges(false))
   }
 
-  /** Fetches the business snapshot. */
-  private async fetchBusinessSnapshot (): Promise<EntitySnapshotIF> {
+  /** Fetches the entity snapshot. */
+  private async fetchEntitySnapshot (): Promise<EntitySnapshotIF> {
     const items = await Promise.all([
       LegalServices.fetchBusinessInfo(this.getBusinessId),
       AuthServices.fetchAuthInfo(this.getBusinessId),

--- a/src/views/Correction/FmCorrection.vue
+++ b/src/views/Correction/FmCorrection.vue
@@ -86,11 +86,11 @@ export default class FmCorrection extends Mixins(CommonMixin, FeeMixin, FilingTe
       // safety check
       if (!this.correctionFiling) throw (new Error('Missing correction filing. Try reloading the page.'))
 
-      // fetch business snapshot
-      const businessSnapshot = await this.fetchBusinessSnapshot()
+      // fetch entity snapshot
+      const entitySnapshot = await this.fetchEntitySnapshot()
 
-      // parse draft correction filing and business snapshot into store
-      this.parseCorrectionFiling(this.correctionFiling, businessSnapshot)
+      // parse draft correction filing and entity snapshot into store
+      this.parseCorrectionFiling(this.correctionFiling, entitySnapshot)
 
       // set the resources
       this.setResource(this.correctionResource)
@@ -112,8 +112,8 @@ export default class FmCorrection extends Mixins(CommonMixin, FeeMixin, FilingTe
     this.$nextTick(() => this.setHaveUnsavedChanges(false))
   }
 
-  /** Fetches the business snapshot. */
-  private async fetchBusinessSnapshot (): Promise<EntitySnapshotIF> {
+  /** Fetches the entity snapshot. */
+  private async fetchEntitySnapshot (): Promise<EntitySnapshotIF> {
     const items = await Promise.all([
       LegalServices.fetchBusinessInfo(this.getBusinessId),
       AuthServices.fetchAuthInfo(this.getBusinessId),

--- a/src/views/SpecialResolution.vue
+++ b/src/views/SpecialResolution.vue
@@ -207,7 +207,8 @@ export default class SpecialResolution extends Mixins(
 
     // try to fetch data
     try {
-      const businessSnapshot = await this.fetchBusinessSnapshot()
+      // fetch entity snapshot
+      const entitySnapshot = await this.fetchEntitySnapshot()
 
       // update later with resolution-id and parse it once it saved
       if (this.specialResolutionId) {
@@ -227,11 +228,11 @@ export default class SpecialResolution extends Mixins(
           throw new Error('Invalid Special Resolution status')
         }
 
-        // parse special resolution filing and original business snapshot into store
-        this.parseSpecialResolutionFiling(filing, businessSnapshot)
+        // parse special resolution filing and original entity snapshot into store
+        this.parseSpecialResolutionFiling(filing, entitySnapshot)
       } else {
-        // parse business data into store
-        this.parseEntitySnapshot(businessSnapshot)
+        // parse just the entity snapshot into store
+        this.parseEntitySnapshot(entitySnapshot)
       }
 
       if (this.specialResolutionResource) {
@@ -285,8 +286,8 @@ export default class SpecialResolution extends Mixins(
     this.$nextTick(() => this.setHaveUnsavedChanges(false))
   }
 
-  /** Fetches the business snapshot. */
-  private async fetchBusinessSnapshot (): Promise<EntitySnapshotIF> {
+  /** Fetches the entity snapshot. */
+  private async fetchEntitySnapshot (): Promise<EntitySnapshotIF> {
     const items = await Promise.all([
       LegalServices.fetchBusinessInfo(this.getBusinessId),
       AuthServices.fetchAuthInfo(this.getBusinessId),

--- a/tests/unit/Alteration.spec.ts
+++ b/tests/unit/Alteration.spec.ts
@@ -283,7 +283,7 @@ describe('Alteration component', () => {
     expect(wrapper.findComponent(Alteration).exists()).toBe(true)
   })
 
-  it('loads the business snapshot into the store', async () => {
+  it('loads the entity snapshot into the store', async () => {
     await wrapper.setProps({ appReady: true })
     await flushPromises()
     const state = store.state.stateModel

--- a/tests/unit/BenCorrection.spec.ts
+++ b/tests/unit/BenCorrection.spec.ts
@@ -157,7 +157,7 @@ describe('Benefit Company Correction component', () => {
   })
 
   // FUTURE
-  xit('loads the business snapshot into the store', async () => {
+  xit('loads the entity snapshot into the store', async () => {
     await wrapper.setProps({ appReady: true })
     await flushPromises()
     const state = store.state.stateModel

--- a/tests/unit/Change.spec.ts
+++ b/tests/unit/Change.spec.ts
@@ -246,7 +246,7 @@ describe('Change component', () => {
   })
 
   // FUTURE
-  xit('loads the business snapshot into the store', async () => {
+  xit('loads the entity snapshot into the store', async () => {
     await wrapper.setProps({ appReady: true })
     await flushPromises()
     const state = store.state.stateModel

--- a/tests/unit/Conversion.spec.ts
+++ b/tests/unit/Conversion.spec.ts
@@ -247,7 +247,7 @@ describe('Conversion component', () => {
   })
 
   // FUTURE
-  xit('loads the business snapshot into the store', async () => {
+  xit('loads the entity snapshot into the store', async () => {
     await wrapper.setProps({ appReady: true })
     await flushPromises()
     const state = store.state.stateModel

--- a/tests/unit/FmCorrection.spec.ts
+++ b/tests/unit/FmCorrection.spec.ts
@@ -183,7 +183,7 @@ describe('Firm Correction component', () => {
   })
 
   // FUTURE
-  xit('loads the business snapshot into the store', async () => {
+  xit('loads the entity snapshot into the store', async () => {
     await wrapper.setProps({ appReady: true })
     await flushPromises()
     const state = store.state.stateModel

--- a/tests/unit/SpecialResolution.spec.ts
+++ b/tests/unit/SpecialResolution.spec.ts
@@ -177,7 +177,7 @@ describe('SpecialResolution component', () => {
     expect(wrapper.findComponent(SpecialResolution).exists()).toBe(true)
   })
 
-  it('loads the business snapshot into the store', async () => {
+  it('loads the entity snapshot into the store', async () => {
     await wrapper.setProps({ appReady: true })
     await flushPromises()
     const state = store.state.stateModel

--- a/tests/unit/SpecialResolution.spec.ts
+++ b/tests/unit/SpecialResolution.spec.ts
@@ -36,7 +36,7 @@ describe('SpecialResolution component', () => {
 
     const get = sinon.stub(axios, 'get')
 
-    // GET payment fee for immediate alteration
+    // GET payment fees for immediate alteration
     get.withArgs('https://pay.api.url/fees/CP/SPRLN')
       .returns(Promise.resolve({
         data: { 'filingFees': 70.0,
@@ -51,6 +51,24 @@ describe('SpecialResolution component', () => {
             'pst': 0
           },
           'total': 70.0
+        }
+      }))
+
+    // GET payment fees for future effective alteration
+    get.withArgs('https://pay.api.url/fees/CP/SPRLN?futureEffective=true')
+      .returns(Promise.resolve({
+        data: { 'filingFees': 70.0,
+          'filingType': 'Special resolution',
+          'filingTypeCode': 'SPRLN',
+          'futureEffectiveFees': 100.0,
+          'priorityFees': 0,
+          'processingFees': 0,
+          'serviceFees': 0,
+          'tax': {
+            'gst': 0,
+            'pst': 0
+          },
+          'total': 170.0
         }
       }))
 
@@ -177,7 +195,7 @@ describe('SpecialResolution component', () => {
     expect(wrapper.findComponent(SpecialResolution).exists()).toBe(true)
   })
 
-  it('loads the entity snapshot into the store', async () => {
+  it.only('loads the entity snapshot into the store', async () => {
     await wrapper.setProps({ appReady: true })
     await flushPromises()
     const state = store.state.stateModel

--- a/tests/unit/state-getters.spec.ts
+++ b/tests/unit/state-getters.spec.ts
@@ -225,7 +225,7 @@ describe('Alteration getters', () => {
   })
 })
 
-describe('BEN IA correction getters', () => {
+describe('BEN correction getters', () => {
   let vm: any
 
   const newAddress = {


### PR DESCRIPTION
*Issue #:* bcgov/entity#13192 and bcgov/entity#13334

*Description of changes:*

Commit 1:
- deleted corrected filings from correction filing interface
- stop saving corrected incorporation application
- fixed missing prepareParties() for firm corrections
- set fallback correction type to CLIENT (more complete than STAFF, and staff can delete and recreate if wrong)
- renamed "business snapshot" -> "entity snapshot"
- app version = 3.5.25

Commit 2:
- renamed isBenIaCorrectionFiling -> isBenCorrectionFiling
- cleaned up Filing Template Mixin

Commit 3:
- fixed unit test errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).