### PR TITLE
15122 Removed taxid from business object on save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.9.14",
+  "version": "3.9.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.9.14",
+      "version": "3.9.15",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.9.14",
+  "version": "3.9.15",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/EntityInfo.vue
+++ b/src/components/common/EntityInfo.vue
@@ -9,8 +9,9 @@
 
           <dl class="business-info">
             <dd id="entity-legal-type">{{originalEntityType}}</dd>
-            <dt class="mr-2">Business No:</dt>
-            <dd id="entity-business-number">{{ getBusinessNumber || 'Not Available' }}</dd>
+            <!-- this is actually business id but should be tax id (see ticket 15122) -->
+            <!-- <dt class="mr-2">Business No:</dt> -->
+            <!-- <dd id="entity-business-number">{{ getBusinessNumber || 'Not Available' }}</dd> -->
             <dt class="mr-2">Incorporation No:</dt>
             <dd id="entity-incorp-number">{{ getBusinessId }}</dd>
           </dl>

--- a/src/interfaces/store-interfaces/state-interfaces/business-information-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/business-information-interface.ts
@@ -11,6 +11,7 @@ export interface BusinessInformationIF {
   legalType: CorpTypeCd
   nrNumber?: string
   startDate?: string // YYYY-MM-DD
+  taxId?: string // may br BN9 or BN15
 
   // SP/GP only:
   naicsCode?: string

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -132,6 +132,9 @@ export default class FilingTemplateMixin extends DateMixin {
       }
     }
 
+    // delete invalid tax id (see ticket 15122)
+    delete filing.business.taxId
+
     // delete invalid NAICS properties
     delete filing.business.naicsCode
     delete filing.business.naicsDescription
@@ -207,6 +210,9 @@ export default class FilingTemplateMixin extends DateMixin {
         contactPoint: this.getContactPoint
       }
     }
+
+    // delete invalid tax id (see ticket 15122)
+    delete filing.business.taxId
 
     // Apply NR / business name / business type change to filing
     if (this.getNameRequestNumber || this.hasBusinessNameChanged || this.hasBusinessTypeChanged) {
@@ -288,6 +294,10 @@ export default class FilingTemplateMixin extends DateMixin {
         ...this.getSpecialResolution
       }
     }
+
+    // delete invalid tax id (see ticket 15122)
+    delete filing.business.taxId
+
     /* Only add alteration if the association type has changed,
      * rules and memorandum only show up if the association type changes. */
     if (this.hasAssociationTypeChanged) {
@@ -346,6 +356,9 @@ export default class FilingTemplateMixin extends DateMixin {
         contactPoint: this.getContactPoint
       }
     }
+
+    // delete invalid tax id (see ticket 15122)
+    delete filing.business.taxId
 
     // Apply NAICS change to filing
     if (this.hasNaicsChanged) {
@@ -445,6 +458,9 @@ export default class FilingTemplateMixin extends DateMixin {
         parties: null // applied below
       }
     }
+
+    // delete invalid tax id (see ticket 15122)
+    delete filing.business.taxId
 
     // Apply NAICS change to filing
     if (this.hasNaicsChanged) {

--- a/tests/unit/EntityInfo.spec.ts
+++ b/tests/unit/EntityInfo.spec.ts
@@ -77,7 +77,8 @@ describe('Entity Info component in a Correction as a named company', () => {
 
   it('renders the business name and numbers', () => {
     expect(wrapper.find('#entity-legal-name').text()).toBe('My Mock Name Inc.')
-    expect(wrapper.find('#entity-business-number').text()).toBe('1234567')
+    // this is actually business id but should be tax id (see ticket 15122)
+    // expect(wrapper.find('#entity-business-number').text()).toBe('1234567')
     expect(wrapper.find('#entity-incorp-number').text()).toBe('BC1234567')
   })
 
@@ -147,7 +148,8 @@ describe('Entity Info component in a Correction as a numbered company', () => {
 
   it('renders the business name and numbers', () => {
     expect(wrapper.find('#entity-legal-name').text()).toBe('Numbered Benefit Company')
-    expect(wrapper.find('#entity-business-number').text()).toBe('7654321')
+    // this is actually business id but should be tax id (see ticket 15122)
+    // expect(wrapper.find('#entity-business-number').text()).toBe('7654321')
     expect(wrapper.find('#entity-incorp-number').text()).toBe('BC7654321')
   })
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#15122

*Description of changes:*
- hide Business Number in header
- delete invalid taxid from business object
- updated unit tests
- app version = 3.9.15

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).