### PR TITLE
14545 Upper case display for Corp Name Translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.9.8",
+  "version": "3.9.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.9.8",
+      "version": "3.9.9",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.9.8",
+  "version": "3.9.9",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/YourCompany/NameTranslations/AddNameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/AddNameTranslation.vue
@@ -19,14 +19,14 @@
       <div class="action-btns">
         <v-btn v-if="!isAddingTranslation"
           large outlined color="error"
-          id="name-translation-remove"
+          id="name-translation-btn-remove"
           @click="removeTranslation(nameIndex)"
         >
           <span>Remove</span>
         </v-btn>
         <v-btn
           large color="primary" class="ml-auto"
-          id="name-translation-btn-ok"
+          id="name-translation-btn-done"
           @click="validateAddTranslation()"
         >
             Done

--- a/src/components/common/YourCompany/NameTranslations/AddNameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/AddNameTranslation.vue
@@ -5,7 +5,7 @@
       attach="#add-name-translation"
     />
     <!-- Name Translation form -->
-    <v-form v-model="nameTranslationForm" ref="nameTranslationForm" class="name-translation-form">
+    <v-form v-model="nameTranslationForm" ref="nameTranslationForm">
       <v-text-field
         filled
         persistent-hint
@@ -13,6 +13,7 @@
         label="Name Translation"
         v-model="nameTranslation"
         :rules="nameTranslationRules"
+        @input="nameTranslation = nameTranslation.toUpperCase()"
       />
 
       <div class="action-btns">

--- a/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
@@ -19,7 +19,7 @@
       <v-col cols="7" v-if="draftTranslations && translationsExceptRemoved.length">
         <div
           v-for="(translation, index) in translationsExceptRemoved"
-          class="info-text text-uppercase"
+          class="info-text"
           :key="`name_translation_${index}`"
         >
           {{ translation.name }}

--- a/tests/unit/AddNameTranslation.spec.ts
+++ b/tests/unit/AddNameTranslation.spec.ts
@@ -47,7 +47,7 @@ describe('Add Name Translation component', () => {
     }
   })
 
