### PR TITLE
14520 Renamed entity type getters, etc for consistency between projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.9.7",
+      "version": "3.9.8",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Alteration/Articles/Articles.vue
+++ b/src/components/Alteration/Articles/Articles.vue
@@ -7,7 +7,7 @@
 
     <div
       class="section-container"
-      v-if="getBusinessInformation.hasRestrictions || isBaseCorrectionFiling"
+      v-if="getBusinessInformation.hasRestrictions || isBcCorrectionFiling"
       :class="{'invalid-section': invalidCompanyProvisions}">
       <CompanyProvisions
         class="sub-section"
@@ -59,7 +59,7 @@ export default class Articles extends Mixins(CommonMixin) {
   @Getter getHasRightsOrRestrictions!: boolean
   @Getter getIsResolutionDatesValid!: boolean
   @Getter getComponentValidate!: boolean
-  @Getter isBaseCorrectionFiling!: boolean
+  @Getter isBcCorrectionFiling!: boolean
 
   // Global actions
   @Action setProvisionsRemoved!: ActionBindingIF

--- a/src/components/Change/ChangeSummary.vue
+++ b/src/components/Change/ChangeSummary.vue
@@ -57,7 +57,7 @@
       <article id="org-person-summary-section" class="section-container pb-0">
         <v-row no-gutters>
           <v-col cols="12" sm="3">
-            <label>{{ isTypeSP ? 'Proprietor' : 'Partner' }} Information</label>
+            <label>{{ isSoleProp ? 'Proprietor' : 'Partner' }} Information</label>
           </v-col>
         </v-row>
         <v-row no-gutters class="mt-4">
@@ -95,7 +95,7 @@ export default class ChangeSummary extends Vue {
   @Getter getResource!: ResourceIF
   @Getter getNameRequestLegalName!: string
   @Getter getBusinessNumber!: string
-  @Getter isTypeSP!: boolean
+  @Getter isSoleProp!: boolean
 
   // Global actions
   @Action setSummaryMode!: ActionBindingIF

--- a/src/components/Conversion/ConversionSummary.vue
+++ b/src/components/Conversion/ConversionSummary.vue
@@ -40,7 +40,7 @@
       <article id="org-person-summary-section" class="section-container pb-0">
         <v-row no-gutters>
           <v-col cols="12" sm="3">
-            <label>{{ isTypeSP ? 'Proprietor' : 'Partner' }} Information</label>
+            <label>{{ isSoleProp ? 'Proprietor' : 'Partner' }} Information</label>
           </v-col>
         </v-row>
         <v-row no-gutters class="mt-4">
@@ -75,7 +75,7 @@ export default class ConversionSummary extends Vue {
   @Getter havePeopleAndRolesChanged!: boolean
   @Getter getResource!: ResourceIF
   @Getter getCurrentNaics!: NaicsIF
-  @Getter isTypeSP!: boolean
+  @Getter isSoleProp!: boolean
 
   // Global actions
   @Action setSummaryMode!: ActionBindingIF

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -130,7 +130,7 @@
 
             <!-- Roles -->
             <v-col cols="12" sm="2" :class="{ 'removed': wasRemoved(orgPerson)}">
-              <template v-if="isBaseCorrectionFiling">
+              <template v-if="isBcCorrectionFiling">
                 <!-- Warning if orgPerson has no roles -->
                 <div v-if="orgPerson.roles.length > 0">
                   <v-col v-for="(role, index) in orgPerson.roles" :key="index" class="col-roles">
@@ -408,7 +408,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
   // Store getter
   @Getter getOrgPeople!: OrgPersonIF[]
   @Getter isAlterationFiling!: boolean
-  @Getter isBaseCorrectionFiling!: boolean
+  @Getter isBcCorrectionFiling!: boolean
   @Getter isCorrectionFiling!: boolean
   @Getter isFirmChangeFiling!: boolean
   @Getter isFirmConversionFiling!: boolean
@@ -424,7 +424,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
       'Name',
       'Mailing Address',
       'Delivery Address',
-      this.isBaseCorrectionFiling ? 'Roles' : ''
+      this.isBcCorrectionFiling ? 'Roles' : ''
     ]
   }
 
@@ -466,7 +466,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
     if (this.isFirmConversionFiling) {
       return true
     }
-    if (this.isBaseCorrectionFiling) {
+    if (this.isBcCorrectionFiling) {
       return true
     }
     if (this.isFirmCorrectionFiling) {

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -247,7 +247,7 @@
               </article>
 
               <!-- Roles (base corrections only) -->
-              <article v-if="isBaseCorrectionFiling" class="roles mt-6">
+              <article v-if="isBcCorrectionFiling" class="roles mt-6">
                 <label class="sub-header">Roles</label>
                 <v-row class="roles-row mt-4">
                   <v-col cols="4" class="mt-0" v-if="isPerson">
@@ -388,9 +388,9 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
   // Global getter
   @Getter getCurrentDate!: string
   @Getter getResource!: ResourceIF
-  @Getter isBaseCorrectionFiling!: boolean
+  @Getter isBcCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
-  @Getter isTypeFirm!: boolean
+  @Getter isCorpClassFirm!: boolean
   @Getter isRoleStaff!: boolean
 
   // Local variables
@@ -529,7 +529,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
     if (this.isFirmConversionFiling) {
       return true
     }
-    if (this.isBaseCorrectionFiling) {
+    if (this.isBcCorrectionFiling) {
       return true
     }
     if (this.isFirmCorrectionFiling) {
@@ -562,7 +562,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
       // can add proprietor or partner
       return (this.isNew && (this.isProprietor || this.isPartner))
     }
-    if (this.isBaseCorrectionFiling) {
+    if (this.isBcCorrectionFiling) {
       // base corrections don't use this component
       return false
     }
@@ -716,7 +716,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
       }
       person.deliveryAddress = { ...this.inProgressDeliveryAddress }
     }
-    if (this.isBaseCorrectionFiling) {
+    if (this.isBcCorrectionFiling) {
       person.roles = this.setPersonRoles(this.orgPerson)
     } else {
       person.roles = this.orgPerson.roles
@@ -831,7 +831,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
       (v: string) => (v?.length <= 30) || 'Cannot exceed 30 characters' // maximum character count
     ]
 
-    if (this.isTypeFirm) {
+    if (this.isCorpClassFirm) {
       this.orgNameRules = [
         (v: string) => !!v?.trim() || 'Business or corporation name is required',
         (v: string) => (v?.length <= 150) || 'Cannot exceed 150 characters' // maximum character count

--- a/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
@@ -8,22 +8,22 @@
       </div>
 
       <!-- Instructional people and roles text (base corrections only)-->
-      <article v-if="isBaseCorrectionFiling" class="section-container">
+      <article v-if="isBcCorrectionFiling" class="section-container">
         This application must include the following:
         <ul>
           <li>
             <v-icon v-if="haveMinimumDirectors" color="green darken-2" class="dir-valid">mdi-check</v-icon>
             <v-icon v-else color="red" class="dir-invalid">mdi-close</v-icon>
             <span class="ml-2">
-              <template v-if="isTypeBC || isTypeBEN || isTypeULC">At least one Director</template>
-              <template v-if="isTypeCCC">At least three Directors</template>
+              <template v-if="isBcCompany || isBenefitCompany || isBcUlcCompany">At least one Director</template>
+              <template v-if="isBcCcc">At least three Directors</template>
             </span>
           </li>
         </ul>
       </article>
 
       <!-- Correction section (base corrections only) -->
-      <article v-if="isBaseCorrectionFiling" class="section-container">
+      <article v-if="isBcCorrectionFiling" class="section-container">
         <v-btn
           id="btn-add-person"
           outlined
@@ -49,7 +49,7 @@
         />
 
         <!-- SP add buttons (conversion filing only) -->
-        <div v-if="isTypeSP && isFirmConversionFiling && !haveRequiredProprietor" class="mt-8">
+        <div v-if="isSoleProp && isFirmConversionFiling && !haveRequiredProprietor" class="mt-8">
           <v-btn
             id="sp-btn-add-person"
             outlined
@@ -86,7 +86,7 @@
         </div>
 
         <!-- GP add buttons (change or conversion filings only)-->
-        <div v-if="isTypeGP && (isFirmChangeFiling || isFirmConversionFiling)" class="mt-8">
+        <div v-if="isPartnership && (isFirmChangeFiling || isFirmConversionFiling)" class="mt-8">
           <v-btn
             id="gp-btn-add-person"
             outlined
@@ -174,14 +174,14 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
   @Getter isRoleStaff!: boolean
   @Getter getResource!: ResourceIF
   @Getter getComponentValidate!: boolean
-  @Getter isBaseCorrectionFiling!: boolean
+  @Getter isBcCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
-  @Getter isTypeBC!: boolean
-  @Getter isTypeBEN!: boolean
-  @Getter isTypeCCC!: boolean
-  @Getter isTypeGP!: boolean
-  @Getter isTypeSP!: boolean
-  @Getter isTypeULC!: boolean
+  @Getter isBcCompany!: boolean
+  @Getter isBenefitCompany!: boolean
+  @Getter isBcCcc!: boolean
+  @Getter isPartnership!: boolean
+  @Getter isSoleProp!: boolean
+  @Getter isBcUlcCompany!: boolean
 
   // Global actions
   @Action setPeopleAndRoles!: ActionBindingIF
@@ -214,10 +214,10 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
   // FUTURE: should move rules and text to resource files
   /** True when the minimum director count is met. */
   get haveMinimumDirectors (): boolean {
-    if (this.isTypeBC || this.isTypeBEN || this.isTypeULC) {
+    if (this.isBcCompany || this.isBenefitCompany || this.isBcUlcCompany) {
       return this.hasRole(RoleTypes.DIRECTOR, 1, CompareModes.AT_LEAST)
     }
-    if (this.isTypeCCC) {
+    if (this.isBcCcc) {
       return this.hasRole(RoleTypes.DIRECTOR, 3, CompareModes.AT_LEAST)
     }
     return false // should never happen
@@ -230,19 +230,19 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
       return false
     }
     if (this.isFirmChangeFiling) {
-      if (this.isTypeGP) return this.haveMinimumPartners
-      if (this.isTypeSP) return this.haveRequiredProprietor
+      if (this.isPartnership) return this.haveMinimumPartners
+      if (this.isSoleProp) return this.haveRequiredProprietor
       return false
     }
     if (this.isFirmConversionFiling) {
-      if (this.isTypeGP) return this.haveMinimumPartners
-      if (this.isTypeSP) return this.haveRequiredProprietor
+      if (this.isPartnership) return this.haveMinimumPartners
+      if (this.isSoleProp) return this.haveRequiredProprietor
       return false
     }
     if (this.isCorrectionFiling) {
-      if (this.isTypeGP) return this.haveMinimumPartners
-      if (this.isTypeSP) return this.haveRequiredProprietor
-      if (this.isTypeBC || this.isTypeBEN || this.isTypeCCC || this.isTypeULC) {
+      if (this.isPartnership) return this.haveMinimumPartners
+      if (this.isSoleProp) return this.haveRequiredProprietor
+      if (this.isBcCompany || this.isBenefitCompany || this.isBcCcc || this.isBcUlcCompany) {
         return this.haveMinimumDirectors
       }
       return false
@@ -379,7 +379,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
     this.currentOrgPerson.actions = actions
 
     // for firms, use business lookup initially
-    if (this.isTypeGP || this.isTypeSP) {
+    if (this.isPartnership || this.isSoleProp) {
       this.currentOrgPerson.isLookupBusiness = true
     }
 

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -172,7 +172,7 @@
             <span>Undo</span>
           </v-btn>
           <v-btn
-            v-else-if="isTypeBC"
+            v-else-if="isBcCompany"
             text color="primary"
             id="btn-correct-business-type"
             @click="isEditingType = true"
@@ -239,9 +239,9 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
   @Getter getResource!: ResourceIF
   @Getter hasBusinessTypeChanged!: boolean
   @Getter isConflictingLegalType!: boolean
-  @Getter isTypeBC!: boolean
-  @Getter isTypeFirm!: boolean
-  @Getter isTypeCP!: boolean
+  @Getter isBcCompany!: boolean
+  @Getter isCorpClassFirm!: boolean
+  @Getter isCoop!: boolean
   @Getter getEntityType!: CorpTypeCd
 
   @Action setEntityType!: ActionBindingIF
@@ -304,7 +304,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
 
   /** Whether to show the Change Info tooltip (firm and coop filings only). */
   get showChangeInfoTooltip ():boolean {
-    return (this.isTypeFirm || this.isTypeCP)
+    return (this.isCorpClassFirm || this.isCoop)
   }
 
   /** Reset company type values to original. */

--- a/src/components/common/YourCompany/OfficeAddresses.vue
+++ b/src/components/common/YourCompany/OfficeAddresses.vue
@@ -119,7 +119,7 @@
       </v-row>
 
       <!-- Records office (BC/BEN/CCC/ULC only) -->
-      <v-row v-if="isTypeBase" id="summary-records-address" class="mt-4 mx-0" no-gutters>
+      <v-row v-if="isCorpClassBc" id="summary-records-address" class="mt-4 mx-0" no-gutters>
         <v-col cols="3" class="pr-2">
           <label :class="{'error-text': invalidSection}">Records Office</label>
         </v-col>
@@ -320,7 +320,7 @@
         </div>
 
         <!-- "Same as" checkbox -->
-        <div id="edit-records-address" v-if="isTypeBase">
+        <div id="edit-records-address" v-if="isCorpClassBc">
           <div class="address-edit-header" :class="{'mt-8': inheritMailingAddress}">
             <label class="address-edit-title">Records Office</label>
             <v-checkbox
@@ -456,8 +456,8 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   @Getter hasDeliveryChanged!: boolean
   @Getter hasRecMailingChanged!: boolean
   @Getter hasRecDeliveryChanged!: boolean
-  @Getter isTypeBase!: boolean
-  @Getter isBaseCorrectionFiling!: boolean
+  @Getter isCorpClassBc!: boolean
+  @Getter isBcCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
 
   // Global actions
@@ -539,7 +539,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * Sets local address data and "inherit" flags from store.
    */
   private setLocalProperties (): void {
-    if (this.isBaseCorrectionFiling || this.isAlterationFiling) {
+    if (this.isBcCorrectionFiling || this.isAlterationFiling) {
       // assign registered office addresses (may be {})
       this.mailingAddress = { ...this.getOfficeAddresses?.registeredOffice?.mailingAddress }
       this.deliveryAddress = { ...this.getOfficeAddresses?.registeredOffice?.deliveryAddress }
@@ -754,7 +754,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * Sets updated office addresses in store.
    */
   private storeAddresses (): void {
-    if (this.isBaseCorrectionFiling) {
+    if (this.isBcCorrectionFiling) {
       // at the moment, only BEN corrections are supported
       this.setOfficeAddresses({
         registeredOffice: {
@@ -842,7 +842,7 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
    * Also called when we know what kind of correction this is.
    */
   @Watch('getOfficeAddresses', { deep: true, immediate: true })
-  @Watch('isBaseCorrectionFiling')
+  @Watch('isBcCorrectionFiling')
   @Watch('isFirmCorrectionFiling')
   private updateAddresses (): void {
     // set local properties from store

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -199,7 +199,7 @@
     </div>
 
     <!-- Name Translation(s) (alterations and base corrections only) -->
-    <div v-if="isAlterationFiling || isBaseCorrectionFiling"
+    <div v-if="isAlterationFiling || isBcCorrectionFiling"
       id="name-translate-section"
       class="section-container"
       :class="{'invalid-section': invalidTranslationSection}"
@@ -210,10 +210,10 @@
       />
     </div>
 
-    <v-divider v-if="isTypeCP" class="mx-4 my-1" />
+    <v-divider v-if="isCoop" class="mx-4 my-1" />
 
     <!--- Association Type (coop only) -->
-    <div v-if="isTypeCP"
+    <div v-if="isCoop"
         id="association-type-section"
         class="section-container"
         :class="{'invalid-section': invalidAssociationTypeSection}"
@@ -258,7 +258,7 @@
     </template>
 
     <!-- Recognition Date and Time (alterations and base corrections only) -->
-    <template v-if="isAlterationFiling || isBaseCorrectionFiling">
+    <template v-if="isAlterationFiling || isBcCorrectionFiling">
       <v-divider class="mx-4 my-1" />
 
       <div class="section-container">
@@ -293,7 +293,7 @@
     </template>
 
     <!-- Folio Information (all except SP or GP) -->
-    <template v-if="isPremiumAccount && !isTypeFirm">
+    <template v-if="isPremiumAccount && !isCorpClassFirm">
       <v-divider class="mx-4 my-1" />
 
       <div id="folio-number-section" class="section-container" :class="{'invalid-section': invalidFolioSection}">
@@ -353,9 +353,9 @@ export default class YourCompany extends Mixins(
   @Getter isPremiumAccount!: boolean
   @Getter getEntitySnapshot!: EntitySnapshotIF
   @Getter getBusinessContact!: ContactPointIF
-  @Getter isTypeFirm!: boolean
-  @Getter isTypeCP!: boolean
-  @Getter isBaseCorrectionFiling!: boolean
+  @Getter isCorpClassFirm!: boolean
+  @Getter isCoop!: boolean
+  @Getter isBcCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
   @Getter getEntityType!: CorpTypeCd
   @Getter getAssociationType!: CoopTypes
@@ -464,7 +464,7 @@ export default class YourCompany extends Mixins(
 
   /** The recognition date or business start date string. */
   get recognitionDateTime (): string {
-    if (this.isBaseCorrectionFiling) {
+    if (this.isBcCorrectionFiling) {
       if (this.getBusinessFoundingDateTime) {
         return this.apiToPacificDateTime(this.getBusinessFoundingDateTime)
       }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -55,7 +55,7 @@ export default class FilingTemplateMixin extends DateMixin {
   @Getter getHasPlanOfArrangement!: boolean
   @Getter haveOfficeAddressesChanged!: boolean
   @Getter getCompletingParty!: CompletingPartyIF
-  @Getter isBaseCorrectionFiling!: boolean
+  @Getter isBcCorrectionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
   @Getter isClientErrorCorrection!: boolean
   @Getter getAssociationType!: CoopTypes
@@ -155,8 +155,8 @@ export default class FilingTemplateMixin extends DateMixin {
       filing.correction.parties = parties
     }
 
-    // add in data specific to base corrections
-    if (this.isBaseCorrectionFiling) {
+    // add in data specific to corp class BC corrections
+    if (this.isBcCorrectionFiling) {
       filing.correction.nameTranslations = isDraft ? this.getNameTranslations : this.prepareNameTranslations()
       filing.correction.shareStructure = {
         shareClasses: isDraft ? this.getShareClasses : this.prepareShareClasses(),
@@ -537,8 +537,8 @@ export default class FilingTemplateMixin extends DateMixin {
     // store Correction Information
     this.setCorrectionInformation(cloneDeep(filing.correction))
 
-    // store Business Information for base corrections
-    if (this.isBaseCorrectionFiling) {
+    // store Business Information for corp class BC corrections
+    if (this.isBcCorrectionFiling) {
       this.setBusinessInformation({
         ...entitySnapshot.businessInfo,
         ...filing.business
@@ -576,8 +576,8 @@ export default class FilingTemplateMixin extends DateMixin {
       }
     ))
 
-    // store Name Translations (base corrections only)
-    if (this.isBaseCorrectionFiling) {
+    // store Name Translations (corp class BC corrections only)
+    if (this.isBcCorrectionFiling) {
       this.setNameTranslations(cloneDeep(
         this.mapNameTranslations(filing.correction.nameTranslations) ||
         this.mapNameTranslations(entitySnapshot.nameTranslations) ||
@@ -601,8 +601,8 @@ export default class FilingTemplateMixin extends DateMixin {
     orgPersons = orgPersons.filter(op => !(op?.roles.some(role => role.roleType === RoleTypes.COMPLETING_PARTY)))
     this.setPeopleAndRoles(cloneDeep(orgPersons))
 
-    // store Share Classes and Resolution Dates (base corrections only)
-    if (this.isBaseCorrectionFiling) {
+    // store Share Classes and Resolution Dates (corp class BC corrections only)
+    if (this.isBcCorrectionFiling) {
       this.setShareClasses(cloneDeep(
         filing.correction.shareStructure?.shareClasses ||
         entitySnapshot.shareStructure.shareClasses

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -130,7 +130,7 @@ export const isPartnership = (state: StateIF): boolean => {
   return (getEntityType(state) === CorpTypeCd.PARTNERSHIP)
 }
 
-/** Whether the entity is of corp class BC (BC/BEN/CCC/ULC). */
+/** Whether the entity is of corp class "BC" (BC/BEN/CCC/ULC). */
 export const isCorpClassBc = (state: StateIF): boolean => {
   return (
     isBcCompany(state) ||
@@ -140,7 +140,7 @@ export const isCorpClassBc = (state: StateIF): boolean => {
   )
 }
 
-/** Whether the entity is a Firm (GP or SP). */
+/** Whether the entity is of corp class "Firm" (GP or SP). */
 export const isCorpClassFirm = (state: StateIF): boolean => {
   return (isPartnership(state) || isSoleProp(state))
 }

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -55,37 +55,37 @@ export const isConversionFiling = (state: StateIF): boolean => {
   return (state.stateModel.tombstone.filingType === FilingTypes.CONVERSION)
 }
 
-/** Whether the current filing is a firm Change of Registration. */
+/** Whether the current filing is a Change of Registration for a firm corp class. */
 export const isFirmChangeFiling = (state: StateIF): boolean => {
-  return (isTypeFirm(state) && isChangeRegFiling(state))
+  return (isCorpClassFirm(state) && isChangeRegFiling(state))
 }
 
-/** Whether the current filing is a base Correction. */
-export const isBaseCorrectionFiling = (state: StateIF): boolean => {
-  return (isTypeBase(state) && isCorrectionFiling(state))
+/** Whether the current filing is a Correction for a BC corp class. */
+export const isBcCorrectionFiling = (state: StateIF): boolean => {
+  return (isCorpClassBc(state) && isCorrectionFiling(state))
 }
 
-/** Whether the current filing is a firm Correction. */
+/** Whether the current filing is a Correction for a firm corp class. */
 export const isFirmCorrectionFiling = (state: StateIF): boolean => {
-  return (isTypeFirm(state) && isCorrectionFiling(state))
+  return (isCorpClassFirm(state) && isCorrectionFiling(state))
 }
 
-/** Whether the current filing is a firm Conversion. */
+/** Whether the current filing is a Conversion for a firm corp class. */
 export const isFirmConversionFiling = (state: StateIF): boolean => {
-  return (isTypeFirm(state) && isConversionFiling(state))
+  return (isCorpClassFirm(state) && isConversionFiling(state))
 }
 
-/** Whether the current corrected filing is an Incorporation Application. */
+/** Whether the corrected filing is an Incorporation Application. */
 export const isCorrectedIncorporationApplication = (state: StateIF): boolean => {
   return (getCorrectedFilingType(state) === FilingTypes.INCORPORATION_APPLICATION)
 }
 
-/** Whether the current corrected filing is a Registration. */
+/** Whether the corrected filing is a Registration. */
 export const isCorrectedRegistration = (state: StateIF): boolean => {
   return (getCorrectedFilingType(state) === FilingTypes.REGISTRATION)
 }
 
-/** Whether the current corrected filing is a Change of Registration. */
+/** Whether the corrected filing is a Change of Registration. */
 export const isCorrectedChangeReg = (state: StateIF): boolean => {
   return (getCorrectedFilingType(state) === FilingTypes.CHANGE_OF_REGISTRATION)
 }
@@ -96,53 +96,53 @@ export const getEntityType = (state: StateIF): CorpTypeCd => {
 }
 
 /** Whether the entity is a Benefit Company. */
-export const isTypeBEN = (state: StateIF): boolean => {
+export const isBenefitCompany = (state: StateIF): boolean => {
   return (getEntityType(state) === CorpTypeCd.BENEFIT_COMPANY)
 }
 
 /** Whether the entity is a Cooperative. */
-export const isTypeCP = (state: StateIF): boolean => {
+export const isCoop = (state: StateIF): boolean => {
   return (getEntityType(state) === CorpTypeCd.COOP)
 }
 
 /** Whether the entity is a BC Company. */
-export const isTypeBC = (state: StateIF): boolean => {
+export const isBcCompany = (state: StateIF): boolean => {
   return (getEntityType(state) === CorpTypeCd.BC_COMPANY)
 }
 
 /** Whether the entity is a Community Contribution Company. */
-export const isTypeCCC = (state: StateIF): boolean => {
+export const isBcCcc = (state: StateIF): boolean => {
   return (getEntityType(state) === CorpTypeCd.BC_CCC)
 }
 
 /** Whether the entity is an Unlimited Liability Company. */
-export const isTypeULC = (state: StateIF): boolean => {
+export const isBcUlcCompany = (state: StateIF): boolean => {
   return (getEntityType(state) === CorpTypeCd.BC_ULC_COMPANY)
 }
 
 /** Whether the entity is a Sole Proprietorship. */
-export const isTypeSP = (state: StateIF): boolean => {
+export const isSoleProp = (state: StateIF): boolean => {
   return (getEntityType(state) === CorpTypeCd.SOLE_PROP)
 }
 
 /** Whether the entity is a General Partnership. */
-export const isTypeGP = (state: StateIF): boolean => {
+export const isPartnership = (state: StateIF): boolean => {
   return (getEntityType(state) === CorpTypeCd.PARTNERSHIP)
 }
 
-/** Whether the entity is a base type (BC/BEN/CCC/ULC). */
-export const isTypeBase = (state: StateIF): boolean => {
+/** Whether the entity is of corp class BC (BC/BEN/CCC/ULC). */
+export const isCorpClassBc = (state: StateIF): boolean => {
   return (
-    isTypeBC(state) ||
-    isTypeBEN(state) ||
-    isTypeCCC(state) ||
-    isTypeULC(state)
+    isBcCompany(state) ||
+    isBenefitCompany(state) ||
+    isBcCcc(state) ||
+    isBcUlcCompany(state)
   )
 }
 
 /** Whether the entity is a Firm (GP or SP). */
-export const isTypeFirm = (state: StateIF): boolean => {
-  return (isTypeGP(state) || isTypeSP(state))
+export const isCorpClassFirm = (state: StateIF): boolean => {
+  return (isPartnership(state) || isSoleProp(state))
 }
 
 /** Whether the current account is a premium account. */
@@ -405,7 +405,7 @@ export const isFilingPaying = (state: StateIF): boolean => {
  * - staff payment
  */
 export const hasCorrectionDataChanged = (state: StateIF): boolean => {
-  if (isBaseCorrectionFiling(state)) {
+  if (isBcCorrectionFiling(state)) {
     return (
       hasBusinessNameChanged(state) ||
       hasBusinessTypeChanged(state) ||
@@ -525,7 +525,7 @@ export const hasConversionDataChanged = (state: StateIF): boolean => {
 
 /** Whether the subject correction filing is valid. */
 export const isCorrectionValid = (state: StateIF): boolean => {
-  if (isBaseCorrectionFiling(state)) {
+  if (isBcCorrectionFiling(state)) {
     if (isClientErrorCorrection(state)) {
       return (
         getFlagsCompanyInfo(state).isValidCompanyName &&
@@ -723,7 +723,7 @@ export const getOriginalOfficeAddresses = (state: StateIF): AddressesIF => {
 
 /** True if (registered) mailing address has changed. */
 export const hasMailingChanged = (state: StateIF): boolean => {
-  if (isAlterationFiling(state) || isBaseCorrectionFiling(state)) {
+  if (isAlterationFiling(state) || isBcCorrectionFiling(state)) {
     return !IsSame(
       getOfficeAddresses(state)?.registeredOffice?.mailingAddress,
       getOriginalOfficeAddresses(state)?.registeredOffice?.mailingAddress,
@@ -742,7 +742,7 @@ export const hasMailingChanged = (state: StateIF): boolean => {
 
 /** True if (registered) delivery address has changed. */
 export const hasDeliveryChanged = (state: StateIF): boolean => {
-  if (isAlterationFiling(state) || isBaseCorrectionFiling(state)) {
+  if (isAlterationFiling(state) || isBcCorrectionFiling(state)) {
     return !IsSame(
       getOfficeAddresses(state)?.registeredOffice?.deliveryAddress,
       getOriginalOfficeAddresses(state)?.registeredOffice?.deliveryAddress,

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -152,10 +152,10 @@ export default class Alteration extends Mixins(
   @Getter isPremiumAccount!: boolean
   @Getter getAppValidate!: boolean
   @Getter showFeeSummary!: boolean
-  @Getter isTypeBC!: boolean
-  @Getter isTypeBEN!: boolean
-  @Getter isTypeCCC!: boolean
-  @Getter isTypeULC!: boolean
+  @Getter isBcCompany!: boolean
+  @Getter isBenefitCompany!: boolean
+  @Getter isBcCcc!: boolean
+  @Getter isBcUlcCompany!: boolean
 
   // Global actions
   @Action setHaveUnsavedChanges!: ActionBindingIF
@@ -184,10 +184,10 @@ export default class Alteration extends Mixins(
   /** The resource file for an alteration filing. */
   get alterationResource (): ResourceIF {
     switch (true) {
-      case this.isTypeBC: return BcAlterationResource
-      case this.isTypeBEN: return BenAlterationResource
-      case this.isTypeCCC: return CccAlterationResource
-      case this.isTypeULC: return UlcAlterationResource
+      case this.isBcCompany: return BcAlterationResource
+      case this.isBenefitCompany: return BenAlterationResource
+      case this.isBcCcc: return CccAlterationResource
+      case this.isBcUlcCompany: return UlcAlterationResource
     }
     return null
   }

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -124,8 +124,8 @@ export default class Change extends Mixins(
   @Getter isRoleStaff!: boolean
   @Getter isSbcStaff!: boolean
   @Getter isPremiumAccount!: boolean
-  @Getter isTypeGP!: boolean
-  @Getter isTypeSP!: boolean
+  @Getter isPartnership!: boolean
+  @Getter isSoleProp!: boolean
 
   // Global actions
   @Action setHaveUnsavedChanges!: ActionBindingIF
@@ -154,8 +154,8 @@ export default class Change extends Mixins(
 
   /** The resource file for a firm change filing. */
   get firmChangeResource (): ResourceIF {
-    if (this.isTypeGP) return GpChangeResource
-    if (this.isTypeSP) return SpChangeResource
+    if (this.isPartnership) return GpChangeResource
+    if (this.isSoleProp) return SpChangeResource
     return null
   }
 

--- a/src/views/Conversion.vue
+++ b/src/views/Conversion.vue
@@ -79,8 +79,8 @@ export default class Conversion extends Mixins(
   @Getter isSummaryMode!: boolean
   @Getter getAppValidate!: boolean
   @Getter showFeeSummary!: boolean
-  @Getter isTypeGP!: boolean
-  @Getter isTypeSP!: boolean
+  @Getter isPartnership!: boolean
+  @Getter isSoleProp!: boolean
 
   // Global actions
   @Action setHaveUnsavedChanges!: ActionBindingIF
@@ -103,8 +103,8 @@ export default class Conversion extends Mixins(
 
   /** The resource file for a firm conversion filing. */
   get firmConversionResource (): any {
-    if (this.isTypeGP) return GpConversionResource
-    if (this.isTypeSP) return SpConversionResource
+    if (this.isPartnership) return GpConversionResource
+    if (this.isSoleProp) return SpConversionResource
     return null
   }
 

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -16,13 +16,13 @@ import { LegalServices } from '@/services/'
 import { ActionBindingIF, CorrectionFilingIF } from '@/interfaces/'
 import { FilingStatus, FilingTypes } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
-import BaseCorrection from '@/views/Correction/BaseCorrection.vue'
-import FmCorrection from '@/views/Correction/FmCorrection.vue'
+import BcCorrection from '@/views/Correction/BcCorrection.vue'
+import FirmCorrection from '@/views/Correction/FirmCorrection.vue'
 
 @Component({
   components: {
-    BaseCorrection,
-    FmCorrection
+    BcCorrection,
+    FirmCorrection
   }
 })
 export default class Correction extends Mixins(CommonMixin) {
@@ -32,8 +32,8 @@ export default class Correction extends Mixins(CommonMixin) {
   // Global getters
   @Getter getBusinessId!: string
   @Getter isRoleStaff!: boolean
-  @Getter isTypeBase!: boolean
-  @Getter isTypeFirm!: boolean
+  @Getter isCorpClassBc!: boolean
+  @Getter isCorpClassFirm!: boolean
 
   // Global actions
   @Action setFilingId!: ActionBindingIF
@@ -43,8 +43,8 @@ export default class Correction extends Mixins(CommonMixin) {
 
   /** The dynamic component to render. */
   get component (): string {
-    if (this.isTypeBase) return 'BaseCorrection'
-    if (this.isTypeFirm) return 'FmCorrection'
+    if (this.isCorpClassBc) return 'BcCorrection'
+    if (this.isCorpClassFirm) return 'FirmCorrection'
     return null // should never happen
   }
 
@@ -113,9 +113,9 @@ export default class Correction extends Mixins(CommonMixin) {
       }
 
       // set entity type for misc functionality to work
-      // do not proceed if this isn't a BEN or SP/GP correction
+      // do not proceed if this isn't a BC or firm correction
       this.setEntityType(filing.business?.legalType)
-      if (!this.isTypeBase && !this.isTypeFirm) {
+      if (!this.isCorpClassBc && !this.isCorpClassFirm) {
         throw new Error('Invalid correction type')
       }
 

--- a/src/views/Correction/BcCorrection.vue
+++ b/src/views/Correction/BcCorrection.vue
@@ -65,6 +65,7 @@ import { ActionBindingIF, CorrectionFilingIF, EntitySnapshotIF, ResourceIF } fro
 import { BcCorrectionResource, BenCorrectionResource, CccCorrectionResource, UlcCorrectionResource }
   from '@/resources/Correction/'
 
+/** Correction sub-component for corp class "BC" entities. */
 @Component({
   components: {
     CertifySection,

--- a/src/views/Correction/FirmCorrection.vue
+++ b/src/views/Correction/FirmCorrection.vue
@@ -46,6 +46,7 @@ import { AuthServices, LegalServices } from '@/services/'
 import { StaffPaymentOptions } from '@bcrs-shared-components/enums/'
 import { GpCorrectionResource, SpCorrectionResource } from '@/resources/Correction/'
 
+/** Correction sub-component for corp class "Firm" entities. */
 @Component({
   components: {
     CertifySection,

--- a/src/views/SpecialResolution.vue
+++ b/src/views/SpecialResolution.vue
@@ -147,7 +147,7 @@ export default class SpecialResolution extends Mixins(
   @Getter isPremiumAccount!: boolean
   @Getter getAppValidate!: boolean
   @Getter showFeeSummary!: boolean
-  @Getter isTypeCP!: boolean
+  @Getter isCoop!: boolean
 
   // Global actions
   @Action setHaveUnsavedChanges!: ActionBindingIF
@@ -176,9 +176,9 @@ export default class SpecialResolution extends Mixins(
     return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
   }
 
-  /** The resource file for an SpecialResolution filing. */
+  /** The resource file for a Special Resolution filing. */
   get specialResolutionResource (): ResourceIF {
-    if (this.isTypeCP) return CpSpecialResolutionResource
+    if (this.isCoop) return CpSpecialResolutionResource
     return null
   }
 

--- a/tests/unit/BcCorrection.spec.ts
+++ b/tests/unit/BcCorrection.spec.ts
@@ -6,9 +6,11 @@ import sinon from 'sinon'
 import { getVuexStore } from '@/store/'
 import { shallowMount, createLocalVue } from '@vue/test-utils'
 import { AxiosInstance as axios } from '@/utils/'
-import FmCorrection from '@/views/Correction/FmCorrection.vue'
+import { Articles } from '@/components/Alteration/'
+import { CertifySection, Detail, PeopleAndRoles, ShareStructures, StaffPayment, YourCompany, CompletingParty }
+  from '@/components/common/'
+import BcCorrection from '@/views/Correction/BcCorrection.vue'
 import mockRouter from './MockRouter'
-import { CertifySection, CompletingParty, Detail, PeopleAndRoles, StaffPayment, YourCompany } from '@/components/common'
 
 Vue.use(Vuetify)
 
@@ -18,7 +20,7 @@ const store = getVuexStore()
 // Prevent the warning "[Vuetify] Unable to locate target [data-app]"
 document.body.setAttribute('data-app', 'true')
 
-describe('Firm Correction component', () => {
+describe('BC Correction component', () => {
   let wrapper: any
   const { assign } = window.location
 
@@ -27,8 +29,8 @@ describe('Firm Correction component', () => {
   sessionStorage.setItem('AUTH_API_URL', 'https://auth.api.url/')
   sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
   sessionStorage.setItem('DASHBOARD_URL', 'https://dashboard.url/')
-  store.state.stateModel.tombstone.entityType = 'SP'
-  store.state.stateModel.tombstone.businessId = 'FM1234567'
+  store.state.stateModel.tombstone.entityType = 'BEN'
+  store.state.stateModel.tombstone.businessId = 'BC1234567'
 
   beforeEach(async () => {
     // mock the window.location.assign function
@@ -39,52 +41,52 @@ describe('Firm Correction component', () => {
 
     // FUTURE
     // GET payment fee for immediate correction
-    // get.withArgs('https://pay.api.url/fees/SP/CORRECTION')
+    // get.withArgs('https://pay.api.url/fees/BEN/CORRECTION')
     //   .returns(Promise.resolve({
     //     data: {
-    //       filingFees: 100.0,
-    //       filingType: 'Correction',
-    //       filingTypeCode: 'CORRECTION',
-    //       futureEffectiveFees: 0,
-    //       priorityFees: 0,
-    //       processingFees: 0,
-    //       serviceFees: 1.5,
-    //       tax: {
-    //         gst: 0,
-    //         pst: 0
+    //       'filingFees': 100.0,
+    //       'filingType': 'Correction',
+    //       'filingTypeCode': 'CORRECTION',
+    //       'futureEffectiveFees': 0,
+    //       'priorityFees': 0,
+    //       'processingFees': 0,
+    //       'serviceFees': 1.5,
+    //       'tax': {
+    //         'gst': 0,
+    //         'pst': 0
     //       },
-    //       total: 101.5
+    //       'total': 101.5
     //     }
     //   }))
 
     // FUTURE
     // GET payment fee for future correction
-    // get.withArgs('https://pay.api.url/fees/SP/CORRECTION?futureEffective=true')
+    // get.withArgs('https://pay.api.url/fees/BEN/CORRECTION?futureEffective=true')
     //   .returns(Promise.resolve({
     //     data: {
-    //       filingFees: 100.0,
-    //       filingType: 'Correction',
-    //       filingTypeCode: 'CORRECTION',
-    //       futureEffectiveFees: 100.0,
-    //       priorityFees: 0,
-    //       processingFees: 0,
-    //       serviceFees: 1.5,
-    //       tax: {
-    //         gst: 0,
-    //         pst: 0
+    //       'filingFees': 100.0,
+    //       'filingType': 'Correction',
+    //       'filingTypeCode': 'CORRECTION',
+    //       'futureEffectiveFees': 100.0,
+    //       'priorityFees': 0,
+    //       'processingFees': 0,
+    //       'serviceFees': 1.5,
+    //       'tax': {
+    //         'gst': 0,
+    //         'pst': 0
     //       },
-    //       total: 201.5
+    //       'total': 201.5
     //     }
     //   }))
 
     // GET business info
-    get.withArgs('businesses/FM1234567')
+    get.withArgs('businesses/BC1234567')
       .returns(Promise.resolve({
-        data: { business: { legalType: 'SP' } }
+        data: { business: { legalType: 'BC' } }
       }))
 
     // GET auth info
-    get.withArgs('https://auth.api.url/entities/FM1234567')
+    get.withArgs('https://auth.api.url/entities/BC1234567')
       .returns(Promise.resolve({
         data: {
           contacts: [
@@ -97,15 +99,33 @@ describe('Firm Correction component', () => {
       }))
 
     // GET addresses
-    get.withArgs('businesses/FM1234567/addresses')
+    get.withArgs('businesses/BC1234567/addresses')
       .returns(Promise.resolve({
         data: {}
       }))
 
     // GET parties
-    get.withArgs('businesses/FM1234567/parties')
+    get.withArgs('businesses/BC1234567/parties')
       .returns(Promise.resolve({
         data: { parties: [] }
+      }))
+
+    // GET share structure
+    get.withArgs('businesses/BC1234567/share-classes')
+      .returns(Promise.resolve({
+        data: { shareClasses: [] }
+      }))
+
+    // GET name translations
+    get.withArgs('businesses/BC1234567/aliases')
+      .returns(Promise.resolve({
+        data: { aliases: [] }
+      }))
+
+    // GET resolutions
+    get.withArgs('businesses/BC1234567/resolutions')
+      .returns(Promise.resolve({
+        data: { resolutions: [] }
       }))
 
     // create a Local Vue and install router on it
@@ -113,34 +133,17 @@ describe('Firm Correction component', () => {
     localVue.use(VueRouter)
     const router = mockRouter.mock()
     await router.push({ name: 'correction' })
-    wrapper = shallowMount(
-      FmCorrection,
-      {
-        localVue,
-        store,
-        router,
-        vuetify,
-        propsData: {
-          correctionFiling: {
-            business: {},
-            correction: { correctedFilingId: 123 },
-            header: {}
-          }
-        },
-        data: () => ({
-          clientError: false
-        }),
-        computed: {
-          isClientErrorCorrection: {
-            get (): boolean {
-              return this.$data.clientError
-            },
-            set (val: boolean) {
-              this.$data.clientError = val
-            }
-          }
+    wrapper = shallowMount(BcCorrection, { localVue,
+      store,
+      router,
+      vuetify,
+      propsData: {
+        correctionFiling: {
+          business: {},
+          correction: { correctedFilingId: 123 },
+          header: {}
         }
-      })
+      } })
 
     // wait for all queries to complete
     await flushPromises()
@@ -152,34 +155,19 @@ describe('Firm Correction component', () => {
     wrapper.destroy()
   })
 
-  it('renders Firm Correction view and default components', () => {
-    expect(wrapper.findComponent(FmCorrection).exists()).toBe(true)
+  it('renders BC Correction view', () => {
+    expect(wrapper.findComponent(BcCorrection).exists()).toBe(true)
+  })
 
-    // Default components
+  it('loads each component', async () => {
     expect(wrapper.findComponent(YourCompany).exists()).toBe(true)
     expect(wrapper.findComponent(PeopleAndRoles).exists()).toBe(true)
+    expect(wrapper.findComponent(ShareStructures).exists()).toBe(true)
+    expect(wrapper.findComponent(Articles).exists()).toBe(true)
     expect(wrapper.findComponent(Detail).exists()).toBe(true)
-    expect(wrapper.findComponent(StaffPayment).exists()).toBe(true)
-
-    // Components that are only visable for client Error Corrections
-    expect(wrapper.findComponent(CompletingParty).exists()).toBe(false)
-    expect(wrapper.findComponent(CertifySection).exists()).toBe(false)
-  })
-
-  it('renders Firm Correction view and client error components', async () => {
-    wrapper.vm.clientError = true
-    // a wait needed as change to computed value triggers a re-rendering
-    await Vue.nextTick()
-
     expect(wrapper.findComponent(CertifySection).exists()).toBe(true)
+    expect(wrapper.findComponent(StaffPayment).exists()).toBe(true)
     expect(wrapper.findComponent(CompletingParty).exists()).toBe(true)
-    wrapper.vm.clientError = false
-  })
-
-  it('staff payment is defaulted to no fee', () => {
-    // Staff payment No Fee button needs option to be set to NO_FEE enum for the no fee button
-    // to be selected in staff payment component
-    expect(store.state.stateModel.staffPayment.option).toBe(0)
   })
 
   // FUTURE
@@ -189,26 +177,33 @@ describe('Firm Correction component', () => {
     const state = store.state.stateModel
 
     // Validate business identifier
-    expect(state.tombstone.businessId).toBe('FM1234567')
+    expect(state.tombstone.businessId).toBe('BC1234567')
 
     // Validate Business
-    expect(state.businessInformation.legalType).toBe('SP')
-    expect(state.businessInformation.legalName).toBe('Mock Sole Prop')
-    expect(state.businessInformation.identifier).toBe('FM1234567')
+    expect(state.businessInformation.legalType).toBe('BEN')
+    expect(state.businessInformation.legalName).toBe('Mock Business Ltd.')
+    expect(state.businessInformation.identifier).toBe('BC1234567')
 
     // Validate Name Translations
-    expect(state.nameTranslations[0].name).toBe('Mock Sole Prop French')
+    expect(state.nameTranslations[0].name).toBe('Mock Business French Ltd.')
 
-    // Validate Business Office Addresses
+    // Validate Office Addresses
     expect(state.officeAddresses.registeredOffice.deliveryAddress.streetAddress)
-      .toBe('delivery_address - address line one')
+      .toBe('reg delivery_address - address line one')
     expect(state.officeAddresses.recordsOffice.mailingAddress.streetAddress)
-      .toBe('mailing_address - address line two')
+      .toBe('rec mailing_address - address line two')
 
-    // Validate Proprietor
+    // Validate People And Roles
     expect(store.state.stateModel.peopleAndRoles.orgPeople[0].officer.firstName).toBe('CAMERON')
     expect(store.state.stateModel.peopleAndRoles.orgPeople[0].officer.lastName).toBe('BOWLER')
-    expect(store.state.stateModel.peopleAndRoles.orgPeople[0].roles[0].roleType).toBe('Proprietor')
+    expect(store.state.stateModel.peopleAndRoles.orgPeople[0].roles[0].roleType).toBe('Director')
+
+    // Validate Share Structure
+    expect(store.state.stateModel.shareStructureStep.shareClasses[0].name).toBe('Class A Shares')
+    expect(store.state.stateModel.shareStructureStep.shareClasses[0].series[0].name)
+      .toBe('Series A Shares')
+    expect(store.state.stateModel.shareStructureStep.shareClasses[0].series[1].name)
+      .toBe('Series 2 Shares')
 
     // Validate Contact Info
     expect(store.state.stateModel.businessContact.email).toBe('mock@example.com')

--- a/tests/unit/FirmCorrection.spec.ts
+++ b/tests/unit/FirmCorrection.spec.ts
@@ -6,11 +6,9 @@ import sinon from 'sinon'
 import { getVuexStore } from '@/store/'
 import { shallowMount, createLocalVue } from '@vue/test-utils'
 import { AxiosInstance as axios } from '@/utils/'
-import { Articles } from '@/components/Alteration/'
-import { CertifySection, Detail, PeopleAndRoles, ShareStructures, StaffPayment, YourCompany, CompletingParty }
-  from '@/components/common/'
-import BaseCorrection from '@/views/Correction/BaseCorrection.vue'
+import FirmCorrection from '@/views/Correction/FirmCorrection.vue'
 import mockRouter from './MockRouter'
+import { CertifySection, CompletingParty, Detail, PeopleAndRoles, StaffPayment, YourCompany } from '@/components/common'
 
 Vue.use(Vuetify)
 
@@ -20,7 +18,7 @@ const store = getVuexStore()
 // Prevent the warning "[Vuetify] Unable to locate target [data-app]"
 document.body.setAttribute('data-app', 'true')
 
-describe('Benefit Company Correction component', () => {
+describe('Firm Correction component', () => {
   let wrapper: any
   const { assign } = window.location
 
@@ -29,8 +27,8 @@ describe('Benefit Company Correction component', () => {
   sessionStorage.setItem('AUTH_API_URL', 'https://auth.api.url/')
   sessionStorage.setItem('AUTH_WEB_URL', 'https://auth.web.url/')
   sessionStorage.setItem('DASHBOARD_URL', 'https://dashboard.url/')
-  store.state.stateModel.tombstone.entityType = 'BEN'
-  store.state.stateModel.tombstone.businessId = 'BC1234567'
+  store.state.stateModel.tombstone.entityType = 'SP'
+  store.state.stateModel.tombstone.businessId = 'FM1234567'
 
   beforeEach(async () => {
     // mock the window.location.assign function
@@ -41,52 +39,52 @@ describe('Benefit Company Correction component', () => {
 
     // FUTURE
     // GET payment fee for immediate correction
-    // get.withArgs('https://pay.api.url/fees/BEN/CORRECTION')
+    // get.withArgs('https://pay.api.url/fees/SP/CORRECTION')
     //   .returns(Promise.resolve({
     //     data: {
-    //       'filingFees': 100.0,
-    //       'filingType': 'Correction',
-    //       'filingTypeCode': 'CORRECTION',
-    //       'futureEffectiveFees': 0,
-    //       'priorityFees': 0,
-    //       'processingFees': 0,
-    //       'serviceFees': 1.5,
-    //       'tax': {
-    //         'gst': 0,
-    //         'pst': 0
+    //       filingFees: 100.0,
+    //       filingType: 'Correction',
+    //       filingTypeCode: 'CORRECTION',
+    //       futureEffectiveFees: 0,
+    //       priorityFees: 0,
+    //       processingFees: 0,
+    //       serviceFees: 1.5,
+    //       tax: {
+    //         gst: 0,
+    //         pst: 0
     //       },
-    //       'total': 101.5
+    //       total: 101.5
     //     }
     //   }))
 
     // FUTURE
     // GET payment fee for future correction
-    // get.withArgs('https://pay.api.url/fees/BEN/CORRECTION?futureEffective=true')
+    // get.withArgs('https://pay.api.url/fees/SP/CORRECTION?futureEffective=true')
     //   .returns(Promise.resolve({
     //     data: {
-    //       'filingFees': 100.0,
-    //       'filingType': 'Correction',
-    //       'filingTypeCode': 'CORRECTION',
-    //       'futureEffectiveFees': 100.0,
-    //       'priorityFees': 0,
-    //       'processingFees': 0,
-    //       'serviceFees': 1.5,
-    //       'tax': {
-    //         'gst': 0,
-    //         'pst': 0
+    //       filingFees: 100.0,
+    //       filingType: 'Correction',
+    //       filingTypeCode: 'CORRECTION',
+    //       futureEffectiveFees: 100.0,
+    //       priorityFees: 0,
+    //       processingFees: 0,
+    //       serviceFees: 1.5,
+    //       tax: {
+    //         gst: 0,
+    //         pst: 0
     //       },
-    //       'total': 201.5
+    //       total: 201.5
     //     }
     //   }))
 
     // GET business info
-    get.withArgs('businesses/BC1234567')
+    get.withArgs('businesses/FM1234567')
       .returns(Promise.resolve({
-        data: { business: { legalType: 'BC' } }
+        data: { business: { legalType: 'SP' } }
       }))
 
     // GET auth info
-    get.withArgs('https://auth.api.url/entities/BC1234567')
+    get.withArgs('https://auth.api.url/entities/FM1234567')
       .returns(Promise.resolve({
         data: {
           contacts: [
@@ -99,33 +97,15 @@ describe('Benefit Company Correction component', () => {
       }))
 
     // GET addresses
-    get.withArgs('businesses/BC1234567/addresses')
+    get.withArgs('businesses/FM1234567/addresses')
       .returns(Promise.resolve({
         data: {}
       }))
 
     // GET parties
-    get.withArgs('businesses/BC1234567/parties')
+    get.withArgs('businesses/FM1234567/parties')
       .returns(Promise.resolve({
         data: { parties: [] }
-      }))
-
-    // GET share structure
-    get.withArgs('businesses/BC1234567/share-classes')
-      .returns(Promise.resolve({
-        data: { shareClasses: [] }
-      }))
-
-    // GET name translations
-    get.withArgs('businesses/BC1234567/aliases')
-      .returns(Promise.resolve({
-        data: { aliases: [] }
-      }))
-
-    // GET resolutions
-    get.withArgs('businesses/BC1234567/resolutions')
-      .returns(Promise.resolve({
-        data: { resolutions: [] }
       }))
 
     // create a Local Vue and install router on it
@@ -133,17 +113,34 @@ describe('Benefit Company Correction component', () => {
     localVue.use(VueRouter)
     const router = mockRouter.mock()
     await router.push({ name: 'correction' })
-    wrapper = shallowMount(BaseCorrection, { localVue,
-      store,
-      router,
-      vuetify,
-      propsData: {
-        correctionFiling: {
-          business: {},
-          correction: { correctedFilingId: 123 },
-          header: {}
+    wrapper = shallowMount(
+      FirmCorrection,
+      {
+        localVue,
+        store,
+        router,
+        vuetify,
+        propsData: {
+          correctionFiling: {
+            business: {},
+            correction: { correctedFilingId: 123 },
+            header: {}
+          }
+        },
+        data: () => ({
+          clientError: false
+        }),
+        computed: {
+          isClientErrorCorrection: {
+            get (): boolean {
+              return this.$data.clientError
+            },
+            set (val: boolean) {
+              this.$data.clientError = val
+            }
+          }
         }
-      } })
+      })
 
     // wait for all queries to complete
     await flushPromises()
@@ -155,19 +152,34 @@ describe('Benefit Company Correction component', () => {
     wrapper.destroy()
   })
 
-  it('renders Benefit Company Correction view', () => {
-    expect(wrapper.findComponent(BaseCorrection).exists()).toBe(true)
-  })
+  it('renders Firm Correction view and default components', () => {
+    expect(wrapper.findComponent(FirmCorrection).exists()).toBe(true)
 
-  it('loads each component', async () => {
+    // Default components
     expect(wrapper.findComponent(YourCompany).exists()).toBe(true)
     expect(wrapper.findComponent(PeopleAndRoles).exists()).toBe(true)
-    expect(wrapper.findComponent(ShareStructures).exists()).toBe(true)
-    expect(wrapper.findComponent(Articles).exists()).toBe(true)
     expect(wrapper.findComponent(Detail).exists()).toBe(true)
-    expect(wrapper.findComponent(CertifySection).exists()).toBe(true)
     expect(wrapper.findComponent(StaffPayment).exists()).toBe(true)
+
+    // Components that are only visable for client Error Corrections
+    expect(wrapper.findComponent(CompletingParty).exists()).toBe(false)
+    expect(wrapper.findComponent(CertifySection).exists()).toBe(false)
+  })
+
+  it('renders Firm Correction view and client error components', async () => {
+    wrapper.vm.clientError = true
+    // a wait needed as change to computed value triggers a re-rendering
+    await Vue.nextTick()
+
+    expect(wrapper.findComponent(CertifySection).exists()).toBe(true)
     expect(wrapper.findComponent(CompletingParty).exists()).toBe(true)
+    wrapper.vm.clientError = false
+  })
+
+  it('staff payment is defaulted to no fee', () => {
+    // Staff payment No Fee button needs option to be set to NO_FEE enum for the no fee button
+    // to be selected in staff payment component
+    expect(store.state.stateModel.staffPayment.option).toBe(0)
   })
 
   // FUTURE
@@ -177,33 +189,26 @@ describe('Benefit Company Correction component', () => {
     const state = store.state.stateModel
 
     // Validate business identifier
-    expect(state.tombstone.businessId).toBe('BC1234567')
+    expect(state.tombstone.businessId).toBe('FM1234567')
 
     // Validate Business
-    expect(state.businessInformation.legalType).toBe('BEN')
-    expect(state.businessInformation.legalName).toBe('Mock Business Ltd.')
-    expect(state.businessInformation.identifier).toBe('BC1234567')
+    expect(state.businessInformation.legalType).toBe('SP')
+    expect(state.businessInformation.legalName).toBe('Mock Sole Prop')
+    expect(state.businessInformation.identifier).toBe('FM1234567')
 
     // Validate Name Translations
-    expect(state.nameTranslations[0].name).toBe('Mock Business French Ltd.')
+    expect(state.nameTranslations[0].name).toBe('Mock Sole Prop French')
 
-    // Validate Office Addresses
+    // Validate Business Office Addresses
     expect(state.officeAddresses.registeredOffice.deliveryAddress.streetAddress)
-      .toBe('reg delivery_address - address line one')
+      .toBe('delivery_address - address line one')
     expect(state.officeAddresses.recordsOffice.mailingAddress.streetAddress)
-      .toBe('rec mailing_address - address line two')
+      .toBe('mailing_address - address line two')
 
-    // Validate People And Roles
+    // Validate Proprietor
     expect(store.state.stateModel.peopleAndRoles.orgPeople[0].officer.firstName).toBe('CAMERON')
     expect(store.state.stateModel.peopleAndRoles.orgPeople[0].officer.lastName).toBe('BOWLER')
-    expect(store.state.stateModel.peopleAndRoles.orgPeople[0].roles[0].roleType).toBe('Director')
-
-    // Validate Share Structure
-    expect(store.state.stateModel.shareStructureStep.shareClasses[0].name).toBe('Class A Shares')
-    expect(store.state.stateModel.shareStructureStep.shareClasses[0].series[0].name)
-      .toBe('Series A Shares')
-    expect(store.state.stateModel.shareStructureStep.shareClasses[0].series[1].name)
-      .toBe('Series 2 Shares')
+    expect(store.state.stateModel.peopleAndRoles.orgPeople[0].roles[0].roleType).toBe('Proprietor')
 
     // Validate Contact Info
     expect(store.state.stateModel.businessContact.email).toBe('mock@example.com')

--- a/tests/unit/SpecialResolution.spec.ts
+++ b/tests/unit/SpecialResolution.spec.ts
@@ -17,7 +17,7 @@ const store = getVuexStore()
 // Prevent the warning "[Vuetify] Unable to locate target [data-app]"
 document.body.setAttribute('data-app', 'true')
 
-describe('SpecialResolution component', () => {
+describe('Special Resolution component', () => {
   let wrapper: any
   const { assign } = window.location
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#14520

*Description of changes:*
- renamed isTypeBEN -> isBenefitCompany, etc
- renamed isBaseCorrectionFiling -> isBcCorrectionFiling, etc
- renamed isTypeFirm -> isCorpClassFirm, etc
- renamed BaseCorrection.vue -> BcCorrection.vue
- renamed FmCorrection.vue -> FirmCorrection.vue
- app version = 3.9.8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).