### PR TITLE
15092 - add more restoration endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.10.5",
+      "version": "3.10.6",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/enums/routeNames.ts
+++ b/src/enums/routeNames.ts
@@ -4,7 +4,10 @@ export enum RouteNames {
   CHANGE = 'change',
   CONVERSION = 'conversion',
   CORRECTION = 'correction',
-  RESTORATION = 'restoration',
+  RESTORATION_FULL = 'fullRestoration',
+  RESTORATION_LIMITED = 'limitedRestoration',
+  RESTORATION_EXTENSION = 'limitedRestorationExtension',
+  RESTORATION_CONVERSION = 'limitedRestorationToFull',
   SIGN_IN = 'signin',
   SIGN_OUT = 'signout',
   SPECIAL_RESOLUTION = 'special-resolution'

--- a/src/enums/routeNames.ts
+++ b/src/enums/routeNames.ts
@@ -4,8 +4,6 @@ export enum RouteNames {
   CHANGE = 'change',
   CONVERSION = 'conversion',
   CORRECTION = 'correction',
-  RESTORATION_FULL = 'fullRestoration',
-  RESTORATION_LIMITED = 'limitedRestoration',
   RESTORATION_EXTENSION = 'limitedRestorationExtension',
   RESTORATION_CONVERSION = 'limitedRestorationToFull',
   SIGN_IN = 'signin',

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -145,10 +145,8 @@ export default class CommonMixin extends Vue {
       case RouteNames.CHANGE: return 'Business Information'
       case RouteNames.CONVERSION: return 'Record Conversion'
       case RouteNames.CORRECTION: return 'Register Correction'
-      case RouteNames.RESTORATION: {
-        if (this.isLimitedExtendRestorationFiling) return 'Limited Restoration Extension'
-        if (this.isLimitedConversionRestorationFiling) return 'Conversion to Full Restoration'
-      }
+      case RouteNames.RESTORATION_EXTENSION: return 'Limited Restoration Extension'
+      case RouteNames.RESTORATION_CONVERSION: return 'Conversion to Full Restoration'
     }
     return 'Unknown Filing' // should never happen
   }

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -44,8 +44,38 @@ export const routes = [
     }
   },
   {
-    path: '/restoration',
-    name: RouteNames.RESTORATION,
+    path: '/limitedRestorationToFull',
+    name: RouteNames.RESTORATION_CONVERSION,
+    component: Restoration,
+    meta: {
+      requiresAuth: true,
+      isStaffOnly: true,
+      filingType: FilingTypes.RESTORATION
+    }
+  },
+  {
+    path: '/limitedRestorationExtension',
+    name: RouteNames.RESTORATION_EXTENSION,
+    component: Restoration,
+    meta: {
+      requiresAuth: true,
+      isStaffOnly: true,
+      filingType: FilingTypes.RESTORATION
+    }
+  },
+  {
+    path: '/fullRestoration',
+    name: RouteNames.RESTORATION_FULL,
+    component: Restoration,
+    meta: {
+      requiresAuth: true,
+      isStaffOnly: true,
+      filingType: FilingTypes.RESTORATION
+    }
+  },
+  {
+    path: '/limitedRestoration',
+    name: RouteNames.RESTORATION_LIMITED,
     component: Restoration,
     meta: {
       requiresAuth: true,

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -64,26 +64,6 @@ export const routes = [
     }
   },
   {
-    path: '/fullRestoration',
-    name: RouteNames.RESTORATION_FULL,
-    component: Restoration,
-    meta: {
-      requiresAuth: true,
-      isStaffOnly: true,
-      filingType: FilingTypes.RESTORATION
-    }
-  },
-  {
-    path: '/limitedRestoration',
-    name: RouteNames.RESTORATION_LIMITED,
-    component: Restoration,
-    meta: {
-      requiresAuth: true,
-      isStaffOnly: true,
-      filingType: FilingTypes.RESTORATION
-    }
-  },
-  {
     path: '/special-resolution',
     name: RouteNames.SPECIAL_RESOLUTION,
     component: SpecialResolution,

--- a/tests/unit/FilingTypeToName.spec.ts
+++ b/tests/unit/FilingTypeToName.spec.ts
@@ -5,7 +5,7 @@ describe('Enum Mixin', () => {
     expect(FilingTypeToName(null)).toBe('Unknown Type')
     expect(FilingTypeToName('alteration' as any)).toBe('Alteration')
     expect(FilingTypeToName('changeOfRegistration' as any)).toBe('Change of Registration')
-    expect(FilingTypeToName('conversion' as any)).toBe('Conversion')
+    expect(FilingTypeToName('conversion' as any)).toBe('Record Conversion')
     expect(FilingTypeToName('correction' as any)).toBe('Correction')
     expect(FilingTypeToName('incorporationApplication' as any)).toBe('Incorporation Application')
     expect(FilingTypeToName('registration' as any)).toBe('Registration')

--- a/tests/unit/FilingTypeToName.spec.ts
+++ b/tests/unit/FilingTypeToName.spec.ts
@@ -5,7 +5,7 @@ describe('Enum Mixin', () => {
     expect(FilingTypeToName(null)).toBe('Unknown Type')
     expect(FilingTypeToName('alteration' as any)).toBe('Alteration')
     expect(FilingTypeToName('changeOfRegistration' as any)).toBe('Change of Registration')
-    expect(FilingTypeToName('conversion' as any)).toBe('Record Conversion')
+    expect(FilingTypeToName('conversion' as any)).toBe('Conversion')
     expect(FilingTypeToName('correction' as any)).toBe('Correction')
     expect(FilingTypeToName('incorporationApplication' as any)).toBe('Incorporation Application')
     expect(FilingTypeToName('registration' as any)).toBe('Registration')

--- a/tests/unit/Restoration.spec.ts
+++ b/tests/unit/Restoration.spec.ts
@@ -237,7 +237,7 @@ describe('Restoration component - edit page', () => {
     store.state.stateModel.businessInformation = { ...entitySnapshot.businessInfo }
     store.state.resourceModel = BenRestorationResource
 
-    await router.push({ name: 'restoration', query: { 'restoration-id': '1234' } })
+    await router.push({ name: 'limitedRestorationExtension', query: { 'restoration-id': '1234' } })
     wrapper = mount(Restoration, { localVue, store, router, vuetify })
 
     // enable filing and wait for all queries to complete

--- a/tests/unit/Restoration.spec.ts
+++ b/tests/unit/Restoration.spec.ts
@@ -319,7 +319,7 @@ describe('Restoration component - summary page (with filing changes)', () => {
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
-    await router.push({ name: 'restoration', query: { 'restoration-id': '1234' } })
+    await router.push({ name: 'limitedRestorationExtension', query: { 'restoration-id': '1234' } })
     wrapper = mount(Restoration, {
       localVue,
       store,
@@ -402,7 +402,7 @@ describe('Restoration component - summary page (with no filing changes)', () => 
     const localVue = createLocalVue()
     localVue.use(VueRouter)
     const router = mockRouter.mock()
-    await router.push({ name: 'restoration', query: { 'restoration-id': '1234' } })
+    await router.push({ name: 'limitedRestorationExtension', query: { 'restoration-id': '1234' } })
     wrapper = mount(Restoration, {
       localVue,
       store,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15092

Add the following endpoints:  

- /limitedRestorationToFull
- /limitedRestorationExtension
- /fullRestoration
- /limitedRestoration

By separating restorations to different endpoints, we can keep the code cleaner and easier to read.  

### Caution, this change will break existing functionality until business-filings-ui makes a similar change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
