### PR TITLE
15081 add restoration extension and conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.10.2",
+      "version": "3.10.3",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -160,7 +160,7 @@ import { ConfirmDialog as ConfirmDialogShared } from '@bcrs-shared-components/co
 import * as Views from '@/views/'
 import * as Dialogs from '@/dialogs/'
 import { AuthServices, LegalServices } from '@/services/'
-import { CommonMixin, DateMixin, FilingTemplateMixin } from '@/mixins/'
+import { CommonMixin, FilingTemplateMixin } from '@/mixins/'
 import { FilingDataIF, ActionBindingIF, ConfirmDialogType, FlagsReviewCertifyIF, FlagsCompanyInfoIF,
   AlterationFilingIF, ChgRegistrationFilingIF, ConversionFilingIF, SpecialResolutionFilingIF }
   from '@/interfaces/'
@@ -170,6 +170,7 @@ import { ComponentsCompanyInfo, ComponentsReviewCertify, RouteNames } from '@/en
 import { FeeSummaryActions } from '@bcrs-shared-components/enums/'
 import { getEntityDashboardBreadcrumb, getMyBusinessRegistryBreadcrumb, getRegistryDashboardBreadcrumb,
   getStaffDashboardBreadcrumb } from '@/resources/BreadCrumbResources'
+import DateUtilities from '@/services/date-utilities'
 
 @Component({
   components: {
@@ -184,9 +185,13 @@ import { getEntityDashboardBreadcrumb, getMyBusinessRegistryBreadcrumb, getRegis
     SbcFeeSummary,
     ...Dialogs,
     ...Views
-  }
+  },
+  mixins: [
+    CommonMixin,
+    FilingTemplateMixin
+  ]
 })
