### PR TITLE
13193 Added missing Change of Registration filing code + misc cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.5.26",
+  "version": "3.5.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.5.26",
+      "version": "3.5.27",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.5.26",
+  "version": "3.5.27",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/CourtOrderPoa.vue
+++ b/src/components/common/CourtOrderPoa.vue
@@ -12,6 +12,7 @@
       <CourtOrderPoaShared
         id="court-order"
         :autoValidation="getAppValidate"
+        :draftCourtOrderNumber="getFileNumber"
         :hasDraftPlanOfArrangement="getHasPlanOfArrangement"
         :invalidSection="invalidCourtOrder"
         @emitCourtNumber="setFileNumber($event)"
@@ -40,6 +41,7 @@ export default class CourtOrderPoa extends Vue {
   /** Store getters */
   @Getter getFlagsReviewCertify!: FlagsReviewCertifyIF
   @Getter getAppValidate!: boolean
+  @Getter getFileNumber!: string
   @Getter getHasPlanOfArrangement!: boolean
 
   /** Global actions */
@@ -53,3 +55,15 @@ export default class CourtOrderPoa extends Vue {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+// fix hard-coded whitespace inside shared component
+// we want the same padding as "section-container py-6"
+#court-order {
+  margin-top: 0 !important;
+  padding-top: 0.5rem !important;
+  padding-right: 1.875rem !important;
+  padding-bottom: 1.5rem !important;
+  padding-left: 0.375rem !important;
+}
+</style>

--- a/src/interfaces/filing-interfaces/chg-registration-interfaces.ts
+++ b/src/interfaces/filing-interfaces/chg-registration-interfaces.ts
@@ -1,4 +1,5 @@
-import { AddressesIF, FilingBusinessIF, FilingHeaderIF, NameRequestIF, OrgPersonIF } from '@/interfaces/'
+import { AddressesIF, CourtOrderIF, FilingBusinessIF, FilingHeaderIF, NameRequestIF, OrgPersonIF }
+  from '@/interfaces/'
 import { ContactPointIF, NaicsIF } from '@bcrs-shared-components/interfaces/'
 
 //
@@ -9,7 +10,7 @@ export interface ChgRegistrationIF {
     identifier: string
     naics?: NaicsIF
   }
-  courtOrder?: string
+  courtOrder?: CourtOrderIF
   contactPoint: ContactPointIF
   nameRequest?: NameRequestIF
   offices?: AddressesIF

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -8,8 +8,8 @@
         </header>
 
         <section class="mt-6">
-          You are legally obligated to keep your company information up to date. Necessary fees
-          will be applied as updates are made.
+          You are legally obligated to keep your company information up to date. Necessary fees will be
+          applied as updates are made.
         </section>
 
         <YourCompany class="mt-10" />
@@ -31,9 +31,9 @@
 
         <section class="mt-6">
           <p id="intro-text">
-            Review and certify the changes you are about to make to your company. Certain changes require an Alteration
-            Notice which will incur a {{filingFeesPrice}} fee. Choosing an alteration date and time in the future will
-            incur an additional {{futureEffectiveFeesPrice}} fee.
+            Review and certify the changes you are about to make to your company. Certain changes require
+            an Alteration Notice which will incur a {{filingFeesPrice}} fee. Choosing an alteration date
+            and time in the future will incur an additional {{futureEffectiveFeesPrice}} fee.
           </p>
         </section>
 
@@ -64,27 +64,13 @@
           :disableEdit="!isRoleStaff"
         />
 
-        <!-- STAFF ONLY: Court Order and Plan of Arrangement -->
+        <!-- STAFF ONLY: Court Order/Plan of Arrangement and Staff Payment -->
         <template v-if="isRoleStaff">
-          <h2 class="mt-10">{{showTransactionalFolioNumber ? '4.' : '3.'}} Court Order and Plan of Arrangement</h2>
-          <div class="py-4">
-            If this filing is pursuant to a court order, enter the court order number. If this
-            filing is pursuant to a plan of arrangement, enter the court order number and select
-            Plan of Arrangement.
-          </div>
-
-          <div :class="{'invalid-section': invalidCourtOrder}">
-            <CourtOrderPoaShared
-              id="court-order"
-              :autoValidation="getAppValidate"
-              :draftCourtOrderNumber="getFileNumber"
-              :hasDraftPlanOfArrangement="getHasPlanOfArrangement"
-              :invalidSection="invalidCourtOrder"
-              @emitCourtNumber="setFileNumber($event)"
-              @emitPoa="setHasPlanOfArrangement($event)"
-              @emitValid="setValidCourtOrder($event)"
-            />
-          </div>
+          <CourtOrderPoa
+            class="mt-10"
+            :sectionNumber="showTransactionalFolioNumber ? '4.' : '3.'"
+            :autoValidation="getAppValidate"
+          />
 
           <StaffPayment
             class="mt-10"
@@ -128,18 +114,14 @@ import { Component, Emit, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { getFeatureFlag } from '@/utils/'
 import { AlterationSummary, Articles } from '@/components/Alteration/'
-import { CertifySection, CurrentDirectors, DocumentsDelivery,
-  ShareStructures, StaffPayment, TransactionalFolioNumber, YourCompany }
-  from '@/components/common/'
-import { CourtOrderPoa as CourtOrderPoaShared } from '@bcrs-shared-components/court-order-poa/'
+import { CertifySection, CourtOrderPoa, CurrentDirectors, DocumentsDelivery, ShareStructures, StaffPayment,
+  TransactionalFolioNumber, YourCompany } from '@/components/common/'
 import { AuthServices, LegalServices } from '@/services/'
 import { CommonMixin, FeeMixin, FilingTemplateMixin } from '@/mixins/'
 import { ActionBindingIF, EntitySnapshotIF, FlagsReviewCertifyIF, ResourceIF }
   from '@/interfaces/'
-import { FilingCodes, FilingStatus } from '@/enums/'
-import { StaffPaymentOptions } from '@bcrs-shared-components/enums/'
+import { FilingStatus } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
-import { cloneDeep } from 'lodash'
 import { BenefitCompanyResource } from '@/resources/Alteration/'
 
 @Component({
@@ -147,7 +129,7 @@ import { BenefitCompanyResource } from '@/resources/Alteration/'
     AlterationSummary,
     Articles,
     CertifySection,
-    CourtOrderPoaShared,
+    CourtOrderPoa,
     CurrentDirectors,
     DocumentsDelivery,
     ShareStructures,
@@ -175,7 +157,6 @@ export default class Alteration extends Mixins(
   @Action setHaveUnsavedChanges!: ActionBindingIF
   @Action setFilingId!: ActionBindingIF
   @Action setDocumentOptionalEmailValidity!: ActionBindingIF
-  @Action setValidCourtOrder!: ActionBindingIF
   @Action setResource!: ActionBindingIF
 
   /** Whether App is ready. */
@@ -195,11 +176,6 @@ export default class Alteration extends Mixins(
   /** True if user is authenticated. */
   get isAuthenticated (): boolean {
     return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
-  }
-
-  /** Check validity state, only when prompted by app. */
-  get invalidCourtOrder (): boolean {
-    return (this.getAppValidate && !this.getFlagsReviewCertify.isValidCourtOrder)
   }
 
   /** The resource file for an alteration filing. */
@@ -350,15 +326,5 @@ export default class Alteration extends Mixins(
 <style lang="scss" scoped>
 #done-button {
   width: 10rem;
-}
-
-// fix hard-coded whitespace inside shared component
-// we want the same padding as "section-container py-6"
-::v-deep #court-order {
-  margin-top: 0 !important;
-  padding-top: 0.5rem !important;
-  padding-right: 1.875rem !important;
-  padding-bottom: 1.5rem !important;
-  padding-left: 0.375rem !important;
 }
 </style>

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -8,8 +8,8 @@
         </header>
 
         <section class="mt-6">
-          You must promptly file updates to your business information. Necessary fees will be applied as updates are
-          made.
+          You must promptly file updates to your business information. Necessary fees will be applied as
+          updates are made.
         </section>
 
         <YourCompany class="mt-10" />
@@ -27,8 +27,8 @@
 
         <section class="mt-6">
           <p id="intro-text">
-            Changes were made to your business information that require a filing. Review and certify the changes you
-            are about the make to your business.
+            Changes were made to your business information that require a filing. Review and certify the
+            changes you are about the make to your business.
           </p>
         </section>
 
@@ -64,9 +64,10 @@
           :disableEdit="!isRoleStaff"
         />
 
+        <!-- STAFF ONLY: Court Order/Plan of Arrangement and Staff Payment -->
         <template v-if="isRoleStaff">
           <CourtOrderPoa
-            class="'mt-10"
+            class="mt-10"
             :sectionNumber="showTransactionalFolioNumber ? '5.' : '4.'"
             :autoValidation="getAppValidate"
           />
@@ -88,11 +89,11 @@ import { Component, Emit, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { getFeatureFlag } from '@/utils/'
 import { ChangeSummary } from '@/components/Change/'
-import { CertifySection, CompletingParty, DocumentsDelivery, PeopleAndRoles, YourCompany, StaffPayment,
-  CourtOrderPoa, TransactionalFolioNumber } from '@/components/common/'
+import { CertifySection, CompletingParty, CourtOrderPoa, DocumentsDelivery, PeopleAndRoles, StaffPayment,
+  TransactionalFolioNumber, YourCompany } from '@/components/common/'
 import { AuthServices, LegalServices } from '@/services/'
 import { CommonMixin, FeeMixin, FilingTemplateMixin } from '@/mixins/'
-import { ActionBindingIF, EmptyFees, EntitySnapshotIF, FilingDataIF, ResourceIF } from '@/interfaces/'
+import { ActionBindingIF, EntitySnapshotIF, ResourceIF } from '@/interfaces/'
 import { FilingStatus } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { SoleProprietorshipResource, GeneralPartnershipResource } from '@/resources/Change/'

--- a/src/views/SpecialResolution.vue
+++ b/src/views/SpecialResolution.vue
@@ -110,14 +110,11 @@ import { Component, Emit, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { getFeatureFlag } from '@/utils/'
 import { SpecialResolutionSummary, CreateSpecialResolution } from '@/components/SpecialResolution'
-import { CertifySection, CurrentDirectors, DocumentsDelivery,
-  StaffPayment, TransactionalFolioNumber, YourCompany, CompletingParty }
-  from '@/components/common/'
-import { CourtOrderPoa as CourtOrderPoaShared } from '@bcrs-shared-components/court-order-poa/'
+import { CertifySection, CurrentDirectors, DocumentsDelivery, StaffPayment, TransactionalFolioNumber,
+  YourCompany, CompletingParty } from '@/components/common/'
 import { AuthServices, LegalServices } from '@/services/'
 import { CommonMixin, FeeMixin, FilingTemplateMixin } from '@/mixins/'
-import { ActionBindingIF, EntitySnapshotIF, FeesIF, FilingDataIF, FlagsReviewCertifyIF, ResourceIF }
-  from '@/interfaces/'
+import { ActionBindingIF, EntitySnapshotIF, FlagsReviewCertifyIF, ResourceIF } from '@/interfaces/'
 import { CorpTypeCd, FilingCodes, FilingStatus } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { CooperativeResource } from '@/resources/SpecialResolution/'
@@ -126,7 +123,6 @@ import { CooperativeResource } from '@/resources/SpecialResolution/'
   components: {
     SpecialResolutionSummary,
     CertifySection,
-    CourtOrderPoaShared,
     CurrentDirectors,
     DocumentsDelivery,
     StaffPayment,
@@ -358,15 +354,5 @@ export default class SpecialResolution extends Mixins(
 <style lang="scss" scoped>
 #done-button {
   width: 10rem;
-}
-
-// fix hard-coded whitespace inside shared component
-// we want the same padding as "section-container py-6"
-::v-deep #court-order {
-  margin-top: 0 !important;
-  padding-top: 0.5rem !important;
-  padding-right: 1.875rem !important;
-  padding-bottom: 1.5rem !important;
-  padding-left: 0.375rem !important;
 }
 </style>

--- a/tests/unit/CourtOrderPoa.spec.ts
+++ b/tests/unit/CourtOrderPoa.spec.ts
@@ -11,7 +11,6 @@ Vue.use(Vuetify)
 let vuetify = new Vuetify({})
 
 const localVue = createLocalVue()
-const courtOrderNumber = '#court-order-number-input'
 
 localVue.use(VueRouter)
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#13193

*Description of changes:*
- added missing getter to CourtOrderPoa component
- moved CSS from callers to CourtOrderPoa component
- fixed incorrect Court Order type in Change of Registration interface
- saved missing fields in Change of Registration filing object
- added fallbacks for missing restored fields
- restored missing fields from Change of Registration filing object
- used local CourtOrderPoa shim component for Alterations
- misc cleanup
- app version = 3.5.27

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).