### PR TITLE
13896 Pages should gray out after clicking Save and Resume Later and File Now, to avoid multiple clicks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.8.13",
+  "version": "3.8.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.8.13",
+      "version": "3.8.14",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.8.13",
+  "version": "3.8.14",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -825,10 +825,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
         const error = new Error('Missing Payment Token or Filing ID')
         this.$root.$emit('save-error-event', error)
       }
-      this.setIsFilingPaying(false)
     }
-
-    this.setIsSaving(false)
   }
 }
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -801,6 +801,8 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
 
     // if filing is not a draft, proceed with payment
     if (!isDraft && filingComplete) {
+      // If Saving or Filing is successful then setIsFilingPaying should't be reset to false,
+      // this prevent buttons from being re-enabled if the page is slow to redirect.
       this.setIsFilingPaying(true)
       const paymentToken = filingComplete.header?.paymentToken
       const filingId = filingComplete.header?.filingId

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -117,6 +117,8 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
   protected async onClickSaveResume (): Promise<void> {
     // prevent double saving
     if (this.isBusySaving) return
+    // If Save and Resume is successful setIsSavingResuming should't be reset to false,
+    // this prevent buttons from being re-enabled if the page is slow to redirect.
     this.setIsSavingResuming(true)
 
     try {

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -130,7 +130,6 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
       return
     }
 
-    this.setIsSavingResuming(false)
     this.$root.$emit('go-to-dashboard')
   }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13896

*Description of changes:*

Note to consistently see this error you have to set throttling in dev tools

 - Upon clicking Save and Resume and File Now removed setSaving to false because if the page is slow to redirect then the buttons become reenabled.
 - App version = 3.8.13 -> 3.8.14
 - Replated PR [Create UI](https://github.com/bcgov/business-create-ui/pull/463)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
