### PR TITLE
13345 Fix name translation length + UI fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.8.20",
+  "version": "3.8.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.8.20",
+      "version": "3.8.21",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.8.20",
+  "version": "3.8.21",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/assets/styles/base.scss
+++ b/src/assets/styles/base.scss
@@ -324,6 +324,10 @@ ul.list {
   background-color: white !important;
 }
 
+.gray-background {
+  background-color: $gray1 !important;
+}
+
 // Hides an element to all devices except screen readers
 .sr-only {
   position: absolute;

--- a/src/components/common/YourCompany/NameTranslations/AddNameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/AddNameTranslation.vue
@@ -6,46 +6,39 @@
     />
     <!-- Name Translation form -->
     <v-form v-model="nameTranslationForm" ref="nameTranslationForm" class="name-translation-form">
-      <v-row>
-        <v-col class="pb-0">
-          <v-text-field
-            filled
-            persistent-hint
-            label="Name Translation"
-            id="name-translation-input"
-            v-model="nameTranslation"
-            :rules="nameTranslationRules"
-          />
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <div class="action-btns">
-            <v-btn v-if="!isAddingTranslation"
-              large outlined color="error"
-              id="name-translation-remove"
-              @click="emitRemoveName(nameIndex)"
-            >
-              <span>Remove</span>
-            </v-btn>
-            <v-btn
-              large color="primary" class="ml-auto"
-              id="name-translation-btn-ok"
-              @click="validateAddTranslation()"
-            >
-                Done
-            </v-btn>
-            <v-btn
-              large outlined color="primary"
-              id="name-translation-btn-cancel"
-              @click="cancelNameTranslation()"
-            >
-              <span v-if="isAddingTranslation">Cancel New Name</span>
-              <span v-else>Cancel</span>
-            </v-btn>
-          </div>
-        </v-col>
-      </v-row>
+      <v-text-field
+        filled
+        persistent-hint
+        id="name-translation-input"
+        label="Name Translation"
+        v-model="nameTranslation"
+        :rules="nameTranslationRules"
+      />
+
+      <div class="action-btns">
+        <v-btn v-if="!isAddingTranslation"
+          large outlined color="error"
+          id="name-translation-remove"
+          @click="removeTranslation(nameIndex)"
+        >
+          <span>Remove</span>
+        </v-btn>
+        <v-btn
+          large color="primary" class="ml-auto"
+          id="name-translation-btn-ok"
+          @click="validateAddTranslation()"
+        >
+            Done
+        </v-btn>
+        <v-btn
+          large outlined color="primary"
+          id="name-translation-btn-cancel"
+          @click="cancelNameTranslation()"
+        >
+          <span v-if="isAddingTranslation">Cancel New Name</span>
+          <span v-else>Cancel</span>
+        </v-btn>
+      </div>
     </v-form>
   </div>
 </template>
@@ -70,19 +63,18 @@ export default class AddNameTranslation extends Mixins(CommonMixin) {
   }
 
   @Prop({ default: '' }) readonly editNameTranslation!: string
-
   @Prop({ default: -1 }) readonly editNameIndex!: number
 
-  // Local Properties
+  // Local properties
   protected nameTranslationForm = false
   protected nameTranslation = ''
   protected nameIndex = -1
 
-  // Validation Rules
+  // Validation rules
   readonly nameTranslationRules: Array<VuetifyRuleFunction> = [
     (v: string) => !!v || 'A name translation is required', // is not empty
     (v: string) => /^[A-Za-zÀ-ÿ_@./#’&+-]+(?: [A-Za-zÀ-ÿ_@./#’&+-]+)*$/.test(v) || 'Invalid character', // English, French and single spaces
-    (v: string) => (!v || v.length <= 150) || 'Cannot exceed 150 characters' // maximum character count
+    (v: string) => (!v || v.length <= 50) || 'Cannot exceed 50 characters' // maximum character count
   ]
 
   /** Called when component is mounted. */
@@ -117,72 +109,66 @@ export default class AddNameTranslation extends Mixins(CommonMixin) {
       }
     ).then(async (confirm) => {
       if (confirm) {
-        this.addTranslation()
+        this.addTranslation(this.nameTranslation)
       }
     }).catch(() => {
       this.cancelTranslation()
     })
   }
 
-  /**
-   * Returns True if we are adding, False if editing.
-   */
+  /** Is True if we are adding, or False if editing. */
   get isAddingTranslation (): boolean {
     return (this.editNameTranslation === '')
   }
 
-  /**
-   * Trigger validation before add in case of blank name.
-   */
+  /** Triggers validation before add in case of blank name. */
   protected validateAddTranslation (): void {
     if (this.$refs.nameTranslationForm.validate()) {
-      this.addTranslation()
+      this.addTranslation(this.nameTranslation)
     }
   }
 
-  // Events
+  /**
+   * Emits an event with a string to the parent to handle addition.
+   * @param translation the name to add
+   */
   @Emit('addTranslation')