-export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMixin) {
+export default class App extends Vue {
   // Refs
   $refs!: {
     confirm: ConfirmDialogType
@@ -444,7 +449,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
 
   /** Fetches and stores the current JS date. */
   private async updateCurrentJsDate (): Promise<void> {
-    const jsDate = await this.getServerDate()
+    const jsDate = await DateUtilities.getServerDate()
     this.setCurrentJsDate(jsDate)
   }
 
@@ -494,7 +499,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
     this.resetFlags()
 
     // set current date from "real time" date from server
-    this.setCurrentDate(this.dateToYyyyMmDd(this.getCurrentJsDate))
+    this.setCurrentDate(DateUtilities.dateToYyyyMmDd(this.getCurrentJsDate))
 
     // get and store keycloak roles
     try {

--- a/src/components/Restoration/YourCompanySummary.vue
+++ b/src/components/Restoration/YourCompanySummary.vue
@@ -5,7 +5,7 @@
       <v-row no-gutters>
         <v-col cols="9">
           <img class="header-icon" src="@/assets/images/currency-usd-circle.svg">
-          <label class="summary-title">Your Company</label>
+          <label class="summary-title pl-2">Your Company</label>
         </v-col>
       </v-row>
     </div>
@@ -19,7 +19,7 @@
           </v-col>
           <v-col cols="8" class="mt-n1" v-if="isLimitedExtendRestorationFiling">
             <div class="font-weight-bold">Limited Restoration Extension</div>
-            <div>Extension Time: {{ getFormattedExpiryText }}</div>
+            <div>Extension Time: {{ getFormattedExpiryText() }}</div>
           </v-col>
           <v-col cols="8" class="mt-n1" v-if="isLimitedConversionRestorationFiling">
             <div class="font-weight-bold">Conversion to Full Restoration</div>
@@ -58,40 +58,6 @@ export default {
   display: flex;
   background-color: $BCgovBlue5O;
   padding: 1.25rem;
-}
-
-.summary-title {
-  padding-left: 0.5rem;
-}
-
-.company-name {
-  font-size: 1.5rem;
-}
-
-.actions {
-  position: absolute;
-  right: 0;
-
-  #btn-delete-restoration {
-    margin-top: -6px;
-  }
-}
-
-.inner-col-1 {
-  // adjustment to make this inner container column the same width as the outer columns
-  // ie, decrease width by 1/2 container margin + padding
-  flex: 0 0 calc(25% - 1.5rem);
-}
-
-.inner-col-2 {
-  // adjustment to make this inner container column the same width as the outer columns
-  // ie, increase width by 1/2 container margin + padding
-  flex: 0 0 calc(75% + 1.5rem);
-  max-width: calc(75% + 1.5rem);
-}
-
-#effective-date-text {
-  color: $gray7;
 }
 
 // hide first v-divider

--- a/src/components/Restoration/YourCompanySummary.vue
+++ b/src/components/Restoration/YourCompanySummary.vue
@@ -1,0 +1,101 @@
+<template>
+  <v-card flat id="restoration-summary">
+    <!-- Section Header -->
+    <div class="summary-header px-4 mb-2 rounded-t">
+      <v-row no-gutters>
+        <v-col cols="9">
+          <img class="header-icon" src="@/assets/images/currency-usd-circle.svg">
+          <label class="summary-title">Your Company</label>
+        </v-col>
+      </v-row>
+    </div>
+    <!-- Business Name -->
+    <template>
+      <v-divider class="mx-4" />
+      <div class="section-container business-name-summary">
+        <v-row no-gutters>
+          <v-col cols="3">
+            <label><strong>Restoration Type</strong></label>
+          </v-col>
+          <v-col cols="8" class="mt-n1" v-if="isLimitedExtendRestorationFiling">
+            <div class="font-weight-bold">Limited Restoration Extension</div>
+            <div>Extension Time: {{ getFormattedExpiryText }}</div>
+          </v-col>
+          <v-col cols="8" class="mt-n1" v-if="isLimitedConversionRestorationFiling">
+            <div class="font-weight-bold">Conversion to Full Restoration</div>
+            <div>[TODO - Applicant's relationship: Director, Shareholder]</div>
+          </v-col>
+        </v-row>
+        <v-row no-gutters class="mt-3" v-if="hasFileNumber">
+          <v-col cols="3">
+            <label><strong>Approval Type</strong></label>
+          </v-col>
+          <v-col cols="8" class="mt-n1">
+            <div class="font-weight-bold">Approved by Court Order</div>
+            <div>Court Order Number: {{ getFileNumber }}</div>
+          </v-col>
+        </v-row>
+      </div>
+    </template>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { mapGetters } from 'vuex'
+
+export default {
+  computed: {
+    ...mapGetters(['isLimitedConversionRestorationFiling', 'isLimitedExtendRestorationFiling',
+      'hasFileNumber', 'getFileNumber', 'getFormattedExpiryText'])
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/assets/styles/theme.scss';
+
+.summary-header {
+  display: flex;
+  background-color: $BCgovBlue5O;
+  padding: 1.25rem;
+}
+
+.summary-title {
+  padding-left: 0.5rem;
+}
+
+.company-name {
+  font-size: 1.5rem;
+}
+
+.actions {
+  position: absolute;
+  right: 0;
+
+  #btn-delete-restoration {
+    margin-top: -6px;
+  }
+}
+
+.inner-col-1 {
+  // adjustment to make this inner container column the same width as the outer columns
+  // ie, decrease width by 1/2 container margin + padding
+  flex: 0 0 calc(25% - 1.5rem);
+}
+
+.inner-col-2 {
+  // adjustment to make this inner container column the same width as the outer columns
+  // ie, increase width by 1/2 container margin + padding
+  flex: 0 0 calc(75% + 1.5rem);
+  max-width: calc(75% + 1.5rem);
+}
+
+#effective-date-text {
+  color: $gray7;
+}
+
+// hide first v-divider
+.v-divider:first-of-type {
+  display: none;
+}
+</style>

--- a/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
@@ -30,11 +30,7 @@
       </v-col>
 
       <!-- Actions -->
-      <v-col cols="2" class="mt-n2" v-if="
-      !hasNameTranslationChange &&
-      !isSummaryMode &&
-      !isLimitedConversionRestorationFiling &&
-      !isLimitedExtendRestorationFiling">
+      <v-col cols="2" class="mt-n2" v-if="isEditNameTranslationButtonVisible">
         <div class="actions mr-4">
           <v-btn
             class="correct-name-translation"
@@ -222,6 +218,14 @@ export default class NameTranslation extends Mixins(CommonMixin) {
 
   get translationsExceptRemoved (): NameTranslationIF[] {
     return this.draftTranslations.filter(x => x.action !== ActionTypes.REMOVED)
+  }
+
+  /** Returns true when user can edit the name translations. */
+  get isEditNameTranslationButtonVisible (): boolean {
+    return (!this.hasNameTranslationChange &&
+    !this.isSummaryMode &&
+    !this.isLimitedConversionRestorationFiling &&
+    !this.isLimitedExtendRestorationFiling)
   }
 
   protected saveNameTranslations (): void {

--- a/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
@@ -30,7 +30,7 @@
       </v-col>
 
       <!-- Actions -->
-      <v-col cols="2" class="mt-n2" v-if="isEditNameTranslationButtonVisible">
+      <v-col cols="2" class="mt-n2" v-if="isHideEditNameTranslationButton">
         <div class="actions mr-4">
           <v-btn
             class="correct-name-translation"
@@ -220,12 +220,14 @@ export default class NameTranslation extends Mixins(CommonMixin) {
     return this.draftTranslations.filter(x => x.action !== ActionTypes.REMOVED)
   }
 
-  /** Returns true when user can edit the name translations. */
-  get isEditNameTranslationButtonVisible (): boolean {
-    return (!this.hasNameTranslationChange &&
-    !this.isSummaryMode &&
-    !this.isLimitedConversionRestorationFiling &&
-    !this.isLimitedExtendRestorationFiling)
+  /** Returns true when the edit name translation button should be hidden. */
+  get isHideEditNameTranslationButton (): boolean {
+    return !(
+      this.hasNameTranslationChange ||
+      this.isSummaryMode ||
+      this.isLimitedConversionRestorationFiling ||
+      this.isLimitedExtendRestorationFiling
+    )
   }
 
   protected saveNameTranslations (): void {

--- a/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
@@ -30,7 +30,7 @@
       </v-col>
 
       <!-- Actions -->
-      <v-col cols="2" class="mt-n2" v-if="isHideEditNameTranslationButton">
+      <v-col cols="2" class="mt-n2" v-if="isEditNameTranslationButtonVisible">
         <div class="actions mr-4">
           <v-btn
             class="correct-name-translation"
@@ -220,8 +220,8 @@ export default class NameTranslation extends Mixins(CommonMixin) {
     return this.draftTranslations.filter(x => x.action !== ActionTypes.REMOVED)
   }
 
-  /** Returns true when the edit name translation button should be hidden. */
-  get isHideEditNameTranslationButton (): boolean {
+  /** Returns true when the user can edit the name translations */
+  get isEditNameTranslationButtonVisible (): boolean {
     return !(
       this.hasNameTranslationChange ||
       this.isSummaryMode ||

--- a/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
+++ b/src/components/common/YourCompany/NameTranslations/NameTranslation.vue
@@ -30,7 +30,11 @@
       </v-col>
 
       <!-- Actions -->
-      <v-col cols="2" class="mt-n2" v-if="!hasNameTranslationChange && !isSummaryMode">
+      <v-col cols="2" class="mt-n2" v-if="
+      !hasNameTranslationChange &&
+      !isSummaryMode &&
+      !isLimitedConversionRestorationFiling &&
+      !isLimitedExtendRestorationFiling">
         <div class="actions mr-4">
           <v-btn
             class="correct-name-translation"
@@ -178,6 +182,8 @@ export default class NameTranslation extends Mixins(CommonMixin) {
 
   // Global getter
   @Getter getNameTranslations!: NameTranslationIF[]
+  @Getter isLimitedExtendRestorationFiling!: boolean
+  @Getter isLimitedConversionRestorationFiling!: boolean
 
   // Global actions
   @Action setEditingNameTranslations!: ActionBindingIF

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -317,6 +317,7 @@ import { CommonMixin, DateMixin, NameRequestMixin } from '@/mixins/'
 import { CoopTypes, NameChangeOptions } from '@/enums/'
 import { CorpTypeCd, GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module/'
 import { ConversionNOB } from '@/components/Conversion'
+import DateUtilities from '@/services/date-utilities'
 
 @Component({
   components: {
@@ -455,7 +456,7 @@ export default class YourCompany extends Mixins(
   get expiryDate (): string {
     const expiry = this.getNameRequest?.expiry
     if (expiry) {
-      return this.apiToPacificDateTime(expiry)
+      return DateUtilities.apiToPacificDateTime(expiry)
     }
     return null
   }
@@ -469,15 +470,15 @@ export default class YourCompany extends Mixins(
   get recognitionDateTime (): string {
     if (this.isBenBcCccUlcCorrectionFiling || this.isRestorationFiling) {
       if (this.getBusinessFoundingDateTime) {
-        return this.apiToPacificDateTime(this.getBusinessFoundingDateTime)
+        return DateUtilities.apiToPacificDateTime(this.getBusinessFoundingDateTime)
       }
       if (this.getCorrectedFilingDate) {
-        return this.apiToPacificDateTime(this.getCorrectedFilingDate)
+        return DateUtilities.apiToPacificDateTime(this.getCorrectedFilingDate)
       }
     }
     if (this.isAlterationFiling) {
       if (this.getBusinessFoundingDateTime) {
-        return this.apiToPacificDateTime(this.getBusinessFoundingDateTime)
+        return DateUtilities.apiToPacificDateTime(this.getBusinessFoundingDateTime)
       }
     }
     return null

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -99,7 +99,7 @@
                 <span>Undo</span>
               </v-btn>
               <v-btn
-                v-else-if="!isFirmConversionFiling"
+                v-else-if="!isFirmConversionFiling && !isLimitedExtendRestorationFiling"
                 text color="primary"
                 id="btn-correct-company-name"
                 @click="isEditingNames = true"
@@ -360,6 +360,8 @@ export default class YourCompany extends Mixins(
   @Getter isRestorationFiling!: boolean
   @Getter getEntityType!: CorpTypeCd
   @Getter getAssociationType!: CoopTypes
+  @Getter isLimitedExtendRestorationFiling!: boolean
+  @Getter isLimitedConversionRestorationFiling!: boolean
 
   // Alteration flag getters
   @Getter hasBusinessNameChanged!: boolean

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -361,6 +361,7 @@ export default class YourCompany extends Mixins(
   @Getter isRestorationFiling!: boolean
   @Getter getEntityType!: CorpTypeCd
   @Getter getAssociationType!: CoopTypes
+  @Getter isLimitedExtendRestorationFiling!: boolean
 
   // Alteration flag getters
   @Getter hasBusinessNameChanged!: boolean

--- a/src/components/common/YourCompany/YourCompany.vue
+++ b/src/components/common/YourCompany/YourCompany.vue
@@ -361,8 +361,6 @@ export default class YourCompany extends Mixins(
   @Getter isRestorationFiling!: boolean
   @Getter getEntityType!: CorpTypeCd
   @Getter getAssociationType!: CoopTypes
-  @Getter isLimitedExtendRestorationFiling!: boolean
-  @Getter isLimitedConversionRestorationFiling!: boolean
 
   // Alteration flag getters
   @Getter hasBusinessNameChanged!: boolean

--- a/src/mixins/date-mixin.ts
+++ b/src/mixins/date-mixin.ts
@@ -1,41 +1,29 @@
-import { Component } from 'vue-property-decorator'
-import { isDate } from 'lodash'
 import { CommonMixin } from '@/mixins/'
+import Vue from 'vue'
+import DateUtilities from '@/services/date-utilities'
+import { Component } from 'vue-property-decorator'
 
 /**
  * Mixin that provides some useful date utilities.
  */
-@Component({})
-export default class DateMixin extends CommonMixin {
+@Component({
+  mixins: [
+    CommonMixin
+  ]
+})
+export default class DateMixin extends Vue {
   /**
-   * Fetches and returns the web server's current date (in UTC).
+   * DEPRECATED Fetches and returns the web server's current date (in UTC).
    * Used to bypass the user's local clock/timezone.
    * Ref: https://www.npmjs.com/package/serverdate
    * @returns a promise to return a Date object
    */
   async getServerDate (): Promise<Date> {
-    const input = `${window.location.origin}/${process.env.VUE_APP_PATH}/`
-    const init: RequestInit = { cache: 'no-store', method: 'HEAD' }
-
-    // don't call fetch() during Jest tests
-    // because it's not defined
-    if (this.isJestRunning) return new Date()
-
-    try {
-      const { headers, ok, statusText } = await fetch(input, init)
-      if (!ok) throw new Error(statusText)
-      return new Date(headers.get('Date'))
-    } catch {
-      // eslint-disable-next-line no-console
-      console.warn('Unable to get server date - using browser date instead')
-      // fall back to local date
-      // NB: new filings may contain invalid date/time
-      return new Date()
-    }
+    return DateUtilities.getServerDate()
   }
 
   /**
-   * Creates and returns a new Date object in UTC, given parameters in Pacific timezone.
+   * DEPRECATED Creates and returns a new Date object in UTC, given parameters in Pacific timezone.
    * (This works regardless of user's local clock/timezone.)
    * @example "2021, 0, 1, 0, 0" -> "2021-01-01T08:00:00.000Z" (Pacific Standard Time)
    * @example "2021, 6, 1, 0, 0" -> "2021-07-01T07:00:00.000Z" (Pacific Daylight Time)
@@ -43,210 +31,115 @@ export default class DateMixin extends CommonMixin {
   createUtcDate (
     year: number, month: number, day: number, hours = 0, minutes = 0, milliseconds = 0
   ): Date {
-    // 1. create the new date in UTC
-    // 2. compute the offset between UTC and Pacific timezone
-    // 3. add the offset to convert the date to Pacific timezone
-    // Ref: https://stackoverflow.com/questions/15141762/
-    const date = new Date(Date.UTC(year, month, day, hours, minutes, milliseconds))
-    const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }))
-    const tzDate = new Date(date.toLocaleString('en-US', { timeZone: 'America/Vancouver' }))
-    const offset = utcDate.getTime() - tzDate.getTime()
-    date.setTime(date.getTime() + offset)
-
-    return date
+    return DateUtilities.createUtcDate(year, month, day, hours, minutes, milliseconds)
   }
 
   /**
-   * Converts a date string (YYYY-MM-DD) to a Date object at 12:00:00 am Pacific time.
+   * DEPRECATED Converts a date string (YYYY-MM-DD) to a Date object at 12:00:00 am Pacific time.
    * @example 2021-11-22 -> 2021-11-22T08:00:00.00Z
    */
   yyyyMmDdToDate (dateStr: string): Date {
-    // safety checks
-    if (!dateStr) return null
-    if (dateStr.length !== 10) return null
-
-    const split = dateStr.split('-')
-    const year = +split[0]
-    const month = +split[1]
-    const day = +split[2]
-
-    // use the date fields to create date object
-    return this.createUtcDate(year, (month - 1), day)
+    return DateUtilities.yyyyMmDdToDate(dateStr)
   }
 
   /**
-   * Converts a date string (MMM dd, yyyy) to a Date object at 12:00:00 am Pacific time.
+   * DEPRECATED Converts a date string (MMM dd, yyyy) to a Date object at 12:00:00 am Pacific time.
    * @example September 5, 2022 -> 2022-09-05T07:00:00.00Z
    */
   mmmDdYyyyToDate (dateStr: string): Date {
-    // safety check
-    if (!dateStr) return null
-
-    // build date as 00:00 UTC
-    const utcDate = new Date(dateStr + ' 00:00 UTC')
-
-    // use the UTC date fields to create date object
-    return this.createUtcDate(utcDate.getUTCFullYear(), utcDate.getUTCMonth(), utcDate.getUTCDate())
+    return DateUtilities.mmmDdYyyyToDate(dateStr)
   }
 
   /**
-   * Converts a Date object to a date string (YYYY-MM-DD) in Pacific timezone.
+   * DEPRECATED Converts a Date object to a date string (YYYY-MM-DD) in Pacific timezone.
    * @example "2021-01-01 07:00:00 GMT" -> "2020-12-31"
    * @example "2021-01-01 08:00:00 GMT" -> "2021-01-01"
    */
   dateToYyyyMmDd (date: Date): string {
-    // safety check
-    if (!isDate(date) || isNaN(date.getTime())) return null
-
-    // NB: some versions of Node have only en-US locale
-    // so use that and convert results accordingly
-    const dateStr = date.toLocaleDateString('en-US', {
-      timeZone: 'America/Vancouver',
-      month: 'numeric', // 12
-      day: 'numeric', // 31
-      year: 'numeric' // 2020
-    })
-
-    // convert mm/dd/yyyy to yyyy-mm-dd
-    // and make sure month and day are 2 digits (eg, 03)
-    const [ mm, dd, yyyy ] = dateStr.split('/')
-    return `${yyyy}-${mm.padStart(2, '0')}-${dd.padStart(2, '0')}`
+    return DateUtilities.dateToYyyyMmDd(date)
   }
 
   /**
-   * Converts a date string (YYYY-MM-DD) to a date string (Month Day, Year) in Pacific timezone.
+   * DEPRECATED Converts a date string (YYYY-MM-DD) to a date string (Month Day, Year) in Pacific timezone.
+   * @param dateStr
    * @param longMonth whether to show long month name (eg, December vs Dec)
    * @param showWeekday whether to show the weekday name (eg, Thursday)
    * @example "2021-01-01" -> "Thursday, December 31, 2020"
    */
   yyyyMmDdToPacificDate (dateStr: string, longMonth = false, showWeekday = false): string {
-    return this.dateToPacificDate(this.yyyyMmDdToDate(dateStr), longMonth, showWeekday)
+    return DateUtilities.yyyyMmDdToPacificDate(dateStr, longMonth, showWeekday)
   }
 
   /**
-   * Converts a Date object to a date string (Month Day, Year) in Pacific timezone.
+   * DEPRECATED Converts a Date object to a date string (Month Day, Year) in Pacific timezone.
+   * @param date
    * @param longMonth whether to show long month name (eg, December vs Dec)
    * @param showWeekday whether to show the weekday name (eg, Thursday)
    * @example "2021-01-01 07:00:00 GMT" -> "Dec 31, 2020"
    * @example "2021-01-01 08:00:00 GMT" -> "Jan 1, 2021"
    */
   dateToPacificDate (date: Date, longMonth = false, showWeekday = false): string {
-    // safety check
-    if (!isDate(date) || isNaN(date.getTime())) return null
-
-    // NB: some versions of Node have only en-US locale
-    // so use that and convert results accordingly
-    let dateStr = date.toLocaleDateString('en-US', {
-      timeZone: 'America/Vancouver',
-      weekday: showWeekday ? 'long' : undefined, // Thursday or nothing
-      month: longMonth ? 'long' : 'short', // December or Dec
-      day: 'numeric', // 31
-      year: 'numeric' // 2020
-    })
-
-    // remove period after month
-    dateStr = dateStr.replace('.', '')
-
-    return dateStr
+    return DateUtilities.dateToPacificDate(date, longMonth, showWeekday)
   }
 
   /**
-   * Converts a Date object to a time string (HH:MM am/pm) in Pacific timezone.
+   * DEPRECATED Converts a Date object to a time string (HH:MM am/pm) in Pacific timezone.
    * @example "2021-01-01 07:00:00 GMT" -> "11:00 pm"
    * @example "2021-01-01 08:00:00 GMT" -> "12:00 am"
    */
   dateToPacificTime (date: Date): string {
-    // safety check
-    if (!isDate(date) || isNaN(date.getTime())) return null
-
-    // NB: some versions of Node have only en-US locale
-    // so use that and convert results accordingly
-    let timeStr = date.toLocaleTimeString('en-US', {
-      timeZone: 'America/Vancouver',
-      hour: 'numeric', // 11
-      minute: '2-digit', // 00
-      hour12: true // a.m./p.m.
-    })
-
-    // replace AM with am and PM with pm
-    timeStr = timeStr.replace('AM', 'am').replace('PM', 'pm')
-
-    return timeStr
+    return DateUtilities.dateToPacificTime(date)
   }
 
   /**
-   * Converts a Date object to a date and time string (Month Day, Year at HH:MM am/pm
+   * DEPRECATED Converts a Date object to a date and time string (Month Day, Year at HH:MM am/pm
    * Pacific time).
    * @example "2021-01-01 07:00:00 GMT" -> "Dec 31, 2020 at 11:00 pm Pacific time"
    * @example "2021-01-01 08:00:00 GMT" -> "Jan 1, 2021 at 12:00 pm Pacific time"
    */
   dateToPacificDateTime (date: Date): string {
-    // safety check
-    if (!isDate(date) || isNaN(date.getTime())) return null
-
-    const dateStr = this.dateToPacificDate(date, true)
-    const timeStr = this.dateToPacificTime(date)
-
-    return `${dateStr} at ${timeStr} Pacific time`
+    return DateUtilities.dateToPacificDateTime(date)
   }
 
   /**
-   * Converts an API datetime string (in UTC) to an ISO datetime string.
+   * DEPRECATED Converts an API datetime string (in UTC) to an ISO datetime string.
    * @example 2021-08-05T16:56:50+00:00 -> 2021-08-05T16:56:50Z
    */
   apiToIso (dateTimeString: string): string {
-    if (!dateTimeString) return null // safety check
-
-    // chop off the milliseconds and UTC offset and append "Zulu" timezone abbreviation
-    return dateTimeString.slice(0, 19) + 'Z'
+    return DateUtilities.apiToIso(dateTimeString)
   }
 
   /**
-   * Converts an API datetime string (in UTC) to a Date object.
+   * DEPRECATED Converts an API datetime string (in UTC) to a Date object.
    * @example 2021-08-05T16:56:50.783101+00:00 -> 2021-08-05T16:56:50Z
    */
   apiToDate (dateTimeString: string): Date {
-    if (!dateTimeString) return null // safety check
-
-    return new Date(this.apiToIso(dateTimeString))
+    return DateUtilities.apiToDate(dateTimeString)
   }
 
   /**
-   * Converts an API datetime string (in UTC) to a date and time string (Month Day, Year at HH:MM am/pm
+   * DEPRECATED Converts an API datetime string (in UTC) to a date and time string (Month Day, Year at HH:MM am/pm
    * Pacific time).
    * @example "2021-01-01T00:00:00.000000+00:00" -> "December 31, 2020 at 04:00 pm Pacific time" (PST example)
    * @example "2021-07-01T00:00:00.000000+00:00" -> "June 30, 2021 at 05:00 pm Pacific time" (PDT example)
    */
   apiToPacificDateTime (dateTimeString: string): string {
-    if (!dateTimeString) return null // safety check
-
-    const date = this.apiToDate(dateTimeString)
-
-    return this.dateToPacificDateTime(date)
+    return DateUtilities.apiToPacificDateTime(dateTimeString)
   }
 
   /**
-   * Converts an API datetime string (in UTC) to a date string (Month Day, Year).
+   * DEPRECATED Converts an API datetime string (in UTC) to a date string (Month Day, Year).
    * @example "2021-01-01T00:00:00.000000+00:00" -> "December 31, 2020"
    */
   apiToPacificDateLong (dateTimeString: string): string {
-    if (!dateTimeString) return null // safety check
-
-    const date = this.apiToDate(dateTimeString)
-    const dateStr = this.dateToPacificDate(date, true)
-
-    return dateStr
+    return DateUtilities.apiToPacificDateLong(dateTimeString)
   }
 
   /**
-   * Converts a Date object to an API datetime string (in UTC).
+   * DEPRECATED Converts a Date object to an API datetime string (in UTC).
    * @example 2021-08-05T16:56:50Z -> 2021-08-05T16:56:50+00:00
    */
   dateToApi (date: Date): string {
-    // safety check
-    if (!isDate(date) || isNaN(date.getTime())) return null
-
-    // replace "Zulu" timezone abbreviation with UTC offset
-    return date.toISOString().replace('Z', '+00:00')
+    return DateUtilities.dateToApi(date)
   }
 }

--- a/src/services/date-utilities.ts
+++ b/src/services/date-utilities.ts
@@ -1,0 +1,257 @@
+import { isDate } from 'lodash'
+
+export default class DateUtilities {
+  /**
+   * Fetches and returns the web server's current date (in UTC).
+   * Used to bypass the user's local clock/timezone.
+   * Ref: https://www.npmjs.com/package/serverdate
+   * @returns a promise to return a Date object
+   */
+  static async getServerDate (): Promise<Date> {
+    const input = `${window.location.origin}/${process.env.VUE_APP_PATH}/`
+    const init: RequestInit = { cache: 'no-store', method: 'HEAD' }
+
+    // don't call fetch() during Jest tests
+    // because it's not defined
+    if (process.env.JEST_WORKER_ID !== undefined) return new Date()
+
+    try {
+      const { headers, ok, statusText } = await fetch(input, init)
+      if (!ok) throw new Error(statusText)
+      return new Date(headers.get('Date'))
+    } catch {
+      // eslint-disable-next-line no-console
+      console.warn('Unable to get server date - using browser date instead')
+      // fall back to local date
+      // NB: new filings may contain invalid date/time
+      return new Date()
+    }
+  }
+
+  /**
+   * Creates and returns a new Date object in UTC, given parameters in Pacific timezone.
+   * (This works regardless of user's local clock/timezone.)
+   * @example "2021, 0, 1, 0, 0" -> "2021-01-01T08:00:00.000Z" (Pacific Standard Time)
+   * @example "2021, 6, 1, 0, 0" -> "2021-07-01T07:00:00.000Z" (Pacific Daylight Time)
+   */
+  static createUtcDate (
+    year: number, month: number, day: number, hours = 0, minutes = 0, milliseconds = 0
+  ): Date {
+    // 1. create the new date in UTC
+    // 2. compute the offset between UTC and Pacific timezone
+    // 3. add the offset to convert the date to Pacific timezone
+    // Ref: https://stackoverflow.com/questions/15141762/
+    const date = new Date(Date.UTC(year, month, day, hours, minutes, milliseconds))
+    const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }))
+    const tzDate = new Date(date.toLocaleString('en-US', { timeZone: 'America/Vancouver' }))
+    const offset = utcDate.getTime() - tzDate.getTime()
+    date.setTime(date.getTime() + offset)
+
+    return date
+  }
+
+  /**
+   * Converts a date string (YYYY-MM-DD) to a Date object at 12:00:00 am Pacific time.
+   * @example 2021-11-22 -> 2021-11-22T08:00:00.00Z
+   */
+  static yyyyMmDdToDate (dateStr: string): Date {
+    // safety checks
+    if (!dateStr) return null
+    if (dateStr.length !== 10) return null
+
+    const split = dateStr.split('-')
+    const year = +split[0]
+    const month = +split[1]
+    const day = +split[2]
+
+    // use the date fields to create date object
+    return this.createUtcDate(year, (month - 1), day)
+  }
+
+  /**
+   * Converts a date string (MMM dd, yyyy) to a Date object at 12:00:00 am Pacific time.
+   * @example September 5, 2022 -> 2022-09-05T07:00:00.00Z
+   */
+  static mmmDdYyyyToDate (dateStr: string): Date {
+    // safety check
+    if (!dateStr) return null
+
+    // build date as 00:00 UTC
+    const utcDate = new Date(dateStr + ' 00:00 UTC')
+
+    // use the UTC date fields to create date object
+    return this.createUtcDate(utcDate.getUTCFullYear(), utcDate.getUTCMonth(), utcDate.getUTCDate())
+  }
+
+  /**
+   * Converts a Date object to a date string (YYYY-MM-DD) in Pacific timezone.
+   * @example "2021-01-01 07:00:00 GMT" -> "2020-12-31"
+   * @example "2021-01-01 08:00:00 GMT" -> "2021-01-01"
+   */
+  static dateToYyyyMmDd (date: Date): string {
+    // safety check
+    if (!isDate(date) || isNaN(date.getTime())) return null
+
+    // NB: some versions of Node have only en-US locale
+    // so use that and convert results accordingly
+    const dateStr = date.toLocaleDateString('en-US', {
+      timeZone: 'America/Vancouver',
+      month: 'numeric', // 12
+      day: 'numeric', // 31
+      year: 'numeric' // 2020
+    })
+
+    // convert mm/dd/yyyy to yyyy-mm-dd
+    // and make sure month and day are 2 digits (eg, 03)
+    const [ mm, dd, yyyy ] = dateStr.split('/')
+    return `${yyyy}-${mm.padStart(2, '0')}-${dd.padStart(2, '0')}`
+  }
+
+  /**
+   * Converts a date string (YYYY-MM-DD) to a date string (Month Day, Year) in Pacific timezone.
+   * @param dateStr
+   * @param longMonth whether to show long month name (eg, December vs Dec)
+   * @param showWeekday whether to show the weekday name (eg, Thursday)
+   * @example "2021-01-01" -> "Thursday, December 31, 2020"
+   */
+  static yyyyMmDdToPacificDate (dateStr: string, longMonth = false, showWeekday = false): string {
+    return this.dateToPacificDate(this.yyyyMmDdToDate(dateStr), longMonth, showWeekday)
+  }
+
+  /**
+   * Converts a Date object to a date string (Month Day, Year) in Pacific timezone.
+   * @param date
+   * @param longMonth whether to show long month name (eg, December vs Dec)
+   * @param showWeekday whether to show the weekday name (eg, Thursday)
+   * @example "2021-01-01 07:00:00 GMT" -> "Dec 31, 2020"
+   * @example "2021-01-01 08:00:00 GMT" -> "Jan 1, 2021"
+   */
+  static dateToPacificDate (date: Date, longMonth = false, showWeekday = false): string {
+    // safety check
+    if (!isDate(date) || isNaN(date.getTime())) return null
+
+    // NB: some versions of Node have only en-US locale
+    // so use that and convert results accordingly
+    let dateStr = date.toLocaleDateString('en-US', {
+      timeZone: 'America/Vancouver',
+      weekday: showWeekday ? 'long' : undefined, // Thursday or nothing
+      month: longMonth ? 'long' : 'short', // December or Dec
+      day: 'numeric', // 31
+      year: 'numeric' // 2020
+    })
+
+    // remove period after month
+    dateStr = dateStr.replace('.', '')
+
+    return dateStr
+  }
+
+  /**
+   * Converts a Date object to a time string (HH:MM am/pm) in Pacific timezone.
+   * @example "2021-01-01 07:00:00 GMT" -> "11:00 pm"
+   * @example "2021-01-01 08:00:00 GMT" -> "12:00 am"
+   */
+  static dateToPacificTime (date: Date): string {
+    // safety check
+    if (!isDate(date) || isNaN(date.getTime())) return null
+
+    // NB: some versions of Node have only en-US locale
+    // so use that and convert results accordingly
+    let timeStr = date.toLocaleTimeString('en-US', {
+      timeZone: 'America/Vancouver',
+      hour: 'numeric', // 11
+      minute: '2-digit', // 00
+      hour12: true // a.m./p.m.
+    })
+
+    // replace AM with am and PM with pm
+    timeStr = timeStr.replace('AM', 'am').replace('PM', 'pm')
+
+    return timeStr
+  }
+
+  /**
+   * Converts a Date object to a date and time string (Month Day, Year at HH:MM am/pm
+   * Pacific time).
+   * @example "2021-01-01 07:00:00 GMT" -> "Dec 31, 2020 at 11:00 pm Pacific time"
+   * @example "2021-01-01 08:00:00 GMT" -> "Jan 1, 2021 at 12:00 pm Pacific time"
+   */
+  static dateToPacificDateTime (date: Date): string {
+    // safety check
+    if (!isDate(date) || isNaN(date.getTime())) return null
+
+    const dateStr = this.dateToPacificDate(date, true)
+    const timeStr = this.dateToPacificTime(date)
+
+    return `${dateStr} at ${timeStr} Pacific time`
+  }
+
+  /**
+   * Converts an API datetime string (in UTC) to an ISO datetime string.
+   * @example 2021-08-05T16:56:50+00:00 -> 2021-08-05T16:56:50Z
+   */
+  static apiToIso (dateTimeString: string): string {
+    if (!dateTimeString) return null // safety check
+
+    // chop off the milliseconds and UTC offset and append "Zulu" timezone abbreviation
+    return dateTimeString.slice(0, 19) + 'Z'
+  }
+
+  /**
+   * Converts an API datetime string (in UTC) to a Date object.
+   * @example 2021-08-05T16:56:50.783101+00:00 -> 2021-08-05T16:56:50Z
+   */
+  static apiToDate (dateTimeString: string): Date {
+    if (!dateTimeString) return null // safety check
+
+    return new Date(this.apiToIso(dateTimeString))
+  }
+
+  /**
+   * Converts an API datetime string (in UTC) to a date and time string (Month Day, Year at HH:MM am/pm
+   * Pacific time).
+   * @example "2021-01-01T00:00:00.000000+00:00" -> "December 31, 2020 at 04:00 pm Pacific time" (PST example)
+   * @example "2021-07-01T00:00:00.000000+00:00" -> "June 30, 2021 at 05:00 pm Pacific time" (PDT example)
+   */
+  static apiToPacificDateTime (dateTimeString: string): string {
+    if (!dateTimeString) return null // safety check
+
+    const date = this.apiToDate(dateTimeString)
+
+    return this.dateToPacificDateTime(date)
+  }
+
+  /**
+   * Converts an API datetime string (in UTC) to a date string (Month Day, Year).
+   * @example "2021-01-01T00:00:00.000000+00:00" -> "December 31, 2020"
+   */
+  static apiToPacificDateLong (dateTimeString: string): string {
+    if (!dateTimeString) return null // safety check
+
+    const date = this.apiToDate(dateTimeString)
+    return this.dateToPacificDate(date, true)
+  }
+
+  /**
+   * Converts a Date object to an API datetime string (in UTC).
+   * @example 2021-08-05T16:56:50Z -> 2021-08-05T16:56:50+00:00
+   */
+  static dateToApi (date: Date): string {
+    // safety check
+    if (!isDate(date) || isNaN(date.getTime())) return null
+
+    // replace "Zulu" timezone abbreviation with UTC offset
+    return date.toISOString().replace('Z', '+00:00')
+  }
+
+  /**
+   * Returns the number of months remaining when given an expiry date string
+   * like this: monthDiffToToday('2023-12-31')
+   * if needed, today's date can be passed as the second parameter
+   */
+  static monthDiffToToday (dateToStr: string, dateFrom = new Date()): number {
+    const dateTo = this.mmmDdYyyyToDate(dateToStr)
+    return dateTo.getMonth() - dateFrom.getMonth() +
+      (12 * (dateTo.getFullYear() - dateFrom.getFullYear()))
+  }
+}

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -39,6 +39,7 @@ import {
   StaffPaymentIF
 } from '@bcrs-shared-components/interfaces/'
 import { IsSame } from '@/utils/'
+import DateUtilities from '@/services/date-utilities'
 
 /** Whether the user has "staff" keycloak role. */
 export const isRoleStaff = (state: StateIF): boolean => {
@@ -947,6 +948,10 @@ export const haveNewResolutionDates = (state: StateIF): boolean => {
 export const getFileNumber = (state: StateIF): string => {
   return state.stateModel.newAlteration.courtOrder.fileNumber
 }
+/** Returns true if the filing has a court order number  */
+export const hasFileNumber = (state, getters): boolean => {
+  return !!getters.getFileNumber
+}
 
 /** The Plan of Arrangement state. */
 export const getHasPlanOfArrangement = (state: StateIF): boolean => {
@@ -987,7 +992,7 @@ export const getIsResolutionDatesValid = (state: StateIF): boolean => {
  * This is a safety check to ensure that fee summary component is not loaded
  * until there is a valid filing type and entity code.
  */
-export const showFeeSummary = (state: StateIF): boolean => {
+export const showFeeSummary = (state: StateIF, getters): boolean => {
   const defaultFilingData: FilingDataIF[] = [{
     filingTypeCode: null,
     entityType: null,
@@ -995,14 +1000,15 @@ export const showFeeSummary = (state: StateIF): boolean => {
     waiveFees: false
   }]
   const haveFilingChange = (
-    (isCorrectionFiling(state) && hasCorrectionDataChanged(state)) ||
-    (isAlterationFiling(state) && hasAlterationDataChanged(state)) ||
-    (isFirmChangeFiling(state) && hasChangeDataChanged(state)) ||
-    (isFirmConversionFiling(state) && hasConversionDataChanged(state)) ||
-    (isRestorationFiling(state) && hasRestorationDataChanged(state)) ||
-    (isSpecialResolutionFiling(state) && hasSpecialResolutionDataChanged(state))
+    (getters.isCorrectionFiling && getters.hasCorrectionDataChanged) ||
+    (getters.isAlterationFiling && getters.hasAlterationDataChanged) ||
+    (getters.isFirmChangeFiling && getters.hasChangeDataChanged) ||
+    (getters.isFirmConversionFiling && getters.hasConversionDataChanged) ||
+    (getters.isRestorationFiling && getters.hasRestorationDataChanged) ||
+    (getters.isSpecialResolutionFiling && getters.hasSpecialResolutionDataChanged) ||
+    getters.isRestorationFiling
   )
-  return (haveFilingChange && !IsSame(getFilingData(state), defaultFilingData))
+  return (haveFilingChange && !IsSame(getters.getFilingData, defaultFilingData))
 }
 
 /** The current fees. */
@@ -1071,4 +1077,16 @@ export const hideChangeButtonForSoleProps = (state: StateIF, getters): boolean =
   const isOrganization = getters.getOrgPeople[0]?.officer?.partyType === PartyTypes.ORGANIZATION
   const isDba = isProprietor && isOrganization
   return !getters.isRoleStaff && isDba
+}
+
+export const getExpiryDateString = (state: StateIF): string => {
+  return state.stateModel.restoration?.expiry
+}
+
+export const getFormattedExpiryText = (state, getters): string => {
+  if (getters.getExpiryDateString) {
+    return DateUtilities.monthDiffToToday(getters.getExpiryDateString) + ' months, expires on ' +
+      DateUtilities.yyyyMmDdToPacificDate(getters.getExpiryDateString)
+  }
+  return '[no expiry date]'
 }

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -1083,9 +1083,9 @@ export const getExpiryDateString = (state: StateIF): string => {
   return state.stateModel.restoration?.expiry
 }
 
-export const getFormattedExpiryText = (state, getters): string => {
+export const getFormattedExpiryText = (state, getters) => (today = new Date()): string => {
   if (getters.getExpiryDateString) {
-    return DateUtilities.monthDiffToToday(getters.getExpiryDateString) + ' months, expires on ' +
+    return DateUtilities.monthDiffToToday(getters.getExpiryDateString, today) + ' months, expires on ' +
       DateUtilities.yyyyMmDdToPacificDate(getters.getExpiryDateString)
   }
   return '[no expiry date]'

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -91,13 +91,13 @@ export const isRestorationFiling = (state: StateIF): boolean => {
 }
 
 /** Whether the current filing is a Limited Extension Restoration. */
-export const isLimitedExtendRestorationFiling = (state: StateIF): boolean => {
-  return (getRestoration(state).type === RestorationTypes.LTD_EXTEND)
+export const isLimitedExtendRestorationFiling = (state: StateIF, getters): boolean => {
+  return (getters.getRestoration.type === RestorationTypes.LTD_EXTEND)
 }
 
 /** Whether the current filing is a Limited Conversion Restoration. */
-export const isLimitedConversionRestorationFiling = (state: StateIF): boolean => {
-  return (getRestoration(state).type === RestorationTypes.LTD_TO_FULL)
+export const isLimitedConversionRestorationFiling = (state: StateIF, getters): boolean => {
+  return (getters.getRestoration.type === RestorationTypes.LTD_TO_FULL)
 }
 
 /** Whether the current filing is a Change of Registration for a firm corp class. */

--- a/src/views/Restoration.vue
+++ b/src/views/Restoration.vue
@@ -25,6 +25,8 @@
           :validate="getAppValidate"
         />
 
+        <YourCompanySummary class="mt-10" />
+
         <CurrentDirectors class="mt-10" />
 
         <DocumentsDelivery
@@ -81,6 +83,7 @@ import { Component, Emit, Prop, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { GetFeatureFlag } from '@/utils/'
 import RestorationSummary from '@/components/Restoration/RestorationSummary.vue'
+import YourCompanySummary from '@/components/Restoration/YourCompanySummary.vue'
 import { CertifySection, CurrentDirectors, DocumentsDelivery, PeopleAndRoles, StaffPayment,
   YourCompany } from '@/components/common/'
 import { AuthServices, LegalServices } from '@/services/'
@@ -101,7 +104,8 @@ import { FilingDataIF } from '@bcrs-shared-components/interfaces'
     PeopleAndRoles,
     RestorationSummary,
     StaffPayment,
-    YourCompany
+    YourCompany,
+    YourCompanySummary
   },
   mixins: [
     CommonMixin,

--- a/tests/unit/state-getters.spec.ts
+++ b/tests/unit/state-getters.spec.ts
@@ -535,12 +535,14 @@ describe('SP/GP correction getters', () => {
 
 describe('test restoration expiry date', () => {
   it('when no expiry date provided returns visible error', () => {
-    expect(store.getters.getFormattedExpiryText).toEqual('[no expiry date]')
+    expect(store.getters.getFormattedExpiryText()).toEqual('[no expiry date]')
   })
 
   it('displays appropriate text when restoration expiry date is set', () => {
     store.commit('mutateRestorationExpiry', '2023-12-31')
-    expect(store.getters.getFormattedExpiryText).toEqual('10 months, expires on Dec 31, 2023')
+    // pass in date to force today's date to Feb 28th
+    expect(store.getters.getFormattedExpiryText(new Date('2023-02-28')))
+      .toEqual('10 months, expires on Dec 31, 2023')
   })
 
   it('getExpiryDateString() works correctly', () => {

--- a/tests/unit/state-getters.spec.ts
+++ b/tests/unit/state-getters.spec.ts
@@ -3,6 +3,8 @@ import Vuetify from 'vuetify'
 import { shallowMount } from '@vue/test-utils'
 import { getVuexStore } from '@/store/'
 import Actions from '@/components/common/Actions.vue'
+import {getExpiryDateString, getFormattedExpiryText} from "@/store/getters";
+import {mutateRestorationExpiry} from "@/store/mutations";
 
 Vue.use(Vuetify)
 
@@ -406,8 +408,8 @@ describe('SP/GP correction getters', () => {
     naicsDescription: 'NAICS description'
   }
   const newAddress = {
-    deliveryAddress: { postalCode: 'V8V 8V8' },
-    mailingAddress: { postalCode: 'V8V 8V8' }
+    deliveryAddress: {postalCode: 'V8V 8V8'},
+    mailingAddress: {postalCode: 'V8V 8V8'}
   }
   beforeAll(async () => {
     // initialize store
@@ -441,7 +443,7 @@ describe('SP/GP correction getters', () => {
 
     // mount the component and wait for everything to stabilize
     // (this can be any component since we are not really using it)
-    const wrapper = shallowMount(Actions, { store, vuetify })
+    const wrapper = shallowMount(Actions, {store, vuetify})
     vm = wrapper.vm
     await Vue.nextTick()
   })
@@ -469,31 +471,31 @@ describe('SP/GP correction getters', () => {
     expect(vm.hasBusinessStartDateChanged).toBe(false)
 
     // verify that name translation changes are detected
-    store.state.stateModel.nameTranslations = [{ action: 'ACTION' }]
+    store.state.stateModel.nameTranslations = [{action: 'ACTION'}]
     expect(vm.haveNameTranslationsChanged).toBe(true)
     store.state.stateModel.nameTranslations = []
     expect(vm.haveNameTranslationsChanged).toBe(false)
 
     // verify that registered mailing address changes are detected
-    store.state.stateModel.officeAddresses = { businessOffice: newAddress }
+    store.state.stateModel.officeAddresses = {businessOffice: newAddress}
     expect(vm.haveOfficeAddressesChanged).toBe(true)
     store.state.stateModel.officeAddresses = null
     expect(vm.haveOfficeAddressesChanged).toBe(false)
 
     // verify that registered delivery address changes are detected
-    store.state.stateModel.officeAddresses = { businessOffice: newAddress }
+    store.state.stateModel.officeAddresses = {businessOffice: newAddress}
     expect(vm.haveOfficeAddressesChanged).toBe(true)
     store.state.stateModel.officeAddresses = null
     expect(vm.haveOfficeAddressesChanged).toBe(false)
 
     // verify that records mailing address changes are detected
-    store.state.stateModel.officeAddresses = { businessOffice: newAddress }
+    store.state.stateModel.officeAddresses = {businessOffice: newAddress}
     expect(vm.haveOfficeAddressesChanged).toBe(true)
     store.state.stateModel.officeAddresses = null
     expect(vm.haveOfficeAddressesChanged).toBe(false)
 
     // verify that records delivery address changes are detected
-    store.state.stateModel.officeAddresses = { businessOffice: newAddress }
+    store.state.stateModel.officeAddresses = {businessOffice: newAddress}
     expect(vm.haveOfficeAddressesChanged).toBe(true)
     store.state.stateModel.officeAddresses = null
     expect(vm.haveOfficeAddressesChanged).toBe(false)
@@ -528,5 +530,22 @@ describe('SP/GP correction getters', () => {
 
     // finally, this getter should be false
     expect(vm.hasCorrectionDataChanged).toBe(false)
+  })
+})
+
+describe('test restoration expiry date', () => {
+
+  it('when no expiry date provided returns visible error', () => {
+    expect(store.getters.getFormattedExpiryText).toEqual("[no expiry date]")
+  })
+
+  it('displays appropriate text when restoration expiry date is set', () => {
+    store.commit('mutateRestorationExpiry', '2023-12-31')
+    expect(store.getters.getFormattedExpiryText).toEqual("10 months, expires on Dec 31, 2023")
+  })
+
+  it('getExpiryDateString() works correctly', () => {
+    store.commit('mutateRestorationExpiry', '2023-12-31')
+    expect(store.getters.getExpiryDateString).toEqual("2023-12-31")
   })
 })

--- a/tests/unit/state-getters.spec.ts
+++ b/tests/unit/state-getters.spec.ts
@@ -3,8 +3,8 @@ import Vuetify from 'vuetify'
 import { shallowMount } from '@vue/test-utils'
 import { getVuexStore } from '@/store/'
 import Actions from '@/components/common/Actions.vue'
-import {getExpiryDateString, getFormattedExpiryText} from "@/store/getters";
-import {mutateRestorationExpiry} from "@/store/mutations";
+import { getExpiryDateString, getFormattedExpiryText } from '@/store/getters'
+import { mutateRestorationExpiry } from '@/store/mutations'
 
 Vue.use(Vuetify)
 
@@ -408,8 +408,8 @@ describe('SP/GP correction getters', () => {
     naicsDescription: 'NAICS description'
   }
   const newAddress = {
-    deliveryAddress: {postalCode: 'V8V 8V8'},
-    mailingAddress: {postalCode: 'V8V 8V8'}
+    deliveryAddress: { postalCode: 'V8V 8V8' },
+    mailingAddress: { postalCode: 'V8V 8V8' }
   }
   beforeAll(async () => {
     // initialize store
@@ -443,7 +443,7 @@ describe('SP/GP correction getters', () => {
 
     // mount the component and wait for everything to stabilize
     // (this can be any component since we are not really using it)
-    const wrapper = shallowMount(Actions, {store, vuetify})
+    const wrapper = shallowMount(Actions, { store, vuetify })
     vm = wrapper.vm
     await Vue.nextTick()
   })
@@ -471,31 +471,31 @@ describe('SP/GP correction getters', () => {
     expect(vm.hasBusinessStartDateChanged).toBe(false)
 
     // verify that name translation changes are detected
-    store.state.stateModel.nameTranslations = [{action: 'ACTION'}]
+    store.state.stateModel.nameTranslations = [{ action: 'ACTION' }]
     expect(vm.haveNameTranslationsChanged).toBe(true)
     store.state.stateModel.nameTranslations = []
     expect(vm.haveNameTranslationsChanged).toBe(false)
 
     // verify that registered mailing address changes are detected
-    store.state.stateModel.officeAddresses = {businessOffice: newAddress}
+    store.state.stateModel.officeAddresses = { businessOffice: newAddress }
     expect(vm.haveOfficeAddressesChanged).toBe(true)
     store.state.stateModel.officeAddresses = null
     expect(vm.haveOfficeAddressesChanged).toBe(false)
 
     // verify that registered delivery address changes are detected
-    store.state.stateModel.officeAddresses = {businessOffice: newAddress}
+    store.state.stateModel.officeAddresses = { businessOffice: newAddress }
     expect(vm.haveOfficeAddressesChanged).toBe(true)
     store.state.stateModel.officeAddresses = null
     expect(vm.haveOfficeAddressesChanged).toBe(false)
 
     // verify that records mailing address changes are detected
-    store.state.stateModel.officeAddresses = {businessOffice: newAddress}
+    store.state.stateModel.officeAddresses = { businessOffice: newAddress }
     expect(vm.haveOfficeAddressesChanged).toBe(true)
     store.state.stateModel.officeAddresses = null
     expect(vm.haveOfficeAddressesChanged).toBe(false)
 
     // verify that records delivery address changes are detected
-    store.state.stateModel.officeAddresses = {businessOffice: newAddress}
+    store.state.stateModel.officeAddresses = { businessOffice: newAddress }
     expect(vm.haveOfficeAddressesChanged).toBe(true)
     store.state.stateModel.officeAddresses = null
     expect(vm.haveOfficeAddressesChanged).toBe(false)
@@ -534,18 +534,17 @@ describe('SP/GP correction getters', () => {
 })
 
 describe('test restoration expiry date', () => {
-
   it('when no expiry date provided returns visible error', () => {
-    expect(store.getters.getFormattedExpiryText).toEqual("[no expiry date]")
+    expect(store.getters.getFormattedExpiryText).toEqual('[no expiry date]')
   })
 
   it('displays appropriate text when restoration expiry date is set', () => {
     store.commit('mutateRestorationExpiry', '2023-12-31')
-    expect(store.getters.getFormattedExpiryText).toEqual("10 months, expires on Dec 31, 2023")
+    expect(store.getters.getFormattedExpiryText).toEqual('10 months, expires on Dec 31, 2023')
   })
 
   it('getExpiryDateString() works correctly', () => {
     store.commit('mutateRestorationExpiry', '2023-12-31')
-    expect(store.getters.getExpiryDateString).toEqual("2023-12-31")
+    expect(store.getters.getExpiryDateString).toEqual('2023-12-31')
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15081

This PR makes some minor changes to the YourCompany.vue component to support restoration extension and conversion as shown in the screenshots below:

During a limited restoration extension, no changes to the name block are permitted.
![image](https://user-images.githubusercontent.com/25233684/220488829-c7a63191-5a97-4168-9d46-10d5c873ff3f.png)

During a limited restoration conversion to full, users can change the entity's name.
![image](https://user-images.githubusercontent.com/25233684/220488862-17bd5a9e-773e-422f-a6a1-f1133a84eeb5.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