-  it('displays the input field and buttons', async () => {
+  it('Displays the input field and buttons', async () => {
     const wrapper = await wrapperFactory()
 
     // Verify input field
@@ -58,8 +58,7 @@ describe('Add Name Translation component', () => {
     // done button not disabled anymore, validation done by validation function
     expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
 
-    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
+    expect(wrapper.find(removeBtn).exists()).toBeFalsy()
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -67,7 +66,7 @@ describe('Add Name Translation component', () => {
     wrapper.destroy()
   })
 
-  it('enables the Done button when the input is valid', async () => {
+  it('Enables the Done button when the input is valid', async () => {
     const wrapper = await wrapperFactory()
     const vm: any = wrapper.vm
 
@@ -85,8 +84,7 @@ describe('Add Name Translation component', () => {
     expect(wrapper.find(doneBtn).exists()).toBeTruthy()
     expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
 
-    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
+    expect(wrapper.find(removeBtn).exists()).toBeFalsy()
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -97,7 +95,7 @@ describe('Add Name Translation component', () => {
     wrapper.destroy()
   })
 
-  it('enables the Done button when the input is valid - French characters', async () => {
+  it('Enables the Done button when the input is valid - French characters', async () => {
     const wrapper = await wrapperFactory()
     const vm: any = wrapper.vm
 
@@ -115,8 +113,7 @@ describe('Add Name Translation component', () => {
     expect(wrapper.find(doneBtn).exists()).toBeTruthy()
     expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
 
-    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
+    expect(wrapper.find(removeBtn).exists()).toBeFalsy()
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -124,7 +121,7 @@ describe('Add Name Translation component', () => {
     wrapper.destroy()
   })
 
-  it('shows the validation message when the input contains an invalid character', async () => {
+  it('Shows the validation message when the input contains an invalid character', async () => {
     const wrapper = await wrapperFactory()
     const vm: any = wrapper.vm
 
@@ -144,8 +141,7 @@ describe('Add Name Translation component', () => {
     // done button not disabled anymore, validation done by validation function
     expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
 
-    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
+    expect(wrapper.find(removeBtn).exists()).toBeFalsy()
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -159,7 +155,7 @@ describe('Add Name Translation component', () => {
     wrapper.destroy()
   })
 
-  it('shows the validation message when the input is too long', async () => {
+  it('Shows the validation message when the input is too long', async () => {
     const wrapper = await wrapperFactory()
     const vm: any = wrapper.vm
 
@@ -191,7 +187,7 @@ describe('Add Name Translation component', () => {
     wrapper.destroy()
   })
 
-  it('displays the correct name when editing a name translation', async () => {
+  it('Displays the correct name when editing a Name Translation', async () => {
     const wrapper = await wrapperFactory({ editNameTranslation: 'Mock Name Edit' })
     const vm: any = wrapper.vm
 
@@ -215,7 +211,7 @@ describe('Add Name Translation component', () => {
     wrapper.destroy()
   })
 
-  it('shows the validaton message when editing an invalid name translation', async () => {
+  it('Shows the validaton message when editing an invalid Name Translation', async () => {
     const wrapper = await wrapperFactory({ editNameTranslation: 'Mock Name Edit' })
     const vm: any = wrapper.vm
 
@@ -244,7 +240,7 @@ describe('Add Name Translation component', () => {
     wrapper.destroy()
   })
 
-  it('inputed text is capitalized', async () => {
+  it('Input text is capitalized', async () => {
     const wrapper = await wrapperFactory()
     const translationInput = wrapper.find(addTranslationInput)
     await translationInput.setValue('Lower case will be capitalized')

--- a/tests/unit/AddNameTranslation.spec.ts
+++ b/tests/unit/AddNameTranslation.spec.ts
@@ -19,7 +19,8 @@ function resetStore (): void {
 
 // Local references
 const addTranslationInput = '#name-translation-input'
-const okBtn = '#name-translation-btn-ok'
+const doneBtn = '#name-translation-btn-done'
+const removeBtn = '#name-translation-btn-remove'
 const cancelBtn = '#name-translation-btn-cancel'
 
 describe('Add Name Translation component', () => {
@@ -53,9 +54,12 @@ describe('Add Name Translation component', () => {
     expect(wrapper.find(addTranslationInput).exists()).toBeTruthy()
 
     // Verify Action btns and their default states
-    expect(wrapper.find(okBtn).exists()).toBeTruthy()
+    expect(wrapper.find(doneBtn).exists()).toBeTruthy()
     // done button not disabled anymore, validation done by validation function
-    expect(wrapper.find(okBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
+
+    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -78,8 +82,11 @@ describe('Add Name Translation component', () => {
     expect(wrapper.find(addTranslationInput).text()).toEqual('Mock Name Translation')
 
     // Verify Action btns and their states
-    expect(wrapper.find(okBtn).exists()).toBeTruthy()
-    expect(wrapper.find(okBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).exists()).toBeTruthy()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
+
+    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -105,8 +112,11 @@ describe('Add Name Translation component', () => {
     expect(wrapper.find(addTranslationInput).text()).toEqual('Nom commercial simulé')
 
     // Verify Action btns and their states
-    expect(wrapper.find(okBtn).exists()).toBeTruthy()
-    expect(wrapper.find(okBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).exists()).toBeTruthy()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
+
+    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -130,9 +140,12 @@ describe('Add Name Translation component', () => {
     expect(wrapper.find(addTranslationInput).text()).toEqual(invalidText)
 
     // Verify Action btns and their states
-    expect(wrapper.find(okBtn).exists()).toBeTruthy()
+    expect(wrapper.find(doneBtn).exists()).toBeTruthy()
     // done button not disabled anymore, validation done by validation function
-    expect(wrapper.find(okBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
+
+    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -162,9 +175,9 @@ describe('Add Name Translation component', () => {
     expect(wrapper.find(addTranslationInput).text()).toEqual(invalidText)
 
     // Verify Action btns and their states
-    expect(wrapper.find(okBtn).exists()).toBeTruthy()
+    expect(wrapper.find(doneBtn).exists()).toBeTruthy()
     // done button not disabled anymore, validation done by validation function
-    expect(wrapper.find(okBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -187,8 +200,11 @@ describe('Add Name Translation component', () => {
     expect(wrapper.find(addTranslationInput).element.value).toContain('Mock Name Edit')
 
     // Verify Action btns and their states
-    expect(wrapper.find(okBtn).exists()).toBeTruthy()
-    expect(wrapper.find(okBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).exists()).toBeTruthy()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
+
+    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBeUndefined() // enabled
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
@@ -212,9 +228,9 @@ describe('Add Name Translation component', () => {
     await wrapper.find(addTranslationInput).trigger('change')
 
     // Verify Action btns and their states
-    expect(wrapper.find(okBtn).exists()).toBeTruthy()
+    expect(wrapper.find(doneBtn).exists()).toBeTruthy()
     // done button not disabled anymore, validation done by validation function
-    expect(wrapper.find(okBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
     expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()

--- a/tests/unit/AddNameTranslation.spec.ts
+++ b/tests/unit/AddNameTranslation.spec.ts
@@ -227,4 +227,12 @@ describe('Add Name Translation component', () => {
 
     wrapper.destroy()
   })
+
+  it('inputed text is capitalized', async () => {
+    const wrapper = await wrapperFactory()
+    const translationInput = wrapper.find(addTranslationInput)
+    await translationInput.setValue('Lower case will be capitalized')
+
+    expect(wrapper.find(addTranslationInput).element.value).toBe('LOWER CASE WILL BE CAPITALIZED')
+  })
 })


### PR DESCRIPTION
Issue #: /https://github.com/bcgov/entity/issues/14545

Corresponding PR in Create UI https://github.com/bcgov/business-create-ui/pull/491

Description of changes:

corp name translation input is now capitalized.
add unit test for name translation input being capitalized.
align AddNameTranslation.vue component and the unit tests to the Create UI
App version 4.4.2 -> 4.4.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).