-  private addTranslation (): string {
-    return this.nameTranslation
-  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private addTranslation (translation: string): void {}
 
+  /** Emits an event to the parent to handle cancellation. */
   @Emit('cancelTranslation')
   private cancelTranslation (): void {}
 
   /**
-   * Emit an index and event to the parent to handle removal.
-   * @param index The active index which is subject to removal.
+   * Emit an event with an index to the parent to handle removal.
+   * @param index the index of the item to remove
    */
-  @Emit('removeNameTranslation')
+  @Emit('removeTranslation')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected emitRemoveName (index: number): void {}
+  protected removeTranslation (index: number): void {}
 }
 </script>
 
 <style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
 
-.name-translation-form {
-  padding-right: 0.5rem;
+.action-btns {
+  display: flex;
 
-  .action-btns {
-    display: flex;
-    justify-content: flex-end;
-    padding-bottom: 1rem;
+  .v-btn {
+    margin: 0;
+    min-width: 6.5rem;
 
-    .v-btn + .v-btn {
+    + .v-btn {
       margin-left: 0.5rem;
     }
+  }
 
-    .v-btn {
-      min-width: 6.5rem;
-    }
-
-    .v-btn[disabled] {
-      color: white !important;
-      background-color: $app-blue !important;
-      opacity: 0.2;
-    }
+  .v-btn[disabled] {
+    color: white !important;
+    background-color: $app-blue !important;
+    opacity: 0.2;
   }
 }
 

--- a/src/components/common/YourCompany/NameTranslations/ListNameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/ListNameTranslation.vue
@@ -1,118 +1,134 @@
 <template>
-  <v-card flat id="name-translations-list" :style="{opacity: isAddingNameTranslation ? '0.4' : '1.0'}">
-      <!-- List Headers -->
-      <v-row class="name-translation-title list-item__subtitle" no-gutters>
-        <v-col>
-          <h3>Name Translations</h3>
-        </v-col>
-      </v-row>
+  <v-card flat id="list-name-translations" :style="{opacity: isAddingNameTranslation ? '0.4' : '1.0'}">
+    <!-- List Headers -->
+    <v-row class="name-translation-title list-item__subtitle" no-gutters>
+      <v-col>
+        <h3>Name Translations</h3>
+      </v-col>
+    </v-row>
 
-      <!-- List Content -->
-      <v-row
-        class="names-translation-content"
-        v-for="(translation, index) in translationList"
-        :key="`name_translation_${index}`"
-        no-gutters>
-        <v-col class="text-truncate">
-         <span class="name-title text-uppercase">{{translation.name}}</span>
+    <!-- List Content -->
+    <v-row
+      class="names-translation-content gray-background"
+      v-for="(translation, index) in translationsList"
+      :key="`name_translation_${index}`"
+      no-gutters
+    >
+      <v-col class="text-truncate">
+        <span class="name-title text-uppercase">{{translation.name}}</span>
 
-        <br v-if="translation.action">
+        <br v-if="!!translation.action">
+
         <v-chip v-if="translation.action === ActionTypes.ADDED"
-          x-small label color="primary" text-color="white">ADDED</v-chip>
+          x-small label color="primary" text-color="white"
+        >
+          <span>ADDED</span>
+        </v-chip>
+
         <v-chip v-if="translation.action === ActionTypes.EDITED"
-          x-small label color="primary" text-color="white">
+          x-small label color="primary" text-color="white"
+        >
           <span v-if="isCorrectionFiling">CORRECTED</span>
           <span v-else>CHANGED</span>
         </v-chip>
-        <v-chip v-if="translation.action === ActionTypes.REMOVED"
-          x-small label color="grey lighten-2" text-color="grey darken-4">REMOVED</v-chip>
-        </v-col>
 
-        <!-- Actions Column -->
-        <v-col v-if="translation.action === ActionTypes.EDITED || translation.action === ActionTypes.REMOVED">
-          <div class="actions">
-            <span class="edit-action">
+        <v-chip v-if="translation.action === ActionTypes.REMOVED"
+          x-small label color="grey lighten-2" text-color="grey darken-4"
+        >
+          <span>REMOVED</span>
+        </v-chip>
+      </v-col>
+
+      <!-- Actions Column - Edited or Removed-->
+      <v-col v-if="translation.action === ActionTypes.EDITED || translation.action === ActionTypes.REMOVED">
+        <!--  -->
+        <div class="actions mt-n1 float-right">
+          <span class="edit-action">
+            <v-btn
+              text small
+              color="primary"
+              :disabled="isAddingNameTranslation"
+              @click="undoTranslation(index)"
+            >
+              <v-icon small>mdi-undo</v-icon>
+              <span>Undo</span>
+            </v-btn>
+          </span>
+
+          <!-- more actions menu -->
+          <template v-if="translation.action !== ActionTypes.REMOVED">
+            <v-menu offset-y>
+              <template v-slot:activator="{ on }">
+                <v-btn
+                  text color="primary"
+                  class="more-actions-btn"
+                  v-on="on"
+                  :disabled="isAddingNameTranslation"
+                >
+                  <v-icon>mdi-menu-down</v-icon>
+                </v-btn>
+              </template>
+
+              <v-list class="more-actions-list">
+                <v-list-item @click="editTranslation(index)">
+                  <v-list-item-title>
+                    <v-icon small>mdi-pencil</v-icon>
+                    <span class="ml-2">Correct</span>
+                  </v-list-item-title>
+                </v-list-item>
+
+                <v-list-item @click="removeTranslation(index)">
+                  <v-list-item-title>
+                    <v-icon small>mdi-delete</v-icon>
+                    <span class="ml-2">Remove</span>
+                  </v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+          </template>
+        </div>
+      </v-col>
+
+      <!-- Actions Column - Not Edited or Removed -->
+      <v-col v-else class="col-auto">
+        <div class="actions mt-n1 float-right">
+          <span class="edit-action">
+            <v-btn
+              text small
+              color="primary"
+              :disabled="isAddingNameTranslation"
+              @click="editTranslation(index)"
+            >
+              <v-icon small>mdi-pencil</v-icon>
+              <span>Change</span>
+            </v-btn>
+          </span>
+
+          <!-- more actions menu -->
+          <v-menu offset-y>
+            <template v-slot:activator="{ on }">
               <v-btn
-                text
-                color="primary"
+                text color="primary"
+                class="more-actions-btn"
+                v-on="on"
                 :disabled="isAddingNameTranslation"
-                @click="emitNameUndo(index)">
-                  <v-icon small>mdi-undo</v-icon>
-                  <span>Undo</span>
-              </v-btn>
-            </span>
-            <!-- more actions menu -->
-            <span class="actions__more" v-if="translation.action !== ActionTypes.REMOVED">
-              <v-menu offset-y left nudge-bottom="4">
-                <template v-slot:activator="{ on }">
-                  <v-btn
-                    text
-                    small
-                    v-on="on"
-                    color="primary"
-                    class="actions__more-actions__btn"
-                    :disabled="isAddingNameTranslation">
-                    <v-icon>mdi-menu-down</v-icon>
-                  </v-btn>
-                </template>
-                <v-list class="actions__more-actions">
-                  <v-list-item  @click="emitNameEdit(index)">
-                    <v-list-item-subtitle>
-                      <v-icon small>mdi-pencil</v-icon>
-                      <span class="ml-1">Correct</span>
-                    </v-list-item-subtitle>
-                  </v-list-item>
-                  <v-list-item  @click="emitRemoveName(index)">
-                    <v-list-item-subtitle>
-                      <v-icon small>mdi-delete</v-icon>
-                      <span class="ml-1">Remove</span>
-                    </v-list-item-subtitle>
-                  </v-list-item>
-                </v-list>
-              </v-menu>
-            </span>
-          </div>
-        </v-col>
-        <v-col v-else>
-          <div class="actions">
-            <span class="edit-action">
-              <v-btn
-                text
-                color="primary"
-                :disabled="isAddingNameTranslation"
-                @click="emitNameEdit(index)"
               >
-                  <v-icon small>mdi-pencil</v-icon>
-                  <span>Change</span>
+                <v-icon>mdi-menu-down</v-icon>
               </v-btn>
-            </span>
-            <!-- more actions menu -->
-            <span class="actions__more mr-4">
-              <v-menu offset-y left nudge-bottom="4">
-                <template v-slot:activator="{ on }">
-                  <v-btn
-                    text
-                    small
-                    v-on="on"
-                    color="primary"
-                    class="actions__more-actions__btn"
-                    :disabled="isAddingNameTranslation">
-                    <v-icon>mdi-menu-down</v-icon>
-                  </v-btn>
-                </template>
-                <v-list class="actions__more-actions">
-                  <v-list-item  @click="emitRemoveName(index)">
-                    <v-list-item-subtitle>
-                      <v-icon small>mdi-delete</v-icon>
-                      <span class="ml-1">Remove</span>
-                    </v-list-item-subtitle>
-                  </v-list-item>
-                </v-list>
-              </v-menu>
-            </span>
-          </div>
-        </v-col>
-      </v-row>
+            </template>
+
+            <v-list class="more-actions-list">
+              <v-list-item @click="removeTranslation(index)">
+                <v-list-item-title>
+                  <v-icon small>mdi-delete</v-icon>
+                  <span class="ml-2">Remove</span>
+                </v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </div>
+      </v-col>
+    </v-row>
   </v-card>
 </template>
 
@@ -124,8 +140,7 @@ import { CommonMixin } from '@/mixins/'
 
 @Component({})
 export default class ListNameTranslation extends Mixins(CommonMixin) {
-  @Prop({ default: () => [] }) readonly translationList!: NameTranslationIF[]
-
+  @Prop({ default: () => [] }) readonly translationsList!: NameTranslationIF[]
   @Prop({ default: false }) readonly isAddingNameTranslation!: boolean
 
   // Declaration for template
@@ -135,83 +150,79 @@ export default class ListNameTranslation extends Mixins(CommonMixin) {
    * Emit an index and event to the parent to handle editing.
    * @param index The active index which is subject to change.
    */
-  @Emit('editNameTranslation')
+  @Emit('editTranslation')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private emitNameEdit (index: number): void {}
+  protected editTranslation (index: number): void {}
 
   /**
    * Emit an index and event to the parent to handle undo.
    * @param index The active index which is subject to undo.
    */
-  @Emit('nameUndo')
+  @Emit('undoTranslation')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private emitNameUndo (index: number): void {}
+  protected undoTranslation (index: number): void {}
 
   /**
    * Emit an index and event to the parent to handle removal.
    * @param index The active index which is subject to removal.
    */
-  @Emit('removeNameTranslation')
+  @Emit('removeTranslation')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private emitRemoveName (index: number): void {}
+  protected removeTranslation (index: number): void {}
 }
 </script>
 
 <style lang="scss" scoped>
-  @import '@/assets/styles/theme.scss';
+@import '@/assets/styles/theme.scss';
 
-  #name-translations-list {
-    padding-right: 0.5rem;
+.name-translation-title {
+  background-color: $BCgovBlue5O;
+  padding: 0.5rem 1.25rem;
+  font-size: $px-14;
+}
 
-    .name-translation-title {
-      display: flex;
-      background-color: $BCgovBlue5O;
-      padding: .5rem 1.25rem .5rem 1.25rem;
-      font-size: $px-14;
-      margin-top: 1rem;
+.names-translation-content {
+  padding: 0.5rem 1.25rem;
+  border-top: 1px solid $gray4;
+  font-size: $px-14;
+
+  .name-title {
+    color: $gray7;
+  }
+
+  .actions {
+    .edit-action {
+      border-right: 1px solid $gray4;
     }
 
-    .names-translation-content {
-      padding: .5rem 1.25rem .5rem 1.25rem;
-      border-top: 1px solid $gray1;
+    .v-btn + .v-btn {
+      margin-left: 0.5rem;
+    }
 
-      .name-title {
-        color: $gray7;
-      }
-
-      .actions {
-        position: absolute;
-        margin-top: -0.5rem;
-        right: 0;
-
-        .actions__more {
-          border-left: 1px solid $gray1;
-        }
-
-        .v-btn {
-          min-width: .5rem;
-        }
-
-        .v-btn + .v-btn {
-          margin-left: 0.5rem;
-        }
-
-        .actions__more-actions__btn {
-          margin-right: 0.5rem;
-        }
-      }
+    .more-actions-btn {
+      padding: 0;
+      min-width: 28px;
     }
   }
+}
 
-  .v-list-item {
-    min-height: 0;
-    padding: 0.5rem 1rem;
-  }
-  .v-list-item__subtitle {
-  color: $app-blue !important;
+// style the more actions buttons
+.v-list-item {
+  min-height: 0;
+  padding: 0.5rem 1rem;
 
-  .v-icon {
-    color: $app-blue !important;
+  .v-list-item__title {
+    color: $app-blue;
+    font-size: $px-14;
   }
+}
+
+.v-icon {
+      color: $app-blue !important;
+    }
+
+// move icon up a bit to line up with text
+.v-icon.mdi-delete {
+  margin-top: -2px;
 }
 </style>

--- a/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
@@ -5,6 +5,7 @@
       attach="#name-translation"
     />
 
+    <!-- Summary mode -->
     <v-row no-gutters v-if="!isEditing">
       <v-col cols="3" class="pr-2">
         <label><strong>Name Translation(s)</strong></label>
@@ -14,9 +15,15 @@
           :editedLabel="editedLabel"
         />
       </v-col>
+
       <v-col cols="7" v-if="draftTranslations && translationsExceptRemoved.length">
-        <div class="info-text text-uppercase" v-for="(translation, index) in translationsExceptRemoved"
-          :key="`name_translation_${index}`">{{ translation.name }}</div>
+        <div
+          v-for="(translation, index) in translationsExceptRemoved"
+          class="info-text text-uppercase"
+          :key="`name_translation_${index}`"
+        >
+          {{ translation.name }}
+        </div>
       </v-col>
       <v-col cols="7" class="info-text" v-else>
         No name translations
@@ -35,12 +42,13 @@
           </v-btn>
         </div>
       </v-col>
+
       <v-col cols="2" class="mt-n2" v-else-if="hasNameTranslationChange && !isSummaryMode">
         <div class="actions mr-4">
           <v-btn
             class="undo-name-translation"
             text color="primary"
-            @click="resetNameTranslations()"
+            @click="undoNameTranslations()"
           >
             <v-icon small>mdi-undo</v-icon>
             <span>Undo</span>
@@ -51,22 +59,22 @@
             <v-menu offset-y left nudge-bottom="4">
               <template v-slot:activator="{ on }">
                 <v-btn
-                  text small color="primary"
+                  text color="primary"
                   class="more-actions-btn"
                   v-on="on"
                 >
                   <v-icon>mdi-menu-down</v-icon>
                 </v-btn>
               </template>
-              <v-list class="actions__more-actions">
+              <v-list class="more-actions-list">
                 <v-list-item
                   class="actions-dropdown_item"
                   @click="isEditing = true"
                 >
-                  <v-list-item-subtitle>
+                  <v-list-item-title>
                     <v-icon small>mdi-pencil</v-icon>
-                    <span class="ml-1">Change</span>
-                  </v-list-item-subtitle>
+                    <span class="ml-2">Change</span>
+                  </v-list-item-title>
                 </v-list-item>
               </v-list>
             </v-menu>
@@ -75,62 +83,69 @@
       </v-col>
     </v-row>
 
+    <!-- Edit mode -->
     <v-row no-gutters v-else>
       <v-col cols="3">
         <label :class="{'error-text': invalidSection}"><strong>Name Translation(s)</strong></label>
       </v-col>
+
       <v-col cols="9">
-        <v-row no-gutters>
-          <v-col>
-            <p>Name translations must use the Latin Alphabet (English, French, etc.).
-              Names that use other writing systems must spell the name phonetically in English or French.
-            </p>
-            <v-btn outlined color="primary" @click="isAddingNameTranslation=true" :disabled="isAddingNameTranslation">
-              <v-icon>mdi-plus</v-icon>
-              <span>Add Name Translation</span>
-            </v-btn>
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-col>
+        <!-- Indented section -->
+        <div class="pr-2">
+          <p class="mb-0">
+            Name translations must use the Latin Alphabet (English, French, etc.).
+            Names that use other writing systems must spell the name phonetically in English or French.
+          </p>
+
+          <v-btn
+            outlined color="primary"
+            class="mt-6"
+            @click="isAddingNameTranslation=true"
+            :disabled="isAddingNameTranslation"
+          >
+            <v-icon>mdi-plus</v-icon>
+            <span>Add Name Translation</span>
+          </v-btn>
+
+          <!-- Add Name Translation component -->
+          <div v-if="isAddingNameTranslation" class="mt-6">
             <AddNameTranslation
-              v-if="isAddingNameTranslation"
-              :editNameTranslation="editingNameTranslation"
+              :editTranslation="editingNameTranslation"
               :editNameIndex="editIndex"
-              @addTranslation="addName($event)"
-              @removeNameTranslation="removeNameTranslation($event)"
-              @cancelTranslation="cancelOrResetEditing()"
+              @addTranslation="addTranslation($event)"
+              @removeTranslation="removeTranslation($event)"
+              @cancelTranslation="cancelTranslation()"
             />
+          </div>
+
+          <!-- List Name Translation component -->
+          <div v-if="draftTranslations && draftTranslations.length > 0" class="mt-6">
             <ListNameTranslation
-              v-if="draftTranslations && draftTranslations.length > 0"
               :isAddingNameTranslation="isAddingNameTranslation"
-              :translationList="draftTranslations"
-              @editNameTranslation="editNameTranslation($event)"
-              @removeNameTranslation="removeNameTranslation($event)"
-              @nameUndo="undoNameTranslation($event)"
+              :translationsList="draftTranslations"
+              @editTranslation="editTranslation($event)"
+              @removeTranslation="removeTranslation($event)"
+              @undoTranslation="undoTranslation($event)"
             />
-          </v-col>
-        </v-row>
-        <v-row pt-5>
-          <v-col cols="12">
-            <div class="action-btns">
-              <v-btn large color="primary"
-                id="name-translation-done"
-                :disabled="isAddingNameTranslation || !hasPendingChange"
-                @click="setNameTranslations()"
-              >
-                <span>Done</span>
-              </v-btn>
-              <v-btn large outlined color="primary"
-                id="name-translation-cancel"
-                @click="cancelNameTranslationCorrection()"
-                :disabled="isAddingNameTranslation"
-              >
-                <span>Cancel</span>
-              </v-btn>
-            </div>
-          </v-col>
-        </v-row>
+          </div>
+        </div>
+
+        <div class="action-btns mt-6">
+          <v-btn large color="primary"
+            id="name-translation-done"
+            :disabled="isAddingNameTranslation || !hasPendingChange"
+            @click="setNameTranslations()"
+          >
+            <span>Done</span>
+          </v-btn>
+          <v-btn large outlined color="primary"
+            id="name-translation-cancel"
+            @click="cancelNameTranslations()"
+            :disabled="isAddingNameTranslation"
+          >
+            <span>Cancel</span>
+          </v-btn>
+        </div>
       </v-col>
     </v-row>
   </div>
@@ -162,9 +177,7 @@ export default class NameTranslation extends Mixins(CommonMixin) {
   }
 
   @Prop({ default: false }) readonly invalidSection!: boolean
-
   @Prop({ default: () => [] }) readonly nameTranslations!: NameTranslationIF[]
-
   @Prop({ default: false }) readonly isSummaryMode!: boolean
 
   // Global action
@@ -175,7 +188,7 @@ export default class NameTranslation extends Mixins(CommonMixin) {
 
   // Local properties
   private draftTranslations: NameTranslationIF[] = []
-  private isEditing: boolean = false
+  private isEditing = false
   private isAddingNameTranslation = false
   private editingNameTranslation = ''
   private editIndex = -1
@@ -201,12 +214,12 @@ export default class NameTranslation extends Mixins(CommonMixin) {
     return this.draftTranslations.filter(x => x.action !== ActionTypes.REMOVED)
   }
 
-  private setNameTranslations (): void {
+  protected setNameTranslations (): void {
     this.emitNameTranslations(this.draftTranslations)
     this.isEditing = false
   }
 
-  private resetNameTranslations (): void {
+  protected undoNameTranslations (): void {
     this.draftTranslations = this.nameTranslations
       .filter(x => x.action !== ActionTypes.ADDED)
       .map(a => {
@@ -220,12 +233,13 @@ export default class NameTranslation extends Mixins(CommonMixin) {
     this.isEditing = false
   }
 
-  private cancelNameTranslationCorrection () {
+  protected cancelNameTranslations () {
     const nameTranslations = this.nameTranslations || []
     // Compare initial/draft translation with the modified translation to identify unsaved data
     // If length is different that means added or removed (a drafted one).
     // If any value is different that means undo or editted.
-    const hasUnsavedData = this.draftTranslations.length !== nameTranslations.length ||
+    const hasUnsavedData =
+      (this.draftTranslations.length !== nameTranslations.length) ||
       !this.draftTranslations.every((translation, index) => {
         return nameTranslations[index].name === translation.name &&
           nameTranslations[index].action === translation.action
@@ -259,11 +273,8 @@ export default class NameTranslation extends Mixins(CommonMixin) {
     })
   }
 
-  /** Add or update a name translation
-   *
-   * @param name The name to add
-   */
-  private addName (name: string): void {
+  /** Adds or updates the specified name translation. */
+  protected addTranslation (name: string): void {
     // Handle name translation adds or updates
     if (this.editIndex > -1) {
       const translation = this.draftTranslations[this.editIndex]
@@ -284,24 +295,18 @@ export default class NameTranslation extends Mixins(CommonMixin) {
       this.draftTranslations.push({ name: name, oldName: null, action: ActionTypes.ADDED })
     }
 
-    this.cancelOrResetEditing()
+    this.cancelTranslation()
   }
 
-  /** Pass an index of the name translation to be edited
-   *
-   * @param index Index number of the name translation to edit
-   */
-  private editNameTranslation (index: number): void {
+  /** Edits the specified name translation. */
+  protected editTranslation (index: number): void {
     this.editingNameTranslation = this.draftTranslations[index].name
     this.editIndex = index
     this.isAddingNameTranslation = true
   }
 
-  /** Remove a name translation
-   *
-   * @param index Index number of the name translation to remove
-   */
-  private removeNameTranslation (index: number): void {
+  /** Removes the specified name translation. */
+  protected removeTranslation (index: number): void {
     const translation = this.draftTranslations[index]
     if (translation.action === ActionTypes.ADDED) {
       this.draftTranslations.splice(index, 1)
@@ -312,17 +317,18 @@ export default class NameTranslation extends Mixins(CommonMixin) {
       }
       translation.action = ActionTypes.REMOVED
     }
-    this.cancelOrResetEditing()
+    this.cancelTranslation()
   }
 
-  /** Cancel adding or editing of name translation */
-  private cancelOrResetEditing (): void {
+  /** Cancels adding or editing the current name translation. */
+  protected cancelTranslation (): void {
     this.isAddingNameTranslation = false
     this.editingNameTranslation = ''
     this.editIndex = -1
   }
 
-  private undoNameTranslation (index: number): void {
+  /** Undoes change to the specified name translation. */
+  protected undoTranslation (index: number): void {
     const translation = this.draftTranslations[index]
     if (translation.action === ActionTypes.EDITED) {
       translation.name = translation.oldName
@@ -331,7 +337,7 @@ export default class NameTranslation extends Mixins(CommonMixin) {
     translation.action = null
   }
 
-  // Watchers
+  /** Updates local property initially and when prop has changed. */
   @Watch('nameTranslations', { deep: true, immediate: true })
   private onNameTranslationsPropValueChanged (): void {
     this.draftTranslations = this.nameTranslations ? cloneDeep(this.nameTranslations) : []
@@ -343,7 +349,6 @@ export default class NameTranslation extends Mixins(CommonMixin) {
     this.setEditingNameTranslations(val)
   }
 
-  // Emitters
   @Emit('nameTranslationsChange')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private emitNameTranslations (translations: NameTranslationIF[]): void {}
@@ -358,40 +363,37 @@ export default class NameTranslation extends Mixins(CommonMixin) {
 <style lang="scss" scoped>
   @import '@/assets/styles/theme.scss';
 
-  #name-translation {
-    .action-btns {
-      display: flex;
-      justify-content: flex-end;
-      padding-bottom: 1rem;
-      padding-right: 0.5rem;
+  .action-btns {
+    display: flex;
+    justify-content: flex-end;
 
-      .v-btn + .v-btn {
-        margin-left: 0.5rem;
-      }
-
-      .v-btn {
-        min-width: 6.5rem;
-      }
-
-      #name-translation-done[disabled] {
-        color: white !important;
-        background-color: $app-blue !important;
-        opacity: 0.2;
-      }
+    .v-btn + .v-btn {
+      margin-left: 0.5rem;
     }
 
-    .undo-name-translation {
-      border-right: 1px solid $gray1;
+    .v-btn {
+      min-width: 6.5rem;
     }
+
+    #name-translation-done[disabled] {
+      color: white !important;
+      background-color: $app-blue !important;
+      opacity: 0.2;
+    }
+  }
+
+  .undo-name-translation {
+    border-right: 1px solid $gray1;
   }
 
   .v-list-item {
     min-height: 0;
     padding: 0.5rem 1rem;
-  }
 
-  .v-list-item__subtitle {
-    color: $app-blue !important;
+    .v-list-item__title {
+      font-size: $px-14;
+      color: $app-blue;
+    }
   }
 
   .v-icon {

--- a/tests/unit/ListNameTranslations.spec.ts
+++ b/tests/unit/ListNameTranslations.spec.ts
@@ -6,7 +6,6 @@ import mockRouter from './MockRouter'
 import { getVuexStore } from '@/store/'
 import { createLocalVue, mount } from '@vue/test-utils'
 import ListNameTranslation from '@/components/common/YourCompany/NameTranslations/ListNameTranslation.vue'
-import flushPromises from 'flush-promises'
 import { NameTranslationIF } from '@/interfaces/store-interfaces/state-interfaces/name-translation-interface'
 
 Vue.use(Vuetify)
@@ -15,10 +14,6 @@ Vue.use(Vuelidate)
 const vuetify = new Vuetify({})
 const store = getVuexStore()
 document.body.setAttribute('data-app', 'true')
-
-function resetStore (): void {
-  store.state.stateModel.nameTranslations = []
-}
 
 // Local references
 const listNameTranslations = '#list-name-translations'
@@ -40,20 +35,21 @@ describe('List Name Translation component', () => {
     // Init Store
     store.state.stateModel.nameTranslations = []
 
-    wrapperFactory = (propsData: any) => {
-      return mount(ListNameTranslation, {
+    wrapperFactory = async (propsData: any) => {
+      const wrapper = mount(ListNameTranslation, {
         localVue,
         router,
         store,
         vuetify,
         propsData: { ...propsData }
       })
+      await Vue.nextTick()
+      return wrapper
     }
   })
 
   it('displays the list of name translations and action btns', async () => {
-    const wrapper = wrapperFactory({ translationList: nameTranslationsList })
-    await flushPromises()
+    const wrapper = await wrapperFactory({ translationsList: nameTranslationsList })
 
     // Verify list exists
     expect(wrapper.find(listNameTranslations).exists()).toBeTruthy()
@@ -83,8 +79,7 @@ describe('List Name Translation component', () => {
   })
 
   it('disables the edit and drop down btns when editing a name translation', async () => {
-    const wrapper = wrapperFactory({ translationList: nameTranslationsList, isAddingNameTranslation: true })
-    await Vue.nextTick()
+    const wrapper = await wrapperFactory({ translationsList: nameTranslationsList, isAddingNameTranslation: true })
 
     // Verify edit btn and default state
     expect(wrapper.find('.edit-action .v-btn').exists()).toBeTruthy()
@@ -102,8 +97,7 @@ describe('List Name Translation component', () => {
   })
 
   it('emits the correct name index when selected for edit', async () => {
-    const wrapper = wrapperFactory({ translationList: nameTranslationsList })
-    await Vue.nextTick()
+    const wrapper = await wrapperFactory({ translationsList: nameTranslationsList })
 
     const namesList = wrapper.vm.$el.querySelectorAll('.names-translation-content')
     expect(namesList[0].textContent).toContain(nameTranslationsList[0].name)
@@ -125,8 +119,7 @@ describe('List Name Translation component', () => {
   })
 
   it('emits the correct name index when selected for removal', async () => {
-    const wrapper = wrapperFactory({ translationList: nameTranslationsList })
-    await Vue.nextTick()
+    const wrapper = await wrapperFactory({ translationsList: nameTranslationsList })
 
     const namesList = wrapper.vm.$el.querySelectorAll('.names-translation-content')
     expect(namesList[0].textContent).toContain(nameTranslationsList[0].name)

--- a/tests/unit/ListNameTranslations.spec.ts
+++ b/tests/unit/ListNameTranslations.spec.ts
@@ -21,7 +21,7 @@ function resetStore (): void {
 }
 
 // Local references
-const nameTranslationsUi = '#name-translations-list'
+const listNameTranslations = '#list-name-translations'
 const nameTranslationsList: NameTranslationIF[] = [
   { name: 'First mock name translation ltd.' },
   { name: 'Second mock name translation inc' },
@@ -56,7 +56,7 @@ describe('List Name Translation component', () => {
     await flushPromises()
 
     // Verify list exists
-    expect(wrapper.find(nameTranslationsUi).exists()).toBeTruthy()
+    expect(wrapper.find(listNameTranslations).exists()).toBeTruthy()
 
     // Verify list title
     expect(wrapper.find('.name-translation-title').text()).toContain('Name Translations')
@@ -73,11 +73,11 @@ describe('List Name Translation component', () => {
     expect(wrapper.find('.edit-action .v-btn').attributes('disabled')).toBeUndefined()
 
     // Verify more actions drop down
-    expect(wrapper.find('.actions__more-actions__btn').exists()).toBeTruthy()
-    await wrapper.find('.actions__more-actions__btn').trigger('click')
+    expect(wrapper.find('.more-actions-btn').exists()).toBeTruthy()
+    await wrapper.find('.more-actions-btn').trigger('click')
 
     // Verify 'Remove' btn
-    expect(wrapper.find('.actions__more-actions').exists()).toBeTruthy()
+    expect(wrapper.find('.more-actions-list').exists()).toBeTruthy()
 
     wrapper.destroy()
   })
@@ -91,12 +91,12 @@ describe('List Name Translation component', () => {
     expect(wrapper.find('.edit-action .v-btn').attributes('disabled')).toBeTruthy()
 
     // Verify more actions drop down
-    expect(wrapper.find('.actions__more-actions__btn').exists()).toBeTruthy()
-    expect(wrapper.find('.actions__more-actions__btn').attributes('disabled')).toBeTruthy()
-    await wrapper.find('.actions__more-actions__btn').trigger('click')
+    expect(wrapper.find('.more-actions-btn').exists()).toBeTruthy()
+    expect(wrapper.find('.more-actions-btn').attributes('disabled')).toBeTruthy()
+    await wrapper.find('.more-actions-btn').trigger('click')
 
     // Verify 'Remove' btn
-    expect(wrapper.find('.actions__more-actions').exists()).toBeFalsy()
+    expect(wrapper.find('.more-actions-list').exists()).toBeFalsy()
 
     wrapper.destroy()
   })
@@ -115,11 +115,11 @@ describe('List Name Translation component', () => {
 
     // Select the first name to edit
     await editBtns.at(0).trigger('click')
-    expect(wrapper.emitted('editNameTranslation').pop()).toEqual([0])
+    expect(wrapper.emitted('editTranslation').pop()).toEqual([0])
 
     // Select the third name to edit
     await editBtns.at(2).trigger('click')
-    expect(wrapper.emitted('editNameTranslation').pop()).toEqual([2])
+    expect(wrapper.emitted('editTranslation').pop()).toEqual([2])
 
     wrapper.destroy()
   })
@@ -135,16 +135,16 @@ describe('List Name Translation component', () => {
     expect(namesList[3].textContent).toContain(nameTranslationsList[3].name)
 
     // Open the first list item dropdown
-    const actionsDropdown = wrapper.findAll('.actions__more-actions__btn')
+    const actionsDropdown = wrapper.findAll('.more-actions-btn')
     await actionsDropdown.at(0).trigger('click')
 
     // Select the first item for removal
-    const removeBtns = wrapper.findAll('.actions__more-actions .v-list-item')
+    const removeBtns = wrapper.findAll('.more-actions-list .v-list-item')
     expect(removeBtns.at(0).exists()).toBeTruthy()
     expect(removeBtns.at(0).attributes('disabled')).toBeUndefined()
     await removeBtns.at(0).trigger('click')
 
-    expect(wrapper.emitted('removeNameTranslation').pop()).toEqual([0])
+    expect(wrapper.emitted('removeTranslation').pop()).toEqual([0])
 
     wrapper.destroy()
   })

--- a/tests/unit/NameTranslation.spec.ts
+++ b/tests/unit/NameTranslation.spec.ts
@@ -5,7 +5,6 @@ import mockRouter from './MockRouter'
 import { getVuexStore } from '@/store/'
 import { createLocalVue, mount } from '@vue/test-utils'
 import NameTranslation from '@/components/common/YourCompany/NameTranslations/NameTranslation.vue'
-import flushPromises from 'flush-promises'
 
 Vue.use(Vuetify)
 
@@ -42,20 +41,21 @@ describe('Name Translation component', () => {
     // Init Store
     store.state.stateModel.nameTranslations = []
 
-    wrapperFactory = (propsData: any) => {
-      return mount(NameTranslation, {
+    wrapperFactory = async (propsData: any) => {
+      const wrapper = mount(NameTranslation, {
         localVue,
         router,
         store,
         vuetify,
         propsData: { ...propsData }
       })
+      await Vue.nextTick()
+      return wrapper
     }
   })
 
   it('displays the list of name translations and action btns', async () => {
-    const wrapper = wrapperFactory({ nameTranslations: nameTranslationsListChanged, isSummaryMode: true })
-    await flushPromises()
+    const wrapper = await wrapperFactory({ nameTranslations: nameTranslationsListChanged, isSummaryMode: true })
 
     // Verify list exists
     expect(wrapper.find('#name-translation').exists()).toBeTruthy()
@@ -71,8 +71,7 @@ describe('Name Translation component', () => {
   })
 
   it('does not display translations if unchanged', async () => {
-    const wrapper = wrapperFactory({ nameTranslations: nameTranslationsList, isSummaryMode: true })
-    await flushPromises()
+    const wrapper = await wrapperFactory({ nameTranslations: nameTranslationsList, isSummaryMode: true })
 
     // Verify list exists
     expect(wrapper.find('#name-translation').exists()).toBeFalsy()

--- a/tests/unit/NameTranslation.spec.ts
+++ b/tests/unit/NameTranslation.spec.ts
@@ -17,7 +17,6 @@ function resetStore (): void {
 }
 
 // Local references
-const nameTranslationsUi = '#name-translations-list'
 const nameTranslationsList = [
   { name: 'First mock name translation ltd.' },
   { name: 'Second mock name translation inc' },


### PR DESCRIPTION
*Issue #:* bcgov/entity#13345

*Description of changes:*
- removed unneeded  name translation form row/cols
- renamed events and handlers for consistency (within this project and with Create UI)
- changed max name translation length to 50
- cleaned up layouts, classnames and CSS for consistency (with Create UI)
- updated unit tests
- app version = 3.8.21

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).