### PR TITLE
13872 Don't allow change of Business Start Date in change filing + misc validation fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.8.6",
+      "version": "3.8.7",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Conversion/ConversionNOB.vue
+++ b/src/components/Conversion/ConversionNOB.vue
@@ -49,14 +49,14 @@
         <div v-if="!onEditMode" class="d-flex justify-space-between align-start">
           <span id="naics-summary">{{ naicsSummary }}</span>
 
-          <div v-if="!hasNaicsChanged" class="mt-n2 mr-n3">
+          <div v-if="!hasNaicsChanged" class="my-n2 mr-n3">
             <v-btn text color="primary" id="nob-change-btn" @click="onChangeClicked()">
               <v-icon small>mdi-pencil</v-icon>
               <span>{{ editLabel }}</span>
             </v-btn>
           </div>
 
-          <div v-else id="nob-more-actions" class="mt-n2 mr-n3">
+          <div v-else id="nob-more-actions" class="my-n2 mr-n3">
             <v-btn text color="primary" id="nob-undo-btn" @click="onUndoClicked()">
               <v-icon small>mdi-undo</v-icon>
               <span>Undo</span>

--- a/src/components/common/YourCompany/BusinessStartDate.vue
+++ b/src/components/common/YourCompany/BusinessStartDate.vue
@@ -59,7 +59,7 @@
         </template>
 
         <!-- outer buttons -->
-        <span v-if="isApplicableFiling" class="mt-n2 mr-n3 float-right">
+        <span v-if="isApplicableFiling" class="my-n2 mr-n3 float-right">
           <!-- Correct Changes button -->
           <v-btn v-if="!onEditMode && !isCorrected" text color="primary"
             id="start-changes-btn" @click="onChangeClicked()"
