### PR TITLE
12571 + 13510: added Business Start Date to firm change and conversion filings + misc fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.7.4",
+      "version": "3.7.5",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/action-chip": "1.0.28",
@@ -25,8 +25,8 @@
         "@bcrs-shared-components/folio-number": "1.0.3",
         "@bcrs-shared-components/help-business-number": "1.0.0",
         "@bcrs-shared-components/interfaces": "1.0.41",
-        "@bcrs-shared-components/nature-of-business": "1.0.11",
-        "@bcrs-shared-components/share-structure": "2.0.2",
+        "@bcrs-shared-components/nature-of-business": "1.0.12",
+        "@bcrs-shared-components/share-structure": "2.0.3",
         "@bcrs-shared-components/staff-payment": "2.0.11",
         "@mdi/font": "^5.5.55",
         "@sentry/browser": "^5.23.0",
@@ -2052,18 +2052,18 @@
       }
     },
     "node_modules/@bcrs-shared-components/nature-of-business": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/nature-of-business/-/nature-of-business-1.0.11.tgz",
-      "integrity": "sha512-B9tgsQ7Ec28N3P64w7YSwLcCoDNzjwvMaeUdnyTYQLe/jj9uYsF4kAzh1eD0z1doa6c+bfTWP0615EeD3A5CHw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/nature-of-business/-/nature-of-business-1.0.12.tgz",
+      "integrity": "sha512-4bkw97ZjQPAqAQokvpPxcv7Zb4i5jr5km0my/dGQ4l01IvWBcSqXovkPJFi2MIclT6Convwek/HIJuUZvgY7ow==",
       "dependencies": {
         "@bcrs-shared-components/interfaces": "^1.0.41",
         "vue-property-decorator": "^8.4.0"
       }
     },
     "node_modules/@bcrs-shared-components/share-structure": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/share-structure/-/share-structure-2.0.2.tgz",
-      "integrity": "sha512-WH+4/1uh1F48wml4ICaxW195OcZyfUUPCDKoRcvFKnrEBjUH0v7kNDWJM5xZXfEGmHAV1QluOjWFH6rDEn4z3A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/share-structure/-/share-structure-2.0.3.tgz",
+      "integrity": "sha512-x972eAbo/2K5t5ACxHPTzQr0Da0+YpFSoEb2T/e5eCDfTvHDWYX9MYg3PgH6zbmyScJ6fBd1oZc2BXz1l0e9vQ==",
       "dependencies": {
         "@bcrs-shared-components/action-chip": "^1.0.28",
         "@bcrs-shared-components/confirm-dialog": "^1.1.1",
@@ -24899,18 +24899,18 @@
       }
     },
     "@bcrs-shared-components/nature-of-business": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/nature-of-business/-/nature-of-business-1.0.11.tgz",
-      "integrity": "sha512-B9tgsQ7Ec28N3P64w7YSwLcCoDNzjwvMaeUdnyTYQLe/jj9uYsF4kAzh1eD0z1doa6c+bfTWP0615EeD3A5CHw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/nature-of-business/-/nature-of-business-1.0.12.tgz",
+      "integrity": "sha512-4bkw97ZjQPAqAQokvpPxcv7Zb4i5jr5km0my/dGQ4l01IvWBcSqXovkPJFi2MIclT6Convwek/HIJuUZvgY7ow==",
       "requires": {
         "@bcrs-shared-components/interfaces": "^1.0.41",
         "vue-property-decorator": "^8.4.0"
       }
     },
     "@bcrs-shared-components/share-structure": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/share-structure/-/share-structure-2.0.2.tgz",
