### PR TITLE
15124 Restore taxId in business object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -136,9 +136,6 @@ export default class FilingTemplateMixin extends DateMixin {
       }
     }
 
-    // delete invalid tax id (see ticket 15122)
-    delete filing.business.taxId
-
     // delete invalid NAICS properties
     delete filing.business.naicsCode
     delete filing.business.naicsDescription
@@ -214,9 +211,6 @@ export default class FilingTemplateMixin extends DateMixin {
         contactPoint: this.getContactPoint
       }
     }
-
-    // delete invalid tax id (see ticket 15122)
-    delete filing.business.taxId
 
     // Apply NR / business name / business type change to filing
     if (this.getNameRequestNumber || this.hasBusinessNameChanged || this.hasBusinessTypeChanged) {
@@ -301,9 +295,6 @@ export default class FilingTemplateMixin extends DateMixin {
       }
     }
 
-    // delete invalid tax id (see ticket 15122)
-    delete filing.business.taxId
-
     // Apply NR / business name / business type change to filing
     if (this.getNameRequestNumber || this.hasBusinessNameChanged || this.hasBusinessTypeChanged) {
       filing.restoration.nameRequest = this.getNameRequest
@@ -365,9 +356,6 @@ export default class FilingTemplateMixin extends DateMixin {
       }
     }
 
-    // delete invalid tax id (see ticket 15122)
-    delete filing.business.taxId
-
     /* Only add alteration if the association type has changed,
      * rules and memorandum only show up if the association type changes. */
     if (this.hasAssociationTypeChanged) {
@@ -427,9 +415,6 @@ export default class FilingTemplateMixin extends DateMixin {
         parties: null // applied below
       }
     }
-
-    // delete invalid tax id (see ticket 15122)
-    delete filing.business.taxId
 
     // Apply NAICS change to filing
     if (this.hasNaicsChanged) {
@@ -529,9 +514,6 @@ export default class FilingTemplateMixin extends DateMixin {
         parties: null // applied below
       }
     }
-
-    // delete invalid tax id (see ticket 15122)
-    delete filing.business.taxId
 
     // Apply NAICS change to filing
     if (this.hasNaicsChanged) {

--- a/tests/unit/EntityInfo.spec.ts
+++ b/tests/unit/EntityInfo.spec.ts
@@ -23,7 +23,8 @@ describe('Entity Info component in a Correction as a named company', () => {
     },
     business: {
       identifier: 'BC1234567',
-      legalType: 'BEN'
+      legalType: 'BEN',
+      taxId: '123456789' // sample BN9
     },
     incorporationApplication: {
       contactPoint: {
@@ -77,8 +78,7 @@ describe('Entity Info component in a Correction as a named company', () => {
 
   it('renders the business name and numbers', () => {
     expect(wrapper.find('#entity-legal-name').text()).toBe('My Mock Name Inc.')
-    // this is actually business id but should be tax id (see ticket 15122)
-    // expect(wrapper.find('#entity-business-number').text()).toBe('1234567')
+    expect(wrapper.find('#entity-business-number').text()).toBe('123456789')
     expect(wrapper.find('#entity-incorp-number').text()).toBe('BC1234567')
   })
 
@@ -97,8 +97,9 @@ describe('Entity Info component in a Correction as a numbered company', () => {
       filingId: 12345
     },
     business: {
-      identifier: 'BC7654321',
-      legalType: 'BEN'
+      identifier: 'BC1234567',
+      legalType: 'BEN',
+      taxId: '123456789BC0001' // sample BN15
     },
     incorporationApplication: {
       contactPoint: {
@@ -148,9 +149,8 @@ describe('Entity Info component in a Correction as a numbered company', () => {
 
   it('renders the business name and numbers', () => {
     expect(wrapper.find('#entity-legal-name').text()).toBe('Numbered Benefit Company')
-    // this is actually business id but should be tax id (see ticket 15122)
-    // expect(wrapper.find('#entity-business-number').text()).toBe('7654321')
-    expect(wrapper.find('#entity-incorp-number').text()).toBe('BC7654321')
+    expect(wrapper.find('#entity-business-number').text()).toBe('123456789BC0001')
+    expect(wrapper.find('#entity-incorp-number').text()).toBe('BC1234567')
   })
 
   it('renders the business contact information', () => {


### PR DESCRIPTION
*Issue #:* bcgov/entity#15124

*Description of changes:*
- removed taxId deletion in Filing Template Mixin
- updated unit tests
- app version = 3.10.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).