@@ -126,11 +126,12 @@ export default class StartDate extends Mixins(CommonMixin, DateMixin) {
 
   protected dropdown = false
   protected onEditMode = false
-  protected isCorrected = null
+  protected isCorrected: boolean = null
   protected newCorrectedStartDate: string = null // date is "Month Day, Year"
 
   get isApplicableFiling (): boolean {
-    return (this.isFirmCorrectionFiling || this.isFirmChangeFiling || this.isFirmConversionFiling)
+    // can change Business Start Date in firm corrections and firm conversions only
+    return (this.isFirmCorrectionFiling || this.isFirmConversionFiling)
   }
 
   /** The minimum start date that can be entered (up to 2 years before reg date). */
@@ -155,23 +156,20 @@ export default class StartDate extends Mixins(CommonMixin, DateMixin) {
 
   /** The business date or business start date string. */
   get businessStartDate (): string {
-    // safety check
-    if (this.isApplicableFiling) {
-      if (this.hasBusinessStartDateChanged) {
-        // set the Corrected flag when reloading from a saved filing
-        this.isCorrected = true
-        return this.yyyyMmDdToPacificDate(this.getCorrectionStartDate, true)
-      }
-      if (this.getBusinessStartDate) {
-        return this.yyyyMmDdToPacificDate(this.getBusinessStartDate, true)
-      }
+    if (this.hasBusinessStartDateChanged) {
+      // set the Corrected flag when reloading from a saved filing
+      this.isCorrected = true
+      return this.yyyyMmDdToPacificDate(this.getCorrectionStartDate, true)
+    }
+    if (this.getBusinessStartDate) {
+      return this.yyyyMmDdToPacificDate(this.getBusinessStartDate, true)
     }
     return '(Not entered)'
   }
 
   /** Whether this component is valid. */
   get isValid (): boolean {
-    return (!this.onEditMode && !!this.getCorrectionStartDate)
+    return (!this.onEditMode && (!!this.getCorrectionStartDate || !!this.getBusinessStartDate))
   }
 
   protected onChangeClicked (): void {

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -84,7 +84,7 @@
           </v-col>
 
           <!-- Actions -->
-          <v-col cols="2" class="mt-n2">
+          <v-col cols="2" class="my-n2">
             <div class="actions mr-4">
               <!-- FUTURE: only show buttons for named company -->
               <v-btn
@@ -629,5 +629,4 @@ export default class YourCompany extends Mixins(
 #contact-info-section {
   border-bottom-left-radius: 0 !important;
 }
-
 </style>

--- a/src/interfaces/stepper-interfaces/PeopleAndRoles/org-person-interface.ts
+++ b/src/interfaces/stepper-interfaces/PeopleAndRoles/org-person-interface.ts
@@ -10,6 +10,7 @@ export interface ApiPersonIF {
   organizationName?: string // required when partyType="organization"
   email?: string
   identifier?: string // aka Incorporation/Registration number
+  taxId?: string
 }
 
 export interface OrgPersonIF {

--- a/src/interfaces/store-interfaces/state-interfaces/flags-company-info-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/flags-company-info-interface.ts
@@ -8,6 +8,7 @@ export interface FlagsCompanyInfoIF {
   isValidCompanyName: boolean
   isValidBusinessType: boolean
   isValidNameTranslation: boolean
+  isValidStartDate: boolean
   isValidNatureOfBusiness: boolean
   isValidAddress: boolean
   isValidContactInfo: boolean
@@ -16,7 +17,6 @@ export interface FlagsCompanyInfoIF {
   isValidShareStructure: boolean
   isValidCompanyProvisions: boolean
   isValidResolutionDate: boolean
-  isValidStartDate: boolean
   isValidAssociationType: boolean
   isValidCreateSpecialResolution: boolean
 }

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -746,11 +746,14 @@ export const havePeopleAndRolesChanged = (state: StateIF): boolean => {
       if (!op.deliveryAddress.deliveryInstructions) op.deliveryAddress.deliveryInstructions = ''
       if (!op.deliveryAddress.streetAddressAdditional) op.deliveryAddress.streetAddressAdditional = ''
     }
+
     if (op.mailingAddress) {
       if (!op.mailingAddress.deliveryInstructions) op.mailingAddress.deliveryInstructions = ''
       if (!op.mailingAddress.streetAddressAdditional) op.mailingAddress.streetAddressAdditional = ''
     }
+
     if (!op.officer.email) op.officer.email = null
+    if (!op.officer.taxId) op.officer.taxId = null
 
     if (op.officer.partyType === PartyTypes.ORGANIZATION) {
       if (!op.officer.identifier) op.officer.identifier = null

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -38,6 +38,7 @@ export const stateModel: StateModelIF = {
       isValidCompanyName: true,
       isValidBusinessType: true,
       isValidNameTranslation: true,
+      isValidStartDate: true,
       isValidNatureOfBusiness: true,
       isValidAddress: true,
       isValidContactInfo: true,
@@ -46,7 +47,6 @@ export const stateModel: StateModelIF = {
       isValidShareStructure: true,
       isValidCompanyProvisions: true,
       isValidResolutionDate: true,
-      isValidStartDate: true,
       isValidAssociationType: true,
       isValidCreateSpecialResolution: true
     },

--- a/tests/unit/BusinessStartDate.spec.ts
+++ b/tests/unit/BusinessStartDate.spec.ts
@@ -31,17 +31,17 @@ describe('Business Start Date', () => {
     wrapper.destroy()
   })
 
-  it('render the component correctly for firm change filings', async () => {
+  it('renders the component correctly for firm change filings', async () => {
     store.state.stateModel.tombstone.filingType = 'changeOfRegistration'
     await router.push({ name: 'change' })
     await Vue.nextTick()
 
     expect(wrapper.find('.pr-2').text()).toBe('Business Start Date')
     expect(wrapper.find('.info-text').text()).toBe('(Not entered)')
-    expect(wrapper.find('#start-changes-btn').text()).toBe('Change')
+    expect(wrapper.find('#start-changes-btn').exists()).toBe(false)
   })
 
-  it('render the component correctly for firm conversion filings', async () => {
+  it('renders the component correctly for firm conversion filings', async () => {
     store.state.stateModel.tombstone.filingType = 'conversion'
     await router.push({ name: 'conversion' })
     await Vue.nextTick()


### PR DESCRIPTION
*Issue #:* bcgov/entity#13872

*Description of changes:*
- fixed whitespace around some action buttons
- disabled Business Start Date for firm change filings
- fixed Business Start Date initial validity for corrections
- fixed Business Start Date validity for conversions (flags out of order)
- normalize taxId to prevent false positives
- app version = 3.8.7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).