-      "integrity": "sha512-WH+4/1uh1F48wml4ICaxW195OcZyfUUPCDKoRcvFKnrEBjUH0v7kNDWJM5xZXfEGmHAV1QluOjWFH6rDEn4z3A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/share-structure/-/share-structure-2.0.3.tgz",
+      "integrity": "sha512-x972eAbo/2K5t5ACxHPTzQr0Da0+YpFSoEb2T/e5eCDfTvHDWYX9MYg3PgH6zbmyScJ6fBd1oZc2BXz1l0e9vQ==",
       "requires": {
         "@bcrs-shared-components/action-chip": "^1.0.28",
         "@bcrs-shared-components/confirm-dialog": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",
@@ -30,8 +30,8 @@
     "@bcrs-shared-components/folio-number": "1.0.3",
     "@bcrs-shared-components/help-business-number": "1.0.0",
     "@bcrs-shared-components/interfaces": "1.0.41",
-    "@bcrs-shared-components/nature-of-business": "1.0.11",
-    "@bcrs-shared-components/share-structure": "2.0.2",
+    "@bcrs-shared-components/nature-of-business": "1.0.12",
+    "@bcrs-shared-components/share-structure": "2.0.3",
     "@bcrs-shared-components/staff-payment": "2.0.11",
     "@mdi/font": "^5.5.55",
     "@sentry/browser": "^5.23.0",

--- a/src/components/Alteration/Articles/CompanyProvisions.vue
+++ b/src/components/Alteration/Articles/CompanyProvisions.vue
@@ -54,7 +54,7 @@
                 >
                   <v-list-item-subtitle>
                     <v-icon small color="primary">mdi-pencil</v-icon>
-                    <span class="drop-down-action ml-1">{{ editLabel }}</span>
+                    <span class="drop-down-action ml-1">Change</span>
                   </v-list-item-subtitle>
                 </v-list-item>
               </v-list>

--- a/src/components/Conversion/ConversionNOB.vue
+++ b/src/components/Conversion/ConversionNOB.vue
@@ -64,13 +64,13 @@
             <v-menu offset-y left nudge-bottom="4" v-model="dropdown">
               <template v-slot:activator="{ on }">
                 <v-btn text small color="primary" id="nob-menu-btn" v-on="on">
-                  <v-icon>{{dropdown ? 'mdi-menu-up' : 'mdi-menu-down'}}</v-icon>
+                  <v-icon>{{ dropdown ? 'mdi-menu-up' : 'mdi-menu-down' }}</v-icon>
                 </v-btn>
               </template>
               <v-btn text color="primary" id="more-changes-btn" class="py-5"
                 @click="onChangeClicked(); dropdown = false">
                 <v-icon small color="primary">mdi-pencil</v-icon>
-                <span>{{ editLabel }}</span>
+                <span>Change</span>
               </v-btn>
             </v-menu>
           </div>

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -197,7 +197,7 @@
                     >
                       <v-list-item-subtitle>
                         <v-icon small>mdi-pencil</v-icon>
-                        <span class="ml-1">{{ editLabel }}</span>
+                        <span class="ml-1">Change</span>
                       </v-list-item-subtitle>
                     </v-list-item>
                     <v-list-item

--- a/src/components/common/YourCompany/NameTranslations/ListNameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/ListNameTranslation.vue
@@ -80,10 +80,10 @@
                 text
                 color="primary"
                 :disabled="isAddingNameTranslation"
-                @click="emitNameEdit(index)">
+                @click="emitNameEdit(index)"
+              >
                   <v-icon small>mdi-pencil</v-icon>
-                  <span v-if="isCorrectionFiling">Correct</span>
-                  <span v-else>Edit</span>
+                  <span>Change</span>
               </v-btn>
             </span>
             <!-- more actions menu -->

--- a/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
@@ -16,11 +16,12 @@
       </v-col>
       <v-col cols="7" v-if="draftTranslations && translationsExceptRemoved.length">
         <div class="info-text text-uppercase" v-for="(translation, index) in translationsExceptRemoved"
-          :key="`name_translation_${index}`">{{translation.name}}</div>
+          :key="`name_translation_${index}`">{{ translation.name }}</div>
       </v-col>
       <v-col cols="7" class="info-text" v-else>
         No name translations
       </v-col>
+
       <!-- Actions -->
       <v-col cols="2" class="mt-n2" v-if="!hasNameTranslationChange && !isSummaryMode">
         <div class="actions mr-4">
@@ -30,7 +31,7 @@
             @click="isEditing = true"
           >
             <v-icon small>mdi-pencil</v-icon>
-            <span>{{editLabel}}</span>
+            <span>{{ editLabel }}</span>
           </v-btn>
         </div>
       </v-col>
@@ -64,7 +65,7 @@
                 >
                   <v-list-item-subtitle>
                     <v-icon small>mdi-pencil</v-icon>
-                    <span class="ml-1">{{editLabel}}</span>
+                    <span class="ml-1">Change</span>
                   </v-list-item-subtitle>
                 </v-list-item>
               </v-list>

--- a/src/components/common/YourCompany/NatureOfBusiness.vue
+++ b/src/components/common/YourCompany/NatureOfBusiness.vue
@@ -4,6 +4,8 @@
     :naics="getCurrentNaics"
     :NaicsServices="NaicsServices"
     :hasNaicsChanges="hasNaicsChanged"
+    :editLabel="editLabel"
+    :editedLabel="editedLabel"
     @valid="onValidChanged($event)"
     @undoNaics="setNaics(getSnapshotNaics)"
     @setNaics="setNaics($event)"
@@ -12,18 +14,19 @@
 
 <script lang="ts">
 import { Action, Getter } from 'vuex-class'
-import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Component, Prop, Mixins } from 'vue-property-decorator'
 import { NaicsServices } from '@/services/'
 import { ActionBindingIF } from '@/interfaces/'
 import { NaicsIF } from '@bcrs-shared-components/interfaces/'
 import { NatureOfBusiness as NatureOfBusinessShared } from '@bcrs-shared-components/nature-of-business/'
