### PR TITLE
14957 Quick fix to search all business statuses when replacing DBA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "business-edit-ui",
-  "version": "3.9.12",
+  "version": "3.9.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.9.12",
+      "version": "3.9.13",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.3",
         "@bcrs-shared-components/breadcrumb": "2.1.3",
-        "@bcrs-shared-components/business-lookup": "1.1.5",
+        "@bcrs-shared-components/business-lookup": "1.1.6",
         "@bcrs-shared-components/certify": "2.1.3",
         "@bcrs-shared-components/completing-party": "2.1.3",
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
@@ -1829,9 +1829,9 @@
       }
     },
     "node_modules/@bcrs-shared-components/business-lookup": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/business-lookup/-/business-lookup-1.1.5.tgz",
-      "integrity": "sha512-gcxv82SGVqthMVt6zXnGVkunn1rJMIO2nCXDphZmuHt8awk8DOsTth7bTiRgzyQRFneD8qaS/y72G/yN9EM6oQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/business-lookup/-/business-lookup-1.1.6.tgz",
+      "integrity": "sha512-uoS8xbgXwZVmbiAmE8NmBft+4LVSarL3ySBtDgElLP6EWKg0fO6h/RFhKOxk2lf7Q5YDYeMqkczMefPidE01Sw==",
       "dependencies": {
         "@bcrs-shared-components/interfaces": "^1.0.47",
         "vue-debounce-decorator": "^1.0.1",
@@ -24908,9 +24908,9 @@
       }
     },
     "@bcrs-shared-components/business-lookup": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/business-lookup/-/business-lookup-1.1.5.tgz",
-      "integrity": "sha512-gcxv82SGVqthMVt6zXnGVkunn1rJMIO2nCXDphZmuHt8awk8DOsTth7bTiRgzyQRFneD8qaS/y72G/yN9EM6oQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/business-lookup/-/business-lookup-1.1.6.tgz",
+      "integrity": "sha512-uoS8xbgXwZVmbiAmE8NmBft+4LVSarL3ySBtDgElLP6EWKg0fO6h/RFhKOxk2lf7Q5YDYeMqkczMefPidE01Sw==",
       "requires": {
         "@bcrs-shared-components/interfaces": "^1.0.47",
         "vue-debounce-decorator": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.9.12",
+  "version": "3.9.13",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",
@@ -16,7 +16,7 @@
     "@babel/compat-data": "^7.19.1",
     "@bcrs-shared-components/action-chip": "1.1.3",
     "@bcrs-shared-components/breadcrumb": "2.1.3",
-    "@bcrs-shared-components/business-lookup": "1.1.5",
+    "@bcrs-shared-components/business-lookup": "1.1.6",
     "@bcrs-shared-components/certify": "2.1.3",
     "@bcrs-shared-components/completing-party": "2.1.3",
     "@bcrs-shared-components/confirm-dialog": "1.2.1",

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -133,6 +133,7 @@
                       :businessLookup="inProgressBusinessLookup"
                       :BusinessLookupServices="BusinessLookupServices"
                       :editableBusinessName="wasReplaced(currentOrgPerson)"
+                      :searchStatus="searchStatus"
                       @setBusiness="updateBusinessDetails($event)"
                       @undoBusiness="resetBusinessDetails($event)"
                     />
@@ -577,6 +578,13 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
   /** Whether the org was selected using lookup (aka business search). */
   get wasBusinessSelectedFromLookup (): boolean {
     return (this.orgPerson?.isLookupBusiness && !!this.inProgressBusinessLookup.identifier)
+  }
+
+  /** Business status to search for. */
+  get searchStatus (): string {
+    // if this is a DBA replacement then search for all statuses
+    // otherwise search for only ACTIVE statuses
+    return this.wasReplaced(this.currentOrgPerson) ? '' : 'ACTIVE'
   }
 
   /**

--- a/src/services/business-lookup-services.ts
+++ b/src/services/business-lookup-services.ts
@@ -30,10 +30,10 @@ export default class BusinessLookupServices {
   /**
    * Searches for business by code or words.
    * @param query code or words to search
-   * @param status status to match (ACTIVE OR HISTORICAL or '' to match all statuses)
+   * @param status status to match (ACTIVE or HISTORICAL or '' to match all statuses)
    * @returns a promise to return the search results
    */
-  static async search (query: string, status = 'ACTIVE'): Promise<BusinessLookupResultIF[]> {
+  static async search (query: string, status: string): Promise<BusinessLookupResultIF[]> {
     const legalType = 'BC,A,ULC,C,S,XP,GP,LP,CUL,XS,LLC,LL,BEN,CP,CC,XL,FI,XCP,PA'
 
     let url = this.businessApiUrl + 'businesses/search/facets?start=0&rows=20'

--- a/tests/unit/business-lookup-services.spec.ts
+++ b/tests/unit/business-lookup-services.spec.ts
@@ -24,7 +24,7 @@ describe('Business Lookup Services', () => {
       .returns(new Promise(resolve => resolve({ data: { searchResults: { results: [result] } } })))
 
     // search and look at results
-    const results = await BusinessLookupServices.search('FM1000002')
+    const results = await BusinessLookupServices.search('FM1000002', 'ACTIVE')
     expect(results.length).toBe(1)
     expect(results[0]).toEqual(result)
 
@@ -39,7 +39,7 @@ describe('Business Lookup Services', () => {
       .returns(new Promise(resolve => resolve({ data: { searchResults: { results: [] } } })))
 
     // search and look at results
-    const results = await BusinessLookupServices.search('FM1000003')
+    const results = await BusinessLookupServices.search('FM1000003', 'ACTIVE')
     expect(results.length).toBe(0)
 
     sinon.restore()


### PR DESCRIPTION
*Issue #:* bcgov/entity#14957

*Description of changes:*
- imported updated shared Business Lookup component
- pass in searchStatus prop to BL component
- changed search status formal parameter to required (not optional)
- updated unit test
- app version - 3.9.13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).