### PR TITLE
15291 hide sole proprietor change button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -283,7 +283,7 @@
 
               <!-- org-person we haven't touched: -->
               <div v-else class="actions mr-4">
-                <span class="edit-action" v-if="showSoleProprietorChangeButton">
+                <span class="edit-action" v-if="hideChangeButtonForSoleProps">
                   <v-btn
                     text color="primary"
                     :id="`officer-${index}-edit-btn`"
@@ -376,7 +376,7 @@ import OrgPerson from './OrgPerson.vue'
 import { CommonMixin, OrgPersonMixin } from '@/mixins/'
 import { IsSame } from '@/utils/'
 import { OrgPersonIF } from '@/interfaces/'
-import { showSoleProprietorChangeButton } from '@/store/getters'
+import { hideChangeButtonForSoleProps } from '@/store/getters'
 
 @Component({
   components: {
@@ -415,7 +415,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
   @Getter isFirmConversionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
   @Getter isRoleStaff!: boolean
-  @Getter showSoleProprietorChangeButton!: boolean
+  @Getter hideChangeButtonForSoleProps!: boolean
 
   /** V-model for dropdown menus. */
   protected dropdown: Array<boolean> = []

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -283,7 +283,7 @@
 
               <!-- org-person we haven't touched: -->
               <div v-else class="actions mr-4">
-                <span class="edit-action">
+                <span class="edit-action" v-if="showSoleProprietorChangeButton">
                   <v-btn
                     text color="primary"
                     :id="`officer-${index}-edit-btn`"
@@ -376,6 +376,7 @@ import OrgPerson from './OrgPerson.vue'
 import { CommonMixin, OrgPersonMixin } from '@/mixins/'
 import { IsSame } from '@/utils/'
 import { OrgPersonIF } from '@/interfaces/'
+import { showSoleProprietorChangeButton } from '@/store/getters'
 
 @Component({
   components: {
@@ -414,6 +415,7 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin, OrgPersonMix
   @Getter isFirmConversionFiling!: boolean
   @Getter isFirmCorrectionFiling!: boolean
   @Getter isRoleStaff!: boolean
+  @Getter showSoleProprietorChangeButton!: boolean
 
   /** V-model for dropdown menus. */
   protected dropdown: Array<boolean> = []

--- a/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/ListPeopleAndRoles.vue
@@ -283,7 +283,7 @@
 
               <!-- org-person we haven't touched: -->
               <div v-else class="actions mr-4">
-                <span class="edit-action" v-if="hideChangeButtonForSoleProps">
+                <span class="edit-action" v-if="!hideChangeButtonForSoleProps">
                   <v-btn
                     text color="primary"
                     :id="`officer-${index}-edit-btn`"
@@ -376,7 +376,6 @@ import OrgPerson from './OrgPerson.vue'
 import { CommonMixin, OrgPersonMixin } from '@/mixins/'
 import { IsSame } from '@/utils/'
 import { OrgPersonIF } from '@/interfaces/'
-import { hideChangeButtonForSoleProps } from '@/store/getters'
 
 @Component({
   components: {

--- a/src/resources/Change/SP.ts
+++ b/src/resources/Change/SP.ts
@@ -21,7 +21,7 @@ export const SpChangeResource: ResourceIF = {
     orgPersonInfo: {
       orgPersonLabel: 'Proprietor',
       orgTypesLabel: 'Business or Corporation',
-      subtitle: 'BC Registries staff can assist in changing the proprietor information.',
+      subtitle: 'BC Registries Staff are available to help you make changes to the business proprietor information.',
       helpSection: {
         header: 'Need Help? Contact Us',
         helpText: [

--- a/src/resources/Change/SP.ts
+++ b/src/resources/Change/SP.ts
@@ -21,7 +21,7 @@ export const SpChangeResource: ResourceIF = {
     orgPersonInfo: {
       orgPersonLabel: 'Proprietor',
       orgTypesLabel: 'Business or Corporation',
-      subtitle: 'BC Registries Staff are available to help you make changes to the business proprietor information.',
+      subtitle: 'If you need to make changes to the business proprietor information, please contact BC Registries Staff.',
       helpSection: {
         header: 'Need Help? Contact Us',
         helpText: [

--- a/src/resources/Change/SP.ts
+++ b/src/resources/Change/SP.ts
@@ -21,9 +21,7 @@ export const SpChangeResource: ResourceIF = {
     orgPersonInfo: {
       orgPersonLabel: 'Proprietor',
       orgTypesLabel: 'Business or Corporation',
-      subtitle: 'You can change the legal name, mailing and delivery addresses and the email address of the ' +
-        'individual proprietor. To change to a different proprietor, you must form a new business with that ' +
-        'proprietor and dissolve this registration.',
+      subtitle: 'BC Registries staff can assist in changing the proprietor information.',
       helpSection: {
         header: 'Need Help? Contact Us',
         helpText: [

--- a/src/resources/Change/SPOrganization.ts
+++ b/src/resources/Change/SPOrganization.ts
@@ -2,7 +2,7 @@ import { NameChangeOptions, FilingCodes, NameRequestTypes } from '@/enums/'
 import { CorpTypeCd, GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module/'
 import { ResourceIF } from '@/interfaces/'
 
-export const SpChangeResource: ResourceIF = {
+export const SpOrganizationChangeResource: ResourceIF = {
   entityReference: 'Business',
   contactLabel: 'Business',
   displayName: GetCorpFullDescription(CorpTypeCd.SOLE_PROP),
@@ -21,9 +21,8 @@ export const SpChangeResource: ResourceIF = {
     orgPersonInfo: {
       orgPersonLabel: 'Proprietor',
       orgTypesLabel: 'Business or Corporation',
-      subtitle: 'You can change the legal name, mailing and delivery addresses and the email address of the ' +
-        'individual proprietor. To change to a different proprietor, you must form a new business with that ' +
-        'proprietor and dissolve this registration.',
+      subtitle: 'If you need to make changes to the business proprietor information, please ' +
+        'contact BC Registries Staff.',
       helpSection: {
         header: 'Need Help? Contact Us',
         helpText: [

--- a/src/resources/Change/index.ts
+++ b/src/resources/Change/index.ts
@@ -1,2 +1,3 @@
 export * from './GP'
 export * from './SP'
+export * from './SPOrganization'

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -1060,13 +1060,15 @@ export const getSpecialResolutionConfirmValid = (state: StateIF): boolean => {
 export const getRestoration = (state: StateIF): RestorationStateIF => {
   return state.stateModel.restoration
 }
+
 /** Returns true when users can change the sole proprietor (SP).
  * Restricts the ability of non-staff users from changing the sole
- * proprietor when the SP is a non-individual.  This restriction has been
+ * proprietor when the SP is an organization.  This restriction has been
  * added to ensure that changes made in business-edit-ui are also updated by
  * staff in COLIN */
 export const showSoleProprietorChangeButton = (state: StateIF, getters): boolean => {
-  const isProprietor = getters.getOrgPeople?.[0].roles?.[0]?.roleType === RoleTypes.PROPRIETOR
-  const isOrganization = getters.getOrgPeople?.[0]?.officer?.partyType === PartyTypes.ORGANIZATION
-  return !(!getters.isRoleStaff && getters.isSoleProp && isOrganization && isProprietor)
+  const isProprietor = getters.getOrgPeople[0]?.roles[0]?.roleType === RoleTypes.PROPRIETOR
+  const isOrganization = getters.getOrgPeople[0]?.officer?.partyType === PartyTypes.ORGANIZATION
+  const isDba = isProprietor && isOrganization
+  return getters.isRoleStaff || !isDba
 }

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -1,12 +1,43 @@
-import { AccountTypes, ActionTypes, CoopTypes, CorrectionErrorTypes, FilingNames, FilingTypes,
-  PartyTypes, RestorationTypes } from '@/enums/'
+import {
+  AccountTypes,
+  ActionTypes,
+  CoopTypes,
+  CorrectionErrorTypes,
+  FilingNames,
+  FilingTypes,
+  PartyTypes,
+  RestorationTypes,
+  RoleTypes
+} from '@/enums/'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
-import { AddressesIF, OrgPersonIF, ShareClassIF, NameRequestIF, BusinessInformationIF, CertifyIF,
-  NameTranslationIF, FilingDataIF, StateIF, EffectiveDateTimeIF, FlagsReviewCertifyIF,
-  FlagsCompanyInfoIF, ResolutionsIF, FeesIF, ResourceIF, EntitySnapshotIF, ValidationFlagsIF,
-  CorrectionInformationIF, RestorationStateIF } from '@/interfaces/'
-import { CompletingPartyIF, ContactPointIF, NaicsIF, StaffPaymentIF, SpecialResolutionIF }
-  from '@bcrs-shared-components/interfaces/'
+import {
+  AddressesIF,
+  BusinessInformationIF,
+  CertifyIF,
+  CorrectionInformationIF,
+  EffectiveDateTimeIF,
+  EntitySnapshotIF,
+  FeesIF,
+  FilingDataIF,
+  FlagsCompanyInfoIF,
+  FlagsReviewCertifyIF,
+  NameRequestIF,
+  NameTranslationIF,
+  OrgPersonIF,
+  ResolutionsIF,
+  ResourceIF,
+  RestorationStateIF,
+  ShareClassIF,
+  StateIF,
+  ValidationFlagsIF
+} from '@/interfaces/'
+import {
+  CompletingPartyIF,
+  ContactPointIF,
+  NaicsIF,
+  SpecialResolutionIF,
+  StaffPaymentIF
+} from '@bcrs-shared-components/interfaces/'
 import { IsSame } from '@/utils/'
 
 /** Whether the user has "staff" keycloak role. */
@@ -1028,4 +1059,14 @@ export const getSpecialResolutionConfirmValid = (state: StateIF): boolean => {
 /** The restoration object. */
 export const getRestoration = (state: StateIF): RestorationStateIF => {
   return state.stateModel.restoration
+}
+/** Returns true when users can change the sole proprietor (SP).
+ * Restricts the ability of non-staff users from changing the sole
+ * proprietor when the SP is a non-individual.  This restriction has been
+ * added to ensure that changes made in business-edit-ui are also updated by
+ * staff in COLIN */
+export const showSoleProprietorChangeButton = (state: StateIF, getters): boolean => {
+  const isProprietor = getters.getOrgPeople?.[0].roles?.[0]?.roleType === RoleTypes.PROPRIETOR
+  const isOrganization = getters.getOrgPeople?.[0]?.officer?.partyType === PartyTypes.ORGANIZATION
+  return !(!getters.isRoleStaff && getters.isSoleProp && isOrganization && isProprietor)
 }

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -1061,7 +1061,7 @@ export const getRestoration = (state: StateIF): RestorationStateIF => {
   return state.stateModel.restoration
 }
 
-/** Returns true when users can change the sole proprietor (SP).
+/** Returns false when users can change the sole proprietor (SP).
  * Restricts the ability of non-staff users from changing the sole
  * proprietor when the SP is an organization.  This restriction has been
  * added to ensure that changes made in business-edit-ui are also updated by
@@ -1070,5 +1070,5 @@ export const hideChangeButtonForSoleProps = (state: StateIF, getters): boolean =
   const isProprietor = getters.getOrgPeople[0]?.roles[0]?.roleType === RoleTypes.PROPRIETOR
   const isOrganization = getters.getOrgPeople[0]?.officer?.partyType === PartyTypes.ORGANIZATION
   const isDba = isProprietor && isOrganization
-  return getters.isRoleStaff || !isDba
+  return !getters.isRoleStaff && isDba
 }

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -1066,7 +1066,7 @@ export const getRestoration = (state: StateIF): RestorationStateIF => {
  * proprietor when the SP is an organization.  This restriction has been
  * added to ensure that changes made in business-edit-ui are also updated by
  * staff in COLIN */
-export const showSoleProprietorChangeButton = (state: StateIF, getters): boolean => {
+export const hideChangeButtonForSoleProps = (state: StateIF, getters): boolean => {
   const isProprietor = getters.getOrgPeople[0]?.roles[0]?.roleType === RoleTypes.PROPRIETOR
   const isOrganization = getters.getOrgPeople[0]?.officer?.partyType === PartyTypes.ORGANIZATION
   const isDba = isProprietor && isOrganization

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -93,9 +93,9 @@ import { CertifySection, CompletingParty, CourtOrderPoa, DocumentsDelivery, Peop
 import { AuthServices, LegalServices } from '@/services/'
 import { CommonMixin, FeeMixin, FilingTemplateMixin } from '@/mixins/'
 import { ActionBindingIF, EntitySnapshotIF, ResourceIF } from '@/interfaces/'
-import { FilingStatus } from '@/enums/'
+import { FilingStatus, PartyTypes } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
-import { SpChangeResource, GpChangeResource } from '@/resources/Change/'
+import { SpChangeResource, GpChangeResource, SpOrganizationChangeResource } from '@/resources/Change/'
 
 @Component({
   components: {
@@ -154,7 +154,9 @@ export default class Change extends Mixins(
 
   /** The resource object for a firm change filing. */
   get firmChangeResource (): ResourceIF {
+    const isOfficerOrganization = this.getOrgPeople[0]?.officer?.partyType === PartyTypes.ORGANIZATION
     if (this.isPartnership) return GpChangeResource
+    if (this.isSoleProp && isOfficerOrganization) return SpOrganizationChangeResource
     if (this.isSoleProp) return SpChangeResource
     return null
   }

--- a/tests/unit/Change.spec.ts
+++ b/tests/unit/Change.spec.ts
@@ -245,6 +245,32 @@ describe('Change component', () => {
     wrapper.vm.showFee = true
   })
 
+  it('resource subtitle states individual sole proprietors can change legal name', () => {
+    store.state.stateModel.tombstone.entityType = 'SP'
+    store.state.stateModel.peopleAndRoles.orgPeople = [
+      {
+        officer: { partyType: 'person' },
+        roles: [{ roleType: 'Proprietor' }]
+      }
+    ]
+    const wrapper: any = shallowMount(Change, { store, vuetify })
+    expect(wrapper.vm.firmChangeResource.changeData.orgPersonInfo.subtitle)
+      .toContain('You can change the legal name, mailing and delivery')
+  })
+
+  it('resource subtitle states organization sole proprietors cannot change legal name', () => {
+    store.state.stateModel.tombstone.entityType = 'SP'
+    store.state.stateModel.peopleAndRoles.orgPeople = [
+      {
+        officer: { partyType: 'organization' },
+        roles: [{ roleType: 'Proprietor' }]
+      }
+    ]
+    const wrapper: any = shallowMount(Change, { store, vuetify })
+    expect(wrapper.vm.firmChangeResource.changeData.orgPersonInfo.subtitle)
+      .toContain('If you need to make changes to the business proprietor information, please')
+  })
+
   // FUTURE
   xit('loads the entity snapshot into the store', async () => {
     await wrapper.setProps({ appReady: true })

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -476,10 +476,10 @@ describe('People And Roles component for Change of Registration', () => {
     store.state.stateModel.peopleAndRoles.orgPeople = [
       {
         officer: {
-          partyType: "organization",
+          partyType: 'organization',
           id: '0'
         },
-        roles: [{ roleType: "Proprietor" }]
+        roles: [{ roleType: 'Proprietor' }]
       }
     ]
     expect(store.getters.showSoleProprietorChangeButton).toBe(false)
@@ -491,10 +491,10 @@ describe('People And Roles component for Change of Registration', () => {
     store.state.stateModel.peopleAndRoles.orgPeople = [
       {
         officer: {
-          partyType: "organization",
+          partyType: 'organization',
           id: '0'
         },
-        roles: [{ roleType: "Proprietor" }]
+        roles: [{ roleType: 'Proprietor' }]
       }
     ]
     expect(store.getters.showSoleProprietorChangeButton).toBe(true)
@@ -506,10 +506,10 @@ describe('People And Roles component for Change of Registration', () => {
     store.state.stateModel.peopleAndRoles.orgPeople = [
       {
         officer: {
-          partyType: "person",
+          partyType: 'person',
           id: '0'
         },
-        roles: [{ roleType: "Proprietor" }]
+        roles: [{ roleType: 'Proprietor' }]
       }
     ]
     expect(store.getters.showSoleProprietorChangeButton).toBe(true)

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -475,14 +475,11 @@ describe('People And Roles component for Change of Registration', () => {
     store.state.stateModel.tombstone.entityType = 'SP'
     store.state.stateModel.peopleAndRoles.orgPeople = [
       {
-        officer: {
-          partyType: 'organization',
-          id: '0'
-        },
+        officer: { partyType: 'organization' },
         roles: [{ roleType: 'Proprietor' }]
       }
     ]
-    expect(store.getters.hideChangeButtonForSoleProps).toBe(false)
+    expect(store.getters.hideChangeButtonForSoleProps).toBe(true)
   })
 
   it('change button is visible to staff for SP where the sole proprietor is an organization', () => {
@@ -490,14 +487,11 @@ describe('People And Roles component for Change of Registration', () => {
     store.state.stateModel.tombstone.entityType = 'SP'
     store.state.stateModel.peopleAndRoles.orgPeople = [
       {
-        officer: {
-          partyType: 'organization',
-          id: '0'
-        },
+        officer: { partyType: 'organization' },
         roles: [{ roleType: 'Proprietor' }]
       }
     ]
-    expect(store.getters.hideChangeButtonForSoleProps).toBe(true)
+    expect(store.getters.hideChangeButtonForSoleProps).toBe(false)
   })
 
   it('change button is visible to users for SP where the sole proprietor is an individual', () => {
@@ -505,13 +499,10 @@ describe('People And Roles component for Change of Registration', () => {
     store.state.stateModel.tombstone.entityType = 'SP'
     store.state.stateModel.peopleAndRoles.orgPeople = [
       {
-        officer: {
-          partyType: 'person',
-          id: '0'
-        },
+        officer: { partyType: 'person' },
         roles: [{ roleType: 'Proprietor' }]
       }
     ]
-    expect(store.getters.hideChangeButtonForSoleProps).toBe(true)
+    expect(store.getters.hideChangeButtonForSoleProps).toBe(false)
   })
 })

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -469,4 +469,49 @@ describe('People And Roles component for Change of Registration', () => {
     expect(wrapper.vm.$data.activeIndex).toBe(NaN)
     expect(wrapper.vm.$data.isAddingEditingOrgPerson).toBe(true)
   })
+
+  it('change button is not visible to users for SP where the sole proprietor is a non-individual', () => {
+    store.state.stateModel.tombstone.keycloakRoles = ['user']
+    store.state.stateModel.tombstone.entityType = 'SP'
+    store.state.stateModel.peopleAndRoles.orgPeople = [
+      {
+        officer: {
+          partyType: "organization",
+          id: '0'
+        },
+        roles: [{ roleType: "Proprietor" }]
+      }
+    ]
+    expect(store.getters.showSoleProprietorChangeButton).toBe(false)
+  })
+
+  it('change button is visible to staff for SP where the sole proprietor is a non-individual', () => {
+    store.state.stateModel.tombstone.keycloakRoles = ['staff']
+    store.state.stateModel.tombstone.entityType = 'SP'
+    store.state.stateModel.peopleAndRoles.orgPeople = [
+      {
+        officer: {
+          partyType: "organization",
+          id: '0'
+        },
+        roles: [{ roleType: "Proprietor" }]
+      }
+    ]
+    expect(store.getters.showSoleProprietorChangeButton).toBe(true)
+  })
+
+  it('change button is visible to users for SP where the sole proprietor is an individual', () => {
+    store.state.stateModel.tombstone.keycloakRoles = ['user']
+    store.state.stateModel.tombstone.entityType = 'SP'
+    store.state.stateModel.peopleAndRoles.orgPeople = [
+      {
+        officer: {
+          partyType: "person",
+          id: '0'
+        },
+        roles: [{ roleType: "Proprietor" }]
+      }
+    ]
+    expect(store.getters.showSoleProprietorChangeButton).toBe(true)
+  })
 })

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -470,7 +470,7 @@ describe('People And Roles component for Change of Registration', () => {
     expect(wrapper.vm.$data.isAddingEditingOrgPerson).toBe(true)
   })
 
-  it('change button is not visible to users for SP where the sole proprietor is a non-individual', () => {
+  it('change button is not visible to users for SP where the sole proprietor is an organization', () => {
     store.state.stateModel.tombstone.keycloakRoles = ['user']
     store.state.stateModel.tombstone.entityType = 'SP'
     store.state.stateModel.peopleAndRoles.orgPeople = [
@@ -485,7 +485,7 @@ describe('People And Roles component for Change of Registration', () => {
     expect(store.getters.showSoleProprietorChangeButton).toBe(false)
   })
 
-  it('change button is visible to staff for SP where the sole proprietor is a non-individual', () => {
+  it('change button is visible to staff for SP where the sole proprietor is an organization', () => {
     store.state.stateModel.tombstone.keycloakRoles = ['staff']
     store.state.stateModel.tombstone.entityType = 'SP'
     store.state.stateModel.peopleAndRoles.orgPeople = [

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -482,7 +482,7 @@ describe('People And Roles component for Change of Registration', () => {
         roles: [{ roleType: 'Proprietor' }]
       }
     ]
-    expect(store.getters.showSoleProprietorChangeButton).toBe(false)
+    expect(store.getters.hideChangeButtonForSoleProps).toBe(false)
   })
 
   it('change button is visible to staff for SP where the sole proprietor is an organization', () => {
@@ -497,7 +497,7 @@ describe('People And Roles component for Change of Registration', () => {
         roles: [{ roleType: 'Proprietor' }]
       }
     ]
-    expect(store.getters.showSoleProprietorChangeButton).toBe(true)
+    expect(store.getters.hideChangeButtonForSoleProps).toBe(true)
   })
 
   it('change button is visible to users for SP where the sole proprietor is an individual', () => {
@@ -512,6 +512,6 @@ describe('People And Roles component for Change of Registration', () => {
         roles: [{ roleType: 'Proprietor' }]
       }
     ]
-    expect(store.getters.showSoleProprietorChangeButton).toBe(true)
+    expect(store.getters.hideChangeButtonForSoleProps).toBe(true)
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15291

The business has requested that non-staff users should not be able to modify the sole proprietor where the sole proprietor is an organization.  This PR hides the appropriate change button and updates the related help text.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