+import { CommonMixin } from '@/mixins'
 
 @Component({
   components: {
     NatureOfBusinessShared
   }
 })
-export default class NatureOfBusiness extends Vue {
+export default class NatureOfBusiness extends Mixins(CommonMixin) {
   /** Whether to show invalid section styling. */
   @Prop({ default: false })
   readonly invalidSection: boolean

--- a/src/components/common/YourCompany/OfficeAddresses.vue
+++ b/src/components/common/YourCompany/OfficeAddresses.vue
@@ -79,7 +79,7 @@
                     >
                       <v-list-item-subtitle>
                         <v-icon small>mdi-pencil</v-icon>
-                        <span class="ml-1">{{ editLabel }}</span>
+                        <span class="ml-1">Change</span>
                       </v-list-item-subtitle>
                     </v-list-item>
                   </v-list>

--- a/src/interfaces/filing-interfaces/chg-registration-interfaces.ts
+++ b/src/interfaces/filing-interfaces/chg-registration-interfaces.ts
@@ -15,6 +15,7 @@ export interface ChgRegistrationIF {
   nameRequest?: NameRequestIF
   offices?: AddressesIF
   parties?: Array<OrgPersonIF>
+  startDate?: string // YYYY-MM-DD
 }
 
 /** Interface for data object UI sends to API. */

--- a/src/interfaces/store-interfaces/state-interfaces/correction-information-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/correction-information-interface.ts
@@ -38,6 +38,6 @@ export interface CorrectionInformationIF {
     shareClasses: ShareClassIF[]
     resolutionDates?: string[]
   }
-  startDate?: string // YYYY-MM-DD
+  startDate?: string // YYYY-MM-DD (firms only)
   provisionsRemoved?: boolean
 }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -92,6 +92,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
   @Action setFileNumber!: ActionBindingIF
   @Action setHasPlanOfArrangement!: ActionBindingIF
   @Action setSpecialResolution!: ActionBindingIF
+  @Action setCorrectionStartDate!: ActionBindingIF
 
   /** The default (hard-coded first line) correction detail comment. */
   public get defaultCorrectionDetailComment (): string {
@@ -416,6 +417,11 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
       filing.header.documentOptionalEmail = this.getDocumentOptionalEmail
     }
 
+    // Apply Business Start Date to filing
+    if (this.hasBusinessStartDateChanged) {
+      filing.changeOfRegistration.startDate = this.getCorrectionStartDate
+    }
+
     // Build Staff Payment into the filing
     filing = this.buildStaffPayment(filing)
 
@@ -488,6 +494,11 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
       parties = this.fixPartySchemaIssues(parties)
 
       filing.conversion.parties = parties
+    }
+
+    // Apply Business Start Date to filing
+    if (this.hasBusinessStartDateChanged) {
+      filing.conversion.startDate = this.getCorrectionStartDate
     }
 
     // Build Staff Payment into the filing
@@ -852,6 +863,9 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
     this.setFileNumber(filing.changeOfRegistration.courtOrder?.fileNumber)
     this.setHasPlanOfArrangement(filing.changeOfRegistration.courtOrder?.hasPlanOfArrangement)
 
+    // store Business Start Date
+    this.setCorrectionStartDate(filing.changeOfRegistration.startDate || null)
+
     // store Staff Payment
     this.storeStaffPayment(filing)
   }
@@ -907,6 +921,9 @@ export default class FilingTemplateMixin extends Mixins(DateMixin, EnumMixin) {
     // (it is managed separately and added to the filing in buildConversionFiling())
     orgPersons = orgPersons.filter(op => !(op?.roles.some(role => role.roleType === RoleTypes.COMPLETING_PARTY)))
     this.setPeopleAndRoles(cloneDeep(orgPersons))
+
+    // store Business Start Date
+    this.setCorrectionStartDate(filing.conversion.startDate || null)
 
     // store Certify State
     this.setCertifyState({

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -471,6 +471,7 @@ export const isSpecialResolutionValid = (state: StateIF): boolean => {
 export const hasChangeDataChanged = (state: StateIF): boolean => {
   return (
     hasBusinessNameChanged(state) ||
+    hasBusinessStartDateChanged(state) ||
     hasNaicsChanged(state) ||
     haveOfficeAddressesChanged(state) ||
     havePeopleAndRolesChanged(state)
@@ -488,6 +489,7 @@ export const hasChangeDataChanged = (state: StateIF): boolean => {
  */
 export const hasConversionDataChanged = (state: StateIF): boolean => {
   return (
+    hasBusinessStartDateChanged(state) ||
     hasNaicsChanged(state) ||
     haveOfficeAddressesChanged(state) ||
     havePeopleAndRolesChanged(state)

--- a/tests/unit/BusinessStartDate.spec.ts
+++ b/tests/unit/BusinessStartDate.spec.ts
@@ -17,35 +17,41 @@ localVue.use(VueRouter)
 const router: any = mockRouter.mock()
 const store: any = getVuexStore()
 
-describe('Start Date', () => {
+describe('Business Start Date', () => {
   let wrapper: any
-
-  const correctionInformation = {
-    comment: 'Test',
-    correctedFilingId: 1,
-    correctedFilingDate: '2021-01-01T00:00:00.000000+00:00',
-    correctedFilingType: 'correction',
-    type: 'STAFF',
-    startDate: ''
-  }
 
   beforeEach(async () => {
     store.state.stateModel.businessInformation.foundingDate = '2021-07-01T00:00:00.000000+00:00'
+    store.state.stateModel.tombstone.entityType = 'SP'
     wrapper = mount(BusinessStartDate, { store, vuetify, localVue, router })
     await flushPromises()
   })
 
-  it('render the component correctly for change filings', async () => {
-    store.state.stateModel.tombstone.filingType = 'change'
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('render the component correctly for firm change filings', async () => {
+    store.state.stateModel.tombstone.filingType = 'changeOfRegistration'
     await router.push({ name: 'change' })
     await Vue.nextTick()
 
     expect(wrapper.find('.pr-2').text()).toBe('Business Start Date')
     expect(wrapper.find('.info-text').text()).toBe('Unknown')
-    expect(wrapper.find('#start-changes-btn').exists()).toBe(false)
+    expect(wrapper.find('#start-changes-btn').text()).toBe('Change')
   })
 
-  it('renders the component correctly for correction filings', async () => {
+  it('render the component correctly for firm conversion filings', async () => {
+    store.state.stateModel.tombstone.filingType = 'conversion'
+    await router.push({ name: 'conversion' })
+    await Vue.nextTick()
+
+    expect(wrapper.find('.pr-2').text()).toBe('Business Start Date')
+    expect(wrapper.find('.info-text').text()).toBe('Unknown')
+    expect(wrapper.find('#start-changes-btn').text()).toBe('Change')
+  })
+
+  it('renders the component correctly for firm correction filings', async () => {
     store.state.stateModel.tombstone.filingType = 'correction'
     await router.push({ name: 'correction' })
     await Vue.nextTick()
@@ -76,9 +82,5 @@ describe('Start Date', () => {
 
     expect(wrapper.find('.v-chip__content').text()).toBe('Corrected')
     expect(wrapper.find('#start-undo-btn').text()).toBe('Undo')
-  })
-
-  afterEach(() => {
-    wrapper.destroy()
   })
 })

--- a/tests/unit/OfficeAddresses.spec.ts
+++ b/tests/unit/OfficeAddresses.spec.ts
@@ -241,7 +241,7 @@ describe('summary mode', () => {
     await moreBtn.trigger('click')
 
     const correctBtn = actions.find('.more-actions #btn-more-actions-edit')
-    expect(correctBtn.find('span').text()).toBe('Correct')
+    expect(correctBtn.find('span').text()).toBe('Change')
 
     wrapper.destroy()
   })


### PR DESCRIPTION
*Issue #:* bcgov/entity#12571 and bcgov/entity#13510

*Description of changes:*
- changed dropdown edit labels to "Change"
- removed obsolete tooltip
- passed in props to shared date picker
- applied Business Start Date to firm change and firm conversion filings
- passed in props to shared nature of business
- added business start date changed to getters
- added start date to change interface
- added start date to change and conversion filing build methods
- added start date to change and conversion filing parse methods
- misc cleanup
- imported updated nature-of-business
- fixed some unit tests
- app version = 3.7.5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).