### PR TITLE
15092 - remove fee summary components from App.vue add to each view instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.7",
+  "version": "3.10.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "3.10.7",
+      "version": "3.10.8",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.5",
+        "@bcrs-shared-components/approval-type": "1.0.15",
         "@bcrs-shared-components/breadcrumb": "2.1.5",
         "@bcrs-shared-components/business-lookup": "1.1.7",
         "@bcrs-shared-components/certify": "2.1.5",
@@ -25,7 +26,9 @@
         "@bcrs-shared-components/folio-number": "1.1.1",
         "@bcrs-shared-components/help-business-number": "1.1.1",
         "@bcrs-shared-components/interfaces": "1.0.48",
+        "@bcrs-shared-components/limited-restoration-panel": "1.0.3",
         "@bcrs-shared-components/nature-of-business": "1.2.4",
+        "@bcrs-shared-components/relationships-panel": "1.0.12",
         "@bcrs-shared-components/share-structure": "2.1.4",
         "@bcrs-shared-components/staff-payment": "2.1.4",
         "@mdi/font": "^5.9.55",
@@ -1819,6 +1822,48 @@
         "vue-property-decorator": "^9.1.2"
       }
     },
+    "node_modules/@bcrs-shared-components/approval-type": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/approval-type/-/approval-type-1.0.15.tgz",
+      "integrity": "sha512-3l0rUeCtXIG6md47afOBwv54wjTY9McfovKrxmjgeOO3wPbB3wtKcsUW3ChoJxY+oe2j9AWVdUX8GL+gqHQTJw==",
+      "dependencies": {
+        "@bcrs-shared-components/date-picker": "^1.2.16",
+        "@bcrs-shared-components/enums": "^1.0.37",
+        "@bcrs-shared-components/interfaces": "^1.0.59",
+        "vue-property-decorator": "^9.1.2"
+      }
+    },
+    "node_modules/@bcrs-shared-components/approval-type/node_modules/@bcrs-shared-components/corp-type-module": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/corp-type-module/-/corp-type-module-1.0.11.tgz",
+      "integrity": "sha512-+iE3qiySSafiA311m14DuoG9Rq/ranBJNT7Kf7KQ9dJFDNNuTA326pCGwKBeuT1L6pFpGeibXGE+vQ0AYnSPUA=="
+    },
+    "node_modules/@bcrs-shared-components/approval-type/node_modules/@bcrs-shared-components/date-picker": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/date-picker/-/date-picker-1.2.16.tgz",
+      "integrity": "sha512-VBK/FsdVymLDTo6vFjoLKRk2mx+aMftE2xmOimDtHHetfnmY48E4WqNruZM4iV8+r4Ve9DLaQFQ2QJ76VsfS6Q==",
+      "dependencies": {
+        "@bcrs-shared-components/interfaces": "^1.0.59",
+        "vue-property-decorator": "^9.1.2"
+      }
+    },
+    "node_modules/@bcrs-shared-components/approval-type/node_modules/@bcrs-shared-components/enums": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.37.tgz",
+      "integrity": "sha512-7S0oteYkZXEzfwjl2q4DVjRS+dnq3yJ7Wjh6PZxDX1L4SnxyXCCYWMO/BXZxeGKuagcsam85ICmyjn2uMRjpPA==",
+      "dependencies": {
+        "@bcrs-shared-components/corp-type-module": "^1.0.11"
+      }
+    },
+    "node_modules/@bcrs-shared-components/approval-type/node_modules/@bcrs-shared-components/interfaces": {
+      "version": "1.0.59",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.0.59.tgz",
+      "integrity": "sha512-sTokG7e+8T3+k6EEIPRQDCq6JN/7TsBTnDImcqKvHboBSNWesH/wfIVYiYwPIwQXjNmUeXzB6nC3NJDyorwM6w==",
+      "dependencies": {
+        "@bcrs-shared-components/enums": "^1.0.37",
+        "vue": "^2.7.10"
+      }
+    },
     "node_modules/@bcrs-shared-components/breadcrumb": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@bcrs-shared-components/breadcrumb/-/breadcrumb-2.1.5.tgz",
@@ -1959,9 +2004,9 @@
       }
     },
     "node_modules/@bcrs-shared-components/enums/node_modules/@bcrs-shared-components/corp-type-module": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/corp-type-module/-/corp-type-module-1.0.9.tgz",
-      "integrity": "sha512-w52/6yvCW92oplOScHuP33gLSA7rsJ9ENyaZ6JKEK78rdrFdCrs1m4/Umr0DQWXUbwZQ43xn2jKXvYWDmIe1Mg=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/corp-type-module/-/corp-type-module-1.0.11.tgz",
+      "integrity": "sha512-+iE3qiySSafiA311m14DuoG9Rq/ranBJNT7Kf7KQ9dJFDNNuTA326pCGwKBeuT1L6pFpGeibXGE+vQ0AYnSPUA=="
     },
     "node_modules/@bcrs-shared-components/fee-summary": {
       "version": "1.2.5",
@@ -2050,6 +2095,14 @@
         "vue": "^2.7.10"
       }
     },
+    "node_modules/@bcrs-shared-components/limited-restoration-panel": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/limited-restoration-panel/-/limited-restoration-panel-1.0.3.tgz",
+      "integrity": "sha512-zfoi7tBhFTx3Ds/PI9/MqyreHaIoxRutfnkmcuheQAWFZJUS0WGUSobTuKF68OxkZpz5YdktTW7a1SpKnJh/CA==",
+      "dependencies": {
+        "vue-property-decorator": "^9.1.2"
+      }
+    },
     "node_modules/@bcrs-shared-components/nature-of-business": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@bcrs-shared-components/nature-of-business/-/nature-of-business-1.2.4.tgz",
@@ -2057,6 +2110,28 @@
       "dependencies": {
         "@bcrs-shared-components/interfaces": "^1.0.48",
         "vue-property-decorator": "^9.1.2"
+      }
+    },
+    "node_modules/@bcrs-shared-components/relationships-panel": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/relationships-panel/-/relationships-panel-1.0.12.tgz",
+      "integrity": "sha512-PWAn+WzmODpANxFFDfZIuOYs8jZFQQI1Uzu0Hejv/H0qPyCd916vj159R1KBIT7ciEAWCXc1KEl7PwARihTvQw==",
+      "dependencies": {
+        "@bcrs-shared-components/enums": "^1.0.37",
+        "vue-property-decorator": "^9.1.2"
+      }
+    },
+    "node_modules/@bcrs-shared-components/relationships-panel/node_modules/@bcrs-shared-components/corp-type-module": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/corp-type-module/-/corp-type-module-1.0.11.tgz",
+      "integrity": "sha512-+iE3qiySSafiA311m14DuoG9Rq/ranBJNT7Kf7KQ9dJFDNNuTA326pCGwKBeuT1L6pFpGeibXGE+vQ0AYnSPUA=="
+    },
+    "node_modules/@bcrs-shared-components/relationships-panel/node_modules/@bcrs-shared-components/enums": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.37.tgz",
+      "integrity": "sha512-7S0oteYkZXEzfwjl2q4DVjRS+dnq3yJ7Wjh6PZxDX1L4SnxyXCCYWMO/BXZxeGKuagcsam85ICmyjn2uMRjpPA==",
+      "dependencies": {
+        "@bcrs-shared-components/corp-type-module": "^1.0.11"
       }
     },
     "node_modules/@bcrs-shared-components/share-structure": {
@@ -24876,6 +24951,50 @@
         "vue-property-decorator": "^9.1.2"
       }
     },
+    "@bcrs-shared-components/approval-type": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/approval-type/-/approval-type-1.0.15.tgz",
+      "integrity": "sha512-3l0rUeCtXIG6md47afOBwv54wjTY9McfovKrxmjgeOO3wPbB3wtKcsUW3ChoJxY+oe2j9AWVdUX8GL+gqHQTJw==",
+      "requires": {
+        "@bcrs-shared-components/date-picker": "^1.2.16",
+        "@bcrs-shared-components/enums": "^1.0.37",
+        "@bcrs-shared-components/interfaces": "^1.0.59",
+        "vue-property-decorator": "^9.1.2"
+      },
+      "dependencies": {
+        "@bcrs-shared-components/corp-type-module": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/corp-type-module/-/corp-type-module-1.0.11.tgz",
+          "integrity": "sha512-+iE3qiySSafiA311m14DuoG9Rq/ranBJNT7Kf7KQ9dJFDNNuTA326pCGwKBeuT1L6pFpGeibXGE+vQ0AYnSPUA=="
+        },
+        "@bcrs-shared-components/date-picker": {
+          "version": "1.2.16",
+          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/date-picker/-/date-picker-1.2.16.tgz",
+          "integrity": "sha512-VBK/FsdVymLDTo6vFjoLKRk2mx+aMftE2xmOimDtHHetfnmY48E4WqNruZM4iV8+r4Ve9DLaQFQ2QJ76VsfS6Q==",
+          "requires": {
+            "@bcrs-shared-components/interfaces": "^1.0.59",
+            "vue-property-decorator": "^9.1.2"
+          }
+        },
+        "@bcrs-shared-components/enums": {
+          "version": "1.0.37",
+          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.37.tgz",
+          "integrity": "sha512-7S0oteYkZXEzfwjl2q4DVjRS+dnq3yJ7Wjh6PZxDX1L4SnxyXCCYWMO/BXZxeGKuagcsam85ICmyjn2uMRjpPA==",
+          "requires": {
+            "@bcrs-shared-components/corp-type-module": "^1.0.11"
+          }
+        },
+        "@bcrs-shared-components/interfaces": {
+          "version": "1.0.59",
+          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.0.59.tgz",
+          "integrity": "sha512-sTokG7e+8T3+k6EEIPRQDCq6JN/7TsBTnDImcqKvHboBSNWesH/wfIVYiYwPIwQXjNmUeXzB6nC3NJDyorwM6w==",
+          "requires": {
+            "@bcrs-shared-components/enums": "^1.0.37",
+            "vue": "^2.7.10"
+          }
+        }
+      }
+    },
     "@bcrs-shared-components/breadcrumb": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@bcrs-shared-components/breadcrumb/-/breadcrumb-2.1.5.tgz",
@@ -25018,9 +25137,9 @@
       },
       "dependencies": {
         "@bcrs-shared-components/corp-type-module": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/corp-type-module/-/corp-type-module-1.0.9.tgz",
-          "integrity": "sha512-w52/6yvCW92oplOScHuP33gLSA7rsJ9ENyaZ6JKEK78rdrFdCrs1m4/Umr0DQWXUbwZQ43xn2jKXvYWDmIe1Mg=="
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/corp-type-module/-/corp-type-module-1.0.11.tgz",
+          "integrity": "sha512-+iE3qiySSafiA311m14DuoG9Rq/ranBJNT7Kf7KQ9dJFDNNuTA326pCGwKBeuT1L6pFpGeibXGE+vQ0AYnSPUA=="
         }
       }
     },
@@ -25113,6 +25232,14 @@
         "vue": "^2.7.10"
       }
     },
+    "@bcrs-shared-components/limited-restoration-panel": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/limited-restoration-panel/-/limited-restoration-panel-1.0.3.tgz",
+      "integrity": "sha512-zfoi7tBhFTx3Ds/PI9/MqyreHaIoxRutfnkmcuheQAWFZJUS0WGUSobTuKF68OxkZpz5YdktTW7a1SpKnJh/CA==",
+      "requires": {
+        "vue-property-decorator": "^9.1.2"
+      }
+    },
     "@bcrs-shared-components/nature-of-business": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@bcrs-shared-components/nature-of-business/-/nature-of-business-1.2.4.tgz",
@@ -25120,6 +25247,30 @@
       "requires": {
         "@bcrs-shared-components/interfaces": "^1.0.48",
         "vue-property-decorator": "^9.1.2"
+      }
+    },
+    "@bcrs-shared-components/relationships-panel": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/relationships-panel/-/relationships-panel-1.0.12.tgz",
+      "integrity": "sha512-PWAn+WzmODpANxFFDfZIuOYs8jZFQQI1Uzu0Hejv/H0qPyCd916vj159R1KBIT7ciEAWCXc1KEl7PwARihTvQw==",
+      "requires": {
+        "@bcrs-shared-components/enums": "^1.0.37",
+        "vue-property-decorator": "^9.1.2"
+      },
+      "dependencies": {
+        "@bcrs-shared-components/corp-type-module": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/corp-type-module/-/corp-type-module-1.0.11.tgz",
+          "integrity": "sha512-+iE3qiySSafiA311m14DuoG9Rq/ranBJNT7Kf7KQ9dJFDNNuTA326pCGwKBeuT1L6pFpGeibXGE+vQ0AYnSPUA=="
+        },
+        "@bcrs-shared-components/enums": {
+          "version": "1.0.37",
+          "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.0.37.tgz",
+          "integrity": "sha512-7S0oteYkZXEzfwjl2q4DVjRS+dnq3yJ7Wjh6PZxDX1L4SnxyXCCYWMO/BXZxeGKuagcsam85ICmyjn2uMRjpPA==",
+          "requires": {
+            "@bcrs-shared-components/corp-type-module": "^1.0.11"
+          }
+        }
       }
     },
     "@bcrs-shared-components/share-structure": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "3.10.7",
+  "version": "3.10.8",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",
@@ -15,6 +15,7 @@
   "dependencies": {
     "@babel/compat-data": "^7.19.1",
     "@bcrs-shared-components/action-chip": "1.1.5",
+    "@bcrs-shared-components/approval-type": "1.0.15",
     "@bcrs-shared-components/breadcrumb": "2.1.5",
     "@bcrs-shared-components/business-lookup": "1.1.7",
     "@bcrs-shared-components/certify": "2.1.5",
@@ -30,7 +31,9 @@
     "@bcrs-shared-components/folio-number": "1.1.1",
     "@bcrs-shared-components/help-business-number": "1.1.1",
     "@bcrs-shared-components/interfaces": "1.0.48",
+    "@bcrs-shared-components/limited-restoration-panel": "1.0.3",
     "@bcrs-shared-components/nature-of-business": "1.2.4",
+    "@bcrs-shared-components/relationships-panel": "1.0.12",
     "@bcrs-shared-components/share-structure": "2.1.4",
     "@bcrs-shared-components/staff-payment": "2.1.4",
     "@mdi/font": "^5.9.55",

--- a/src/App.vue
+++ b/src/App.vue
@@ -87,54 +87,11 @@
       <main v-if="!isErrorDialog">
         <BreadcrumbShared :breadcrumbs="breadcrumbs" />
         <EntityInfo />
-
-        <v-container class="view-container my-8 py-0">
-          <v-row>
-            <v-col cols="9" class="left-side">
-              <router-view
-                :appReady=appReady
-                :isSummaryMode="isSummaryMode"
-                @fetchError="fetchErrorDialog = true"
-                @haveData="haveData = true"
-              />
-            </v-col>
-
-            <v-col cols="3" class="right-side">
-              <affix v-if="showFeeSummary"
-                relative-element-selector=".left-side"
-                :offset="{ top: 86, bottom: 12 }"
-              >
-                <!-- Corrections still use the basic Fee Summary component -->
-                <aside v-if="isCorrectionFiling && correctionHasFilingData">
-                  <SbcFeeSummary
-                    :filingData="[...getFilingData]"
-                    :payURL="payApiUrl"
-                  />
-                </aside>
-
-                <!-- Alteration/Change/Conversion/Restoration filings use the enhanced Fee Summary shared component -->
-                <v-expand-transition>
-                  <FeeSummaryShared
-                    v-if="showFeesummaryShared"
-                    :filingData="getFilingData"
-                    :payApiUrl="payApiUrl"
-                    :isLoading="isBusySaving"
-                    :hasConflicts="isConflictingLegalType && getNameRequestNumber"
-                    :confirmLabel="feeSummaryConfirmLabel"
-                    :errorMessage="feeSummaryError"
-                    :isSummaryMode="isSummaryMode"
-                    @action="handleFeeSummaryActions($event)"
-                  />
-                </v-expand-transition>
-              </affix>
-            </v-col>
-          </v-row>
-        </v-container>
-
-        <!-- Actions component is for Corrections only -->
-        <Actions
-          v-if="isCorrectionFiling"
-          :key="$route.path"
+        <router-view
+          :appReady=appReady
+          :isSummaryMode="isSummaryMode"
+          @fetchError="fetchErrorDialog = true"
+          @haveData="haveData = true"
         />
       </main>
     </div>
@@ -152,8 +109,6 @@ import { GetKeycloakRoles, Navigate, UpdateLdUser, Sleep } from '@/utils/'
 import PaySystemAlert from 'sbc-common-components/src/components/PaySystemAlert.vue'
 import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
 import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
-import SbcFeeSummary from 'sbc-common-components/src/components/SbcFeeSummary.vue'
-import { FeeSummary as FeeSummaryShared } from '@bcrs-shared-components/fee-summary/'
 import { Actions, EntityInfo } from '@/components/common/'
 import { Breadcrumb as BreadcrumbShared } from '@bcrs-shared-components/breadcrumb/'
 import { ConfirmDialog as ConfirmDialogShared } from '@bcrs-shared-components/confirm-dialog/'
@@ -161,13 +116,11 @@ import * as Views from '@/views/'
 import * as Dialogs from '@/dialogs/'
 import { AuthServices, LegalServices } from '@/services/'
 import { CommonMixin, FilingTemplateMixin } from '@/mixins/'
-import { FilingDataIF, ActionBindingIF, ConfirmDialogType, FlagsReviewCertifyIF, FlagsCompanyInfoIF,
-  AlterationFilingIF, ChgRegistrationFilingIF, ConversionFilingIF, SpecialResolutionFilingIF }
+import { FilingDataIF, ActionBindingIF, ConfirmDialogType, FlagsReviewCertifyIF, FlagsCompanyInfoIF }
   from '@/interfaces/'
 import { BreadcrumbIF, CompletingPartyIF } from '@bcrs-shared-components/interfaces/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
-import { ComponentsCompanyInfo, ComponentsReviewCertify, RouteNames } from '@/enums/'
-import { FeeSummaryActions } from '@bcrs-shared-components/enums/'
+import { RouteNames } from '@/enums/'
 import { getEntityDashboardBreadcrumb, getMyBusinessRegistryBreadcrumb, getRegistryDashboardBreadcrumb,
   getStaffDashboardBreadcrumb } from '@/resources/BreadCrumbResources'
 import DateUtilities from '@/services/date-utilities'
@@ -178,11 +131,9 @@ import DateUtilities from '@/services/date-utilities'
     BreadcrumbShared,
     ConfirmDialogShared,
     EntityInfo,
-    FeeSummaryShared,
     PaySystemAlert,
     SbcHeader,
     SbcFooter,
-    SbcFeeSummary,
     ...Dialogs,
     ...Views
   },
@@ -289,11 +240,6 @@ export default class App extends Vue {
     return crumbs
   }
 
-  /** The URL of the Pay API. */
-  get payApiUrl (): string {
-    return sessionStorage.getItem('PAY_API_URL')
-  }
-
   /** True if an error dialog is displayed. */
   get isErrorDialog (): boolean {
     // NB: ignore nameRequestErrorDialog (to leave underlying components rendered)
@@ -316,60 +262,6 @@ export default class App extends Vue {
   /** Whether user is authenticated. */
   get isAuthenticated (): boolean {
     return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
-  }
-
-  /** The fee summary confirm button label. */
-  get feeSummaryConfirmLabel (): string {
-    const isNoFee = this.isFirmChangeFiling || this.isFirmConversionFiling
-    if (this.isSummaryMode) {
-      return (isNoFee && !this.getFilingData.some(fd => fd.priority)) ? 'File Now (No Fee)' : 'File and Pay'
-    } else {
-      return isNoFee ? 'Review and Confirm' : 'Review and Certify'
-    }
-  }
-
-  /** Error text to display in the Fee Summary component. */
-  get feeSummaryError (): string {
-    if (this.isSummaryMode) {
-      return this.hasInvalidReviewSections ? '&lt; Please complete required information' : ''
-    } else {
-      return this.hasInvalidSections ? '&lt; You have unfinished changes' : ''
-    }
-  }
-
-  /** True is there are any invalid component sections. */
-  get hasInvalidSections (): boolean {
-    return (
-      this.getComponentValidate &&
-      Object.values(this.getFlagsCompanyInfo).some(val => val === false)
-    )
-  }
-
-  /** True if there are any invalid review sections. */
-  get hasInvalidReviewSections (): boolean {
-    return (
-      this.getAppValidate &&
-      Object.values(this.getFlagsReviewCertify).some(val => val === false)
-    )
-  }
-  /** Show fee summary only allowed filing types */
-  get showFeesummaryShared (): boolean {
-    return (
-      this.isSpecialResolutionFiling ||
-      this.isAlterationFiling ||
-      this.isFirmChangeFiling ||
-      this.isFirmConversionFiling ||
-      this.isRestorationFiling
-    )
-  }
-
-  /** True if there is filing data for corrections - corrections has a single filing schedule. */
-  get correctionHasFilingData () : boolean {
-    return Boolean(
-      this.getFilingData?.length > 0 &&
-      this.getFilingData[0].filingTypeCode &&
-      this.getFilingData[0].entityType
-    )
   }
 
   /** Helper to check is the current route matches */
@@ -573,37 +465,6 @@ export default class App extends Vue {
     this.appReady = true
   }
 
-  /**
-   * Handles actions from the fee summary component.
-   * NOTE: This is only implemented for Alteration filings atm.
-   * @param action the emitted action
-   */
-  protected async handleFeeSummaryActions (action: FeeSummaryActions): Promise<void> {
-    switch (action) {
-      case FeeSummaryActions.BACK:
-        this.setSummaryMode(false)
-        await this.scrollToTop(document.getElementById('app'))
-        break
-      case FeeSummaryActions.SAVE_RESUME_LATER:
-        // Save filing and return to dashboard.
-        await this.onClickSave()
-        this.goToDashboard()
-        break
-      case FeeSummaryActions.CANCEL:
-        this.goToDashboard()
-        break
-      case FeeSummaryActions.CONFIRM:
-        if (this.isSummaryMode) {
-          // Check validity, and if OK then save and file.
-          await this.validateReviewCertifyPage()
-        } else {
-          // Check validity, and if OK then go to summary page.
-          await this.validateCompanyInfoPage()
-        }
-        break
-    }
-  }
-
   /** Navigates to Manage Businesses dashboard. */
   protected goToManageBusinessDashboard (): void {
     this.fileAndPayInvalidNameRequestDialog = false
@@ -742,101 +603,6 @@ export default class App extends Vue {
     const custom: any = { roles: this.getUserRoles?.slice(1, -1).split(',') }
 
     await UpdateLdUser(key, email, firstName, lastName, custom)
-  }
-
-  /** Perform high level component validations before proceeding to summary page. */
-  private async validateCompanyInfoPage (): Promise<void> {
-    this.setComponentValidate(true)
-
-    // Evaluate valid flags. Scroll to invalid components or continue to review.
-    if (await this.validateAndScroll(this.getFlagsCompanyInfo, ComponentsCompanyInfo)) {
-      // show summary page
-      this.setSummaryMode(true)
-
-      // reset validate flag
-      this.setAppValidate(false)
-
-      // Reset global flag
-      this.setComponentValidate(false)
-
-      // We don't change views, just interchange components, so scroll to top for better UX.
-      await this.scrollToTop(document.getElementById('app'))
-    }
-  }
-
-  /** Perform high level component validations before proceeding to filing and paying. */
-  private async validateReviewCertifyPage (): Promise<void> {
-    // Prompt app validations.
-    this.setAppValidate(true)
-
-    // Wait to allow app validation.
-    await Vue.nextTick()
-
-    // Evaluate valid flags. Scroll to invalid components or file alteration.
-    if (await this.validateAndScroll(this.getFlagsReviewCertify, ComponentsReviewCertify)) {
-      await this.onClickSave(false)
-    }
-  }
-
-  /**
-   * Will create/update a draft alteration or file and pay.
-   * @returns a promise (ie, this is an async method).
-   */
-  private async onClickSave (isDraft = true): Promise<void> {
-    // prevent double saving
-    if (this.isBusySaving) return
-    this.setIsSaving(true)
-
-    let filingComplete: any
-    try {
-      let filing: AlterationFilingIF | ChgRegistrationFilingIF | ConversionFilingIF | SpecialResolutionFilingIF
-      if (this.isAlterationFiling) filing = this.buildAlterationFiling(isDraft)
-      if (this.isFirmChangeFiling) filing = this.buildChangeRegFiling(isDraft)
-      if (this.isFirmConversionFiling) filing = this.buildConversionFiling(isDraft)
-      if (this.isSpecialResolutionFiling) filing = this.buildSpecialResolutionFiling(isDraft)
-
-      // update the filing if we have a filingId, otherwise create a draft
-      filingComplete = this.getFilingId
-        ? await LegalServices.updateFiling(this.getBusinessId, this.getFilingId, filing, isDraft)
-        : await LegalServices.createFiling(this.getBusinessId, filing, isDraft)
-
-      // clear flag
-      this.setHaveUnsavedChanges(false)
-    } catch (error) {
-      this.$root.$emit('save-error-event', error)
-      this.setIsSaving(false)
-      return
-    }
-
-    // if filing is not a draft, proceed with payment
-    if (!isDraft && filingComplete) {
-      // If Saving or Filing is successful then setIsFilingPaying should't be reset to false,
-      // this prevent buttons from being re-enabled if the page is slow to redirect.
-      this.setIsFilingPaying(true)
-      const paymentToken = filingComplete.header?.paymentToken
-      const filingId = filingComplete.header?.filingId
-
-      if (paymentToken && filingId) {
-        const isPaymentActionRequired: boolean = filingComplete.header?.isPaymentActionRequired
-        const returnUrl = sessionStorage.getItem('DASHBOARD_URL') + this.getBusinessId +
-          `?filing_id=${filingId}`
-
-        // if payment action is required, navigate to Pay URL
-        if (isPaymentActionRequired) {
-          const authUrl = sessionStorage.getItem('AUTH_WEB_URL')
-          const payUrl = authUrl + 'makepayment/' + paymentToken + '/' + encodeURIComponent(returnUrl)
-          // assume Pay URL is always reachable
-          // otherwise user will have to retry payment later
-          Navigate(payUrl)
-        } else {
-          // otherwise go straight to dashboard
-          Navigate(returnUrl)
-        }
-      } else {
-        const error = new Error('Missing Payment Token or Filing ID')
-        this.$root.$emit('save-error-event', error)
-      }
-    }
   }
 }
 </script>

--- a/src/components/ViewWrapper.vue
+++ b/src/components/ViewWrapper.vue
@@ -1,0 +1,387 @@
+<template>
+  <div>
+    <v-container class="view-container my-8 py-0">
+      <v-row>
+        <v-col cols="9" class="left-side">
+          <slot></slot>
+        </v-col>
+
+        <v-col cols="3" class="right-side">
+          <affix v-if="showFeeSummary"
+                 relative-element-selector=".left-side"
+                 :offset="{ top: 86, bottom: 12 }"
+          >
+            <!-- Corrections still use the basic Fee Summary component -->
+            <aside v-if="isCorrectionFiling && correctionHasFilingData">
+              <SbcFeeSummary
+                :filingData="[...getFilingData]"
+                :payURL="payApiUrl"
+              />
+            </aside>
+
+            <!-- Alteration/Change/Conversion/Restoration filings use the enhanced Fee Summary shared component -->
+            <v-expand-transition>
+              <FeeSummaryShared
+                v-if="showFeeSummaryShared"
+                :filingData="getFilingData"
+                :payApiUrl="payApiUrl"
+                :isLoading="isBusySaving"
+                :hasConflicts="isConflictingLegalType && getNameRequestNumber"
+                :confirmLabel="feeSummaryConfirmLabel"
+                :errorMessage="feeSummaryError"
+                :isSummaryMode="isSummaryMode"
+                @action="handleFeeSummaryActions($event)"
+              />
+            </v-expand-transition>
+          </affix>
+        </v-col>
+        <!-- end of v-col -->
+      </v-row>
+    </v-container>
+    <!-- Actions component is for Corrections only -->
+    <Actions
+      v-if="isCorrectionFiling"
+      :key="$route.path"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Affix as affix } from 'vue-affix'
+import { Component } from 'vue-property-decorator'
+import { Action, Getter } from 'vuex-class'
+import { Navigate } from '@/utils/'
+import PaySystemAlert from 'sbc-common-components/src/components/PaySystemAlert.vue'
+import SbcFeeSummary from 'sbc-common-components/src/components/SbcFeeSummary.vue'
+import { FeeSummary as FeeSummaryShared } from '@bcrs-shared-components/fee-summary/'
+import { Actions, EntityInfo } from '@/components/common/'
+import { ConfirmDialog as ConfirmDialogShared } from '@bcrs-shared-components/confirm-dialog/'
+import { AuthServices, LegalServices } from '@/services/'
+import { CommonMixin, FilingTemplateMixin } from '@/mixins/'
+import { FilingDataIF, ActionBindingIF, ConfirmDialogType, FlagsReviewCertifyIF, FlagsCompanyInfoIF,
+  AlterationFilingIF, ChgRegistrationFilingIF, ConversionFilingIF, SpecialResolutionFilingIF }
+  from '@/interfaces/'
+import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
+import { ComponentsCompanyInfo, ComponentsReviewCertify, RouteNames } from '@/enums/'
+import { FeeSummaryActions } from '@bcrs-shared-components/enums/'
+
+@Component({
+  components: {
+    Actions,
+    affix,
+    ConfirmDialogShared,
+    EntityInfo,
+    FeeSummaryShared,
+    PaySystemAlert,
+    SbcFeeSummary
+  },
+  mixins: [
+    CommonMixin,
+    FilingTemplateMixin
+  ]
+})
+export default class App extends Vue {
+  // Refs
+  $refs!: {
+    confirm: ConfirmDialogType
+  }
+
+  // Global getters
+  @Getter getUserEmail!: string
+  @Getter getUserPhone!: string
+  @Getter getUserFirstName!: string
+  @Getter getUserLastName!: string
+  @Getter getUserRoles!: string
+  @Getter getUserUsername!: string
+  @Getter getOrgInfo!: any
+  @Getter getFilingData!: FilingDataIF[]
+  @Getter haveUnsavedChanges!: boolean
+  @Getter isBusySaving!: boolean
+  @Getter isCorrectionEditing!: boolean
+  @Getter isSummaryMode!: boolean
+  @Getter showFeeSummary!: boolean
+  @Getter getCurrentJsDate!: Date
+  @Getter getFilingId!: number
+  @Getter isRestorationFiling!: boolean
+
+  // Alteration flag getters
+  @Getter getFlagsReviewCertify!: FlagsReviewCertifyIF
+  @Getter getFlagsCompanyInfo!: FlagsCompanyInfoIF
+  @Getter getAppValidate!: boolean
+  @Getter getComponentValidate!: boolean
+  @Getter isConflictingLegalType!: boolean
+  @Getter isRoleStaff!: boolean
+  @Getter isSbcStaff!: boolean
+
+  // Global actions
+  @Action setHaveUnsavedChanges!: ActionBindingIF
+  @Action setSummaryMode!: ActionBindingIF
+  @Action setComponentValidate!: ActionBindingIF
+  @Action setAppValidate!: ActionBindingIF
+  @Action setIsSaving!: ActionBindingIF
+  @Action setIsFilingPaying!: ActionBindingIF
+
+  // Local properties
+  protected accountAuthorizationDialog = false
+  protected fetchErrorDialog = false
+  protected paymentErrorDialog = false
+  protected staffPaymentErrorDialog = false
+  protected saveErrorDialog = false
+  protected nameRequestErrorDialog = false
+  protected nameRequestErrorType = ''
+  protected saveErrors: Array<object> = []
+  protected saveWarnings: Array<object> = []
+  protected fileAndPayInvalidNameRequestDialog = false
+  protected confirmDeleteAllDialog = false
+
+  // FUTURE: change appReady/haveData to a state machine?
+  /** Whether the app is ready and the views can now load their data. */
+  protected appReady = false
+
+  /** Whether the views have loaded their data and the spinner can be hidden. */
+  protected haveData = false
+
+  /** The Update Current JS Date timer id. */
+  private updateCurrentJsDateId = 0
+
+  /** The URL of the Pay API. */
+  get payApiUrl (): string {
+    return sessionStorage.getItem('PAY_API_URL')
+  }
+
+  /** Whether user is authenticated. */
+  get isAuthenticated (): boolean {
+    return Boolean(sessionStorage.getItem(SessionStorageKeys.KeyCloakToken))
+  }
+
+  /** The fee summary confirm button label. */
+  get feeSummaryConfirmLabel (): string {
+    const isNoFee = this.isFirmChangeFiling || this.isFirmConversionFiling
+    if (this.isSummaryMode) {
+      return (isNoFee && !this.getFilingData.some(fd => fd.priority)) ? 'File Now (No Fee)' : 'File and Pay'
+    } else {
+      return isNoFee ? 'Review and Confirm' : 'Review and Certify'
+    }
+  }
+
+  /** Error text to display in the Fee Summary component. */
+  get feeSummaryError (): string {
+    if (this.isSummaryMode) {
+      return this.hasInvalidReviewSections ? '&lt; Please complete required information' : ''
+    } else {
+      return this.hasInvalidSections ? '&lt; You have unfinished changes' : ''
+    }
+  }
+
+  /** True is there are any invalid component sections. */
+  get hasInvalidSections (): boolean {
+    return (
+      this.getComponentValidate &&
+      Object.values(this.getFlagsCompanyInfo).some(val => val === false)
+    )
+  }
+
+  /** True if there are any invalid review sections. */
+  get hasInvalidReviewSections (): boolean {
+    return (
+      this.getAppValidate &&
+      Object.values(this.getFlagsReviewCertify).some(val => val === false)
+    )
+  }
+  /** Show fee summary only allowed filing types */
+  get showFeeSummaryShared (): boolean {
+    return (
+      this.isSpecialResolutionFiling ||
+      this.isAlterationFiling ||
+      this.isFirmChangeFiling ||
+      this.isFirmConversionFiling
+    )
+  }
+
+  /** True if there is filing data for corrections - corrections has a single filing schedule. */
+  get correctionHasFilingData () : boolean {
+    return Boolean(
+      this.getFilingData?.length > 0 &&
+      this.getFilingData[0].filingTypeCode &&
+      this.getFilingData[0].entityType
+    )
+  }
+
+  /**
+   * Handles actions from the fee summary component.
+   * NOTE: This is only implemented for Alteration filings atm.
+   * @param action the emitted action
+   */
+  protected async handleFeeSummaryActions (action: FeeSummaryActions): Promise<void> {
+    switch (action) {
+      case FeeSummaryActions.BACK:
+        this.setSummaryMode(false)
+        await this.scrollToTop(document.getElementById('app'))
+        break
+      case FeeSummaryActions.SAVE_RESUME_LATER:
+        // Save filing and return to dashboard.
+        await this.onClickSave()
+        this.goToDashboard()
+        break
+      case FeeSummaryActions.CANCEL:
+        this.goToDashboard()
+        break
+      case FeeSummaryActions.CONFIRM:
+        if (this.isSummaryMode) {
+          // Check validity, and if OK then save and file.
+          await this.validateReviewCertifyPage()
+        } else {
+          // Check validity, and if OK then go to summary page.
+          await this.validateCompanyInfoPage()
+        }
+        break
+    }
+  }
+
+  /** Navigates to Manage Businesses dashboard. */
+  protected goToManageBusinessDashboard (): void {
+    this.fileAndPayInvalidNameRequestDialog = false
+    this.setHaveUnsavedChanges(false)
+    // FUTURE: Manage Businesses URL should come from config
+    const manageBusinessUrl = `${sessionStorage.getItem('AUTH_WEB_URL')}business`
+    Navigate(manageBusinessUrl)
+  }
+
+  /** Called to navigate to dashboard. */
+  private async goToDashboard (force = false): Promise<void> {
+    const dashboardUrl = sessionStorage.getItem('DASHBOARD_URL') + this.getBusinessId
+
+    // check if there are no data changes
+    if (!this.haveUnsavedChanges || force) {
+      // navigate to dashboard
+      this.setHaveUnsavedChanges(false)
+      Navigate(dashboardUrl)
+      return
+    }
+
+    // Prompt confirm dialog
+    const hasConfirmed = await this.showConfirmDialog(
+      this.$refs.confirm,
+      'Unsaved Changes',
+      'You have unsaved changes. Do you want to exit?',
+      'Return to my Filing',
+      'Exit Without Saving'
+    )
+
+    if (!hasConfirmed) {
+      // if we get here, Cancel was clicked
+      // ignore changes
+      this.setHaveUnsavedChanges(false)
+      // navigate to dashboard
+      Navigate(dashboardUrl)
+    }
+  }
+
+  /** Perform high level component validations before proceeding to summary page. */
+  private async validateCompanyInfoPage (): Promise<void> {
+    this.setComponentValidate(true)
+
+    // Evaluate valid flags. Scroll to invalid components or continue to review.
+    if (await this.validateAndScroll(this.getFlagsCompanyInfo, ComponentsCompanyInfo)) {
+      // show summary page
+      this.setSummaryMode(true)
+
+      // reset validate flag
+      this.setAppValidate(false)
+
+      // Reset global flag
+      this.setComponentValidate(false)
+
+      // We don't change views, just interchange components, so scroll to top for better UX.
+      await this.scrollToTop(document.getElementById('app'))
+    }
+  }
+
+  /** Perform high level component validations before proceeding to filing and paying. */
+  private async validateReviewCertifyPage (): Promise<void> {
+    // Prompt app validations.
+    this.setAppValidate(true)
+
+    // Wait to allow app validation.
+    await Vue.nextTick()
+
+    // Evaluate valid flags. Scroll to invalid components or file alteration.
+    if (await this.validateAndScroll(this.getFlagsReviewCertify, ComponentsReviewCertify)) {
+      await this.onClickSave(false)
+    }
+  }
+
+  /**
+   * Will create/update a draft alteration or file and pay.
+   * @returns a promise (ie, this is an async method).
+   */
+  private async onClickSave (isDraft = true): Promise<void> {
+    // prevent double saving
+    if (this.isBusySaving) return
+    this.setIsSaving(true)
+
+    let filingComplete: any
+    try {
+      let filing: AlterationFilingIF | ChgRegistrationFilingIF | ConversionFilingIF | SpecialResolutionFilingIF
+      if (this.isAlterationFiling) filing = this.buildAlterationFiling(isDraft)
+      if (this.isFirmChangeFiling) filing = this.buildChangeRegFiling(isDraft)
+      if (this.isFirmConversionFiling) filing = this.buildConversionFiling(isDraft)
+      if (this.isSpecialResolutionFiling) filing = this.buildSpecialResolutionFiling(isDraft)
+
+      // update the filing if we have a filingId, otherwise create a draft
+      filingComplete = this.getFilingId
+        ? await LegalServices.updateFiling(this.getBusinessId, this.getFilingId, filing, isDraft)
+        : await LegalServices.createFiling(this.getBusinessId, filing, isDraft)
+
+      // clear flag
+      this.setHaveUnsavedChanges(false)
+    } catch (error) {
+      this.$root.$emit('save-error-event', error)
+      this.setIsSaving(false)
+      return
+    }
+
+    // if filing is not a draft, proceed with payment
+    if (!isDraft && filingComplete) {
+      // If Saving or Filing is successful then setIsFilingPaying should't be reset to false,
+      // this prevent buttons from being re-enabled if the page is slow to redirect.
+      this.setIsFilingPaying(true)
+      const paymentToken = filingComplete.header?.paymentToken
+      const filingId = filingComplete.header?.filingId
+
+      if (paymentToken && filingId) {
+        const isPaymentActionRequired: boolean = filingComplete.header?.isPaymentActionRequired
+        const returnUrl = sessionStorage.getItem('DASHBOARD_URL') + this.getBusinessId +
+          `?filing_id=${filingId}`
+
+        // if payment action is required, navigate to Pay URL
+        if (isPaymentActionRequired) {
+          const authUrl = sessionStorage.getItem('AUTH_WEB_URL')
+          const payUrl = authUrl + 'makepayment/' + paymentToken + '/' + encodeURIComponent(returnUrl)
+          // assume Pay URL is always reachable
+          // otherwise user will have to retry payment later
+          Navigate(payUrl)
+        } else {
+          // otherwise go straight to dashboard
+          Navigate(returnUrl)
+        }
+      } else {
+        const error = new Error('Missing Payment Token or Filing ID')
+        this.$root.$emit('save-error-event', error)
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+// place app header on top of dialogs (and therefore still usable)
+.app-header {
+  z-index: 1000;
+}
+
+.right-side {
+  position: relative;
+}
+</style>

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -1,111 +1,113 @@
 <template>
-  <section class="pb-10" id="alteration-view">
-    <!-- Company Information page-->
-    <v-slide-x-transition hide-on-leave>
-      <div v-if="!isSummaryMode">
-        <header>
-          <h1>Company Information</h1>
-        </header>
+  <ViewWrapper>
+    <section class="pb-10" id="alteration-view">
+      <!-- Company Information page-->
+      <v-slide-x-transition hide-on-leave>
+        <div v-if="!isSummaryMode">
+          <header>
+            <h1>Company Information</h1>
+          </header>
 
-        <section class="mt-6">
-          You are legally obligated to keep your company information up to date. Necessary fees will be
-          applied as updates are made.
-        </section>
+          <section class="mt-6">
+            You are legally obligated to keep your company information up to date. Necessary fees will be
+            applied as updates are made.
+          </section>
 
-        <YourCompany class="mt-10" />
+          <YourCompany class="mt-10" />
 
-        <CurrentDirectors class="mt-10" />
+          <CurrentDirectors class="mt-10" />
 
-        <ShareStructures class="mt-10" />
+          <ShareStructures class="mt-10" />
 
-        <Articles class="mt-10" />
-      </div>
-    </v-slide-x-transition>
+          <Articles class="mt-10" />
+        </div>
+      </v-slide-x-transition>
 
-    <!-- Review and Certify page -->
-    <v-slide-x-reverse-transition hide-on-leave>
-      <div v-if="isSummaryMode && showFeeSummary">
-        <header>
-          <h1>Review and Certify</h1>
-        </header>
+      <!-- Review and Certify page -->
+      <v-slide-x-reverse-transition hide-on-leave>
+        <div v-if="isSummaryMode && showFeeSummary">
+          <header>
+            <h1>Review and Certify</h1>
+          </header>
 
-        <section class="mt-6">
-          <p id="intro-text">
-            Review and certify the changes you are about to make to your company. Certain changes require
-            an Alteration Notice which will incur a {{filingFeesPrice}} fee. Choosing an alteration date
-            and time in the future will incur an additional {{futureEffectiveFeesPrice}} fee.
-          </p>
-        </section>
+          <section class="mt-6">
+            <p id="intro-text">
+              Review and certify the changes you are about to make to your company. Certain changes require
+              an Alteration Notice which will incur a {{filingFeesPrice}} fee. Choosing an alteration date
+              and time in the future will incur an additional {{futureEffectiveFeesPrice}} fee.
+            </p>
+          </section>
 
-        <AlterationSummary
-          class="mt-10"
-          :validate="getAppValidate"
-          @haveChanges="onAlterationSummaryChanges()"
-        />
-
-        <DocumentsDelivery
-          class="mt-10"
-          sectionNumber="1."
-          :validate="getAppValidate"
-          @valid="setDocumentOptionalEmailValidity($event)"
-        />
-
-        <TransactionalFolioNumber
-          v-if="showTransactionalFolioNumber"
-          class="mt-10"
-          sectionNumber="2."
-          :validate="getAppValidate"
-        />
-
-        <CertifySection
-          class="mt-10"
-          :sectionNumber="showTransactionalFolioNumber ? '3.' : '2.'"
-          :validate="getAppValidate"
-          :disableEdit="!isRoleStaff"
-        />
-
-        <!-- STAFF ONLY: Court Order/Plan of Arrangement and Staff Payment -->
-        <template v-if="isRoleStaff">
-          <CourtOrderPoa
+          <AlterationSummary
             class="mt-10"
-            :sectionNumber="showTransactionalFolioNumber ? '4.' : '3.'"
-            :autoValidation="getAppValidate"
+            :validate="getAppValidate"
+            @haveChanges="onAlterationSummaryChanges()"
           />
 
-          <StaffPayment
+          <DocumentsDelivery
             class="mt-10"
-            :sectionNumber="showTransactionalFolioNumber ? '5.' : '4.'"
-            @haveChanges="onStaffPaymentChanges()"
+            sectionNumber="1."
+            :validate="getAppValidate"
+            @valid="setDocumentOptionalEmailValidity($event)"
           />
-        </template>
-      </div>
-    </v-slide-x-reverse-transition>
 
-    <!-- Done-->
-    <v-fade-transition>
-      <div v-if="isSummaryMode && !showFeeSummary">
-        <header>
-          <h1>Review and Certify</h1>
-        </header>
+          <TransactionalFolioNumber
+            v-if="showTransactionalFolioNumber"
+            class="mt-10"
+            sectionNumber="2."
+            :validate="getAppValidate"
+          />
 
-        <section class="mt-6">
-          You have deleted all fee-based changes and your company information has reverted to its
-          original state. If you made any non-fee changes such as updates to your Registered
-          Office Contact Information, please note that these changes have already been saved.
-        </section>
+          <CertifySection
+            class="mt-10"
+            :sectionNumber="showTransactionalFolioNumber ? '3.' : '2.'"
+            :validate="getAppValidate"
+            :disableEdit="!isRoleStaff"
+          />
 
-        <v-btn
-          large
-          color="primary"
-          id="done-button"
-          class="mt-8"
-          @click="$root.$emit('go-to-dashboard')"
-        >
-          <span>Done</span>
-        </v-btn>
-      </div>
-    </v-fade-transition>
-  </section>
+          <!-- STAFF ONLY: Court Order/Plan of Arrangement and Staff Payment -->
+          <template v-if="isRoleStaff">
+            <CourtOrderPoa
+              class="mt-10"
+              :sectionNumber="showTransactionalFolioNumber ? '4.' : '3.'"
+              :autoValidation="getAppValidate"
+            />
+
+            <StaffPayment
+              class="mt-10"
+              :sectionNumber="showTransactionalFolioNumber ? '5.' : '4.'"
+              @haveChanges="onStaffPaymentChanges()"
+            />
+          </template>
+        </div>
+      </v-slide-x-reverse-transition>
+
+      <!-- Done-->
+      <v-fade-transition>
+        <div v-if="isSummaryMode && !showFeeSummary">
+          <header>
+            <h1>Review and Certify</h1>
+          </header>
+
+          <section class="mt-6">
+            You have deleted all fee-based changes and your company information has reverted to its
+            original state. If you made any non-fee changes such as updates to your Registered
+            Office Contact Information, please note that these changes have already been saved.
+          </section>
+
+          <v-btn
+            large
+            color="primary"
+            id="done-button"
+            class="mt-8"
+            @click="$root.$emit('go-to-dashboard')"
+          >
+            <span>Done</span>
+          </v-btn>
+        </div>
+      </v-fade-transition>
+    </section>
+  </ViewWrapper>
 </template>
 
 <script lang="ts">
@@ -123,9 +125,11 @@ import { FilingStatus } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { BcAlterationResource, BenAlterationResource, CccAlterationResource, UlcAlterationResource }
   from '@/resources/Alteration/'
+import ViewWrapper from '@/components/ViewWrapper.vue'
 
 @Component({
   components: {
+    ViewWrapper,
     AlterationSummary,
     Articles,
     CertifySection,

--- a/src/views/Change.vue
+++ b/src/views/Change.vue
@@ -1,86 +1,88 @@
 <template>
-  <section class="pb-10" id="change-view">
-    <!-- Business Information page-->
-    <v-slide-x-transition hide-on-leave>
-      <div v-if="!isSummaryMode || !showFeeSummary">
-        <header>
-          <h1>Business Information</h1>
-        </header>
+  <ViewWrapper>
+    <section class="pb-10" id="change-view">
+      <!-- Business Information page-->
+      <v-slide-x-transition hide-on-leave>
+        <div v-if="!isSummaryMode || !showFeeSummary">
+          <header>
+            <h1>Business Information</h1>
+          </header>
 
-        <section class="mt-6">
-          You must promptly file updates to your business information. Necessary fees will be applied as
-          updates are made.
-        </section>
+          <section class="mt-6">
+            You must promptly file updates to your business information. Necessary fees will be applied as
+            updates are made.
+          </section>
 
-        <YourCompany class="mt-10" />
+          <YourCompany class="mt-10" />
 
-        <PeopleAndRoles class="mt-10" />
-      </div>
-    </v-slide-x-transition>
+          <PeopleAndRoles class="mt-10" />
+        </div>
+      </v-slide-x-transition>
 
-    <!-- Review and Confirmm page -->
-    <v-slide-x-reverse-transition hide-on-leave>
-      <div v-if="isSummaryMode && showFeeSummary">
-        <header>
-          <h1>Review and Confirm</h1>
-        </header>
+      <!-- Review and Confirmm page -->
+      <v-slide-x-reverse-transition hide-on-leave>
+        <div v-if="isSummaryMode && showFeeSummary">
+          <header>
+            <h1>Review and Confirm</h1>
+          </header>
 
-        <section class="mt-6">
-          <p id="intro-text">
-            Changes were made to your business information that require a filing. Review and certify the
-            changes you are about the make to your business.
-          </p>
-        </section>
+          <section class="mt-6">
+            <p id="intro-text">
+              Changes were made to your business information that require a filing. Review and certify the
+              changes you are about the make to your business.
+            </p>
+          </section>
 
-        <ChangeSummary
-          class="mt-10"
-          :validate="getAppValidate"
-        />
-
-        <DocumentsDelivery
-          class="mt-10"
-          sectionNumber="1."
-          :validate="getAppValidate"
-          @valid="setDocumentOptionalEmailValidity($event)"
-        />
-
-        <CompletingParty
-          class="mt-10"
-          sectionNumber="2."
-          :validate="getAppValidate"
-        />
-
-        <TransactionalFolioNumber
-          v-if="showTransactionalFolioNumber"
-          class="mt-10"
-          sectionNumber="2."
-          :validate="getAppValidate"
-        />
-
-        <CertifySection
-          class="mt-10"
-          :sectionNumber="showTransactionalFolioNumber ? '3.' : '2.'"
-          :validate="getAppValidate"
-          :disableEdit="!(isRoleStaff || isSbcStaff)"
-        />
-
-        <!-- STAFF ONLY: Court Order/Plan of Arrangement and Staff Payment -->
-        <template v-if="isRoleStaff">
-          <CourtOrderPoa
+          <ChangeSummary
             class="mt-10"
-            :sectionNumber="showTransactionalFolioNumber ? '5.' : '4.'"
-            :autoValidation="getAppValidate"
+            :validate="getAppValidate"
           />
 
-          <StaffPayment
+          <DocumentsDelivery
             class="mt-10"
-            :sectionNumber="showTransactionalFolioNumber ? '6.' : '5.'"
-            @haveChanges="onStaffPaymentChanges()"
+            sectionNumber="1."
+            :validate="getAppValidate"
+            @valid="setDocumentOptionalEmailValidity($event)"
           />
-        </template>
-      </div>
-    </v-slide-x-reverse-transition>
-  </section>
+
+          <CompletingParty
+            class="mt-10"
+            sectionNumber="2."
+            :validate="getAppValidate"
+          />
+
+          <TransactionalFolioNumber
+            v-if="showTransactionalFolioNumber"
+            class="mt-10"
+            sectionNumber="2."
+            :validate="getAppValidate"
+          />
+
+          <CertifySection
+            class="mt-10"
+            :sectionNumber="showTransactionalFolioNumber ? '3.' : '2.'"
+            :validate="getAppValidate"
+            :disableEdit="!(isRoleStaff || isSbcStaff)"
+          />
+
+          <!-- STAFF ONLY: Court Order/Plan of Arrangement and Staff Payment -->
+          <template v-if="isRoleStaff">
+            <CourtOrderPoa
+              class="mt-10"
+              :sectionNumber="showTransactionalFolioNumber ? '5.' : '4.'"
+              :autoValidation="getAppValidate"
+            />
+
+            <StaffPayment
+              class="mt-10"
+              :sectionNumber="showTransactionalFolioNumber ? '6.' : '5.'"
+              @haveChanges="onStaffPaymentChanges()"
+            />
+          </template>
+        </div>
+      </v-slide-x-reverse-transition>
+    </section>
+  </ViewWrapper>
 </template>
 
 <script lang="ts">
@@ -96,9 +98,11 @@ import { ActionBindingIF, EntitySnapshotIF, ResourceIF } from '@/interfaces/'
 import { FilingStatus, PartyTypes } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { SpChangeResource, GpChangeResource, SpOrganizationChangeResource } from '@/resources/Change/'
+import ViewWrapper from '@/components/ViewWrapper.vue'
 
 @Component({
   components: {
+    ViewWrapper,
     CertifySection,
     ChangeSummary,
     CompletingParty,

--- a/src/views/Conversion.vue
+++ b/src/views/Conversion.vue
@@ -1,50 +1,52 @@
 <template>
-  <section class="pb-10" id="conversion-view">
-    <!-- Business Information page-->
-    <v-slide-x-transition hide-on-leave>
-      <div v-if="!isSummaryMode || !showFeeSummary">
-        <header>
-          <h1>Record Conversion</h1>
-        </header>
+  <ViewWrapper>
+    <section class="pb-10" id="conversion-view">
+      <!-- Business Information page-->
+      <v-slide-x-transition hide-on-leave>
+        <div v-if="!isSummaryMode || !showFeeSummary">
+          <header>
+            <h1>Record Conversion</h1>
+          </header>
 
-        <section class="mt-6">
-          You must promptly file updates to your business information. Necessary fees will be applied as updates are
-          made.
-        </section>
+          <section class="mt-6">
+            You must promptly file updates to your business information. Necessary fees will be applied as updates are
+            made.
+          </section>
 
-        <YourCompany class="mt-10" />
+          <YourCompany class="mt-10" />
 
-        <PeopleAndRoles class="mt-10" />
-      </div>
-    </v-slide-x-transition>
+          <PeopleAndRoles class="mt-10" />
+        </div>
+      </v-slide-x-transition>
 
-    <!-- Review and Confirmm page -->
-    <v-slide-x-reverse-transition hide-on-leave>
-      <div v-if="isSummaryMode && showFeeSummary">
-        <header>
-          <h1>Review and Confirm</h1>
-        </header>
+      <!-- Review and Confirmm page -->
+      <v-slide-x-reverse-transition hide-on-leave>
+        <div v-if="isSummaryMode && showFeeSummary">
+          <header>
+            <h1>Review and Confirm</h1>
+          </header>
 
-        <section class="mt-6">
-          <p id="intro-text">
-            Changes were made to your business information that require a filing. Review and certify the changes you
-            are about the make to your business.
-          </p>
-        </section>
+          <section class="mt-6">
+            <p id="intro-text">
+              Changes were made to your business information that require a filing. Review and certify the changes you
+              are about the make to your business.
+            </p>
+          </section>
 
-        <ConversionSummary
-          class="mt-10"
-          :validate="getAppValidate"
-        />
+          <ConversionSummary
+            class="mt-10"
+            :validate="getAppValidate"
+          />
 
-        <CompletingParty
-          class="mt-10"
-          sectionNumber="1."
-          :validate="getAppValidate"
-        />
-      </div>
-    </v-slide-x-reverse-transition>
-  </section>
+          <CompletingParty
+            class="mt-10"
+            sectionNumber="1."
+            :validate="getAppValidate"
+          />
+        </div>
+      </v-slide-x-reverse-transition>
+    </section>
+  </ViewWrapper>
 </template>
 
 <script lang="ts">
@@ -60,9 +62,11 @@ import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { SpConversionResource, GpConversionResource } from '@/resources/Conversion/'
 import { ConversionSummary } from '@/components/Conversion'
 import { StatusCodes } from 'http-status-codes'
+import ViewWrapper from '@/components/ViewWrapper.vue'
 
 @Component({
   components: {
+    ViewWrapper,
     ConversionSummary,
     CompletingParty,
     PeopleAndRoles,

--- a/src/views/Correction.vue
+++ b/src/views/Correction.vue
@@ -1,10 +1,13 @@
 <template>
-  <component
-    :is="component"
-    :correctionFiling="correctionFiling"
-    @fetchError="emitFetchError($event)"
-    @haveData="emitHaveData($event)"
-  />
+  <ViewWrapper>
+    <component
+      :is="component"
+      :correctionFiling="correctionFiling"
+      @fetchError="emitFetchError($event)"
+      @haveData="emitHaveData($event)"
+    />
+  </ViewWrapper>
+
 </template>
 
 <script lang="ts">
@@ -18,9 +21,11 @@ import { FilingStatus, FilingTypes } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import CorpCorrection from '@/views/Correction/CorpCorrection.vue'
 import FirmCorrection from '@/views/Correction/FirmCorrection.vue'
+import ViewWrapper from '@/components/ViewWrapper.vue'
 
 @Component({
   components: {
+    ViewWrapper,
     CorpCorrection,
     FirmCorrection
   }

--- a/src/views/Restoration.vue
+++ b/src/views/Restoration.vue
@@ -1,95 +1,97 @@
 <template>
-  <section class="pb-10" id="restoration-view">
-    <!-- Company Information page-->
-    <v-slide-x-transition hide-on-leave>
-      <div v-if="!isSummaryMode">
-        <header>
-          <h1>{{ entityTitle }}</h1>
-        </header>
+  <ViewWrapper>
+    <section class="pb-10" id="restoration-view">
+      <!-- Company Information page-->
+      <v-slide-x-transition hide-on-leave>
+        <div v-if="!isSummaryMode">
+          <header>
+            <h1>{{ entityTitle }}</h1>
+          </header>
 
-        <PeopleAndRoles class="mt-10" />
+          <PeopleAndRoles class="mt-10" />
 
-        <YourCompany class="mt-10" />
-      </div>
-    </v-slide-x-transition>
+          <YourCompany class="mt-10" />
+        </div>
+      </v-slide-x-transition>
 
-    <!-- Review and Certify page -->
-    <v-slide-x-reverse-transition hide-on-leave>
-      <div v-if="isSummaryMode && showFeeSummary">
-        <header>
-          <h1>Review and Certify</h1>
-        </header>
+      <!-- Review and Certify page -->
+      <v-slide-x-reverse-transition hide-on-leave>
+        <div v-if="isSummaryMode && showFeeSummary">
+          <header>
+            <h1>Review and Certify</h1>
+          </header>
 
-        <RestorationSummary
-          class="mt-10"
-          :validate="getAppValidate"
-        />
+          <RestorationSummary
+            class="mt-10"
+            :validate="getAppValidate"
+          />
 
-        <YourCompanySummary class="mt-10" />
+          <YourCompanySummary class="mt-10" />
 
-        <!-- Applicant list -->
-        <v-card id="people-and-roles-vcard" flat class="mt-6">
-          <!-- Header -->
-          <div class="section-container header-container">
-            <v-icon color="appDkBlue">mdi-account-multiple-plus</v-icon>
-            <label class="font-weight-bold pl-2">{{ orgPersonLabel }} Information</label>
-          </div>
-          <div no-gutters class="mt-4 section-container">
+          <!-- Applicant list -->
+          <v-card id="people-and-roles-vcard" flat class="mt-6">
+            <!-- Header -->
+            <div class="section-container header-container">
+              <v-icon color="appDkBlue">mdi-account-multiple-plus</v-icon>
+              <label class="font-weight-bold pl-2">{{ orgPersonLabel }} Information</label>
+            </div>
+            <div no-gutters class="mt-4 section-container">
               <ListPeopleAndRoles
                 :isSummaryView="true"
                 :showDeliveryAddressColumn="false"
                 :showRolesColumn="false"
                 :showEmailColumn="true"
               />
-          </div>
-        </v-card>
+            </div>
+          </v-card>
 
-        <DocumentsDelivery
-          class="mt-10"
-          sectionNumber="1."
-          :validate="getAppValidate"
-          @valid="setDocumentOptionalEmailValidity($event)"
-        />
+          <DocumentsDelivery
+            class="mt-10"
+            sectionNumber="1."
+            :validate="getAppValidate"
+            @valid="setDocumentOptionalEmailValidity($event)"
+          />
 
-        <CertifySection
-          class="mt-10"
-          sectionNumber="2."
-          :validate="getAppValidate"
-        />
+          <CertifySection
+            class="mt-10"
+            sectionNumber="2."
+            :validate="getAppValidate"
+          />
 
-        <StaffPayment
-          class="mt-10"
-          sectionNumber="3."
-          @haveChanges="onStaffPaymentChanges()"
-        />
-      </div>
-    </v-slide-x-reverse-transition>
+          <StaffPayment
+            class="mt-10"
+            sectionNumber="3."
+            @haveChanges="onStaffPaymentChanges()"
+          />
+        </div>
+      </v-slide-x-reverse-transition>
 
-    <!-- Done-->
-    <v-fade-transition>
-      <div v-if="isSummaryMode && !showFeeSummary">
-        <header>
-          <h1>Review and Certify</h1>
-        </header>
+      <!-- Done-->
+      <v-fade-transition>
+        <div v-if="isSummaryMode && !showFeeSummary">
+          <header>
+            <h1>Review and Certify</h1>
+          </header>
 
-        <section class="mt-6">
-          You have deleted all fee-based changes and your company information has reverted to its
-          original state. If you made any non-fee changes such as updates to your Registered
-          Office Contact Information, please note that these changes have already been saved.
-        </section>
+          <section class="mt-6">
+            You have deleted all fee-based changes and your company information has reverted to its
+            original state. If you made any non-fee changes such as updates to your Registered
+            Office Contact Information, please note that these changes have already been saved.
+          </section>
 
-        <v-btn
-          large
-          color="primary"
-          id="done-button"
-          class="mt-8"
-          @click="$root.$emit('go-to-dashboard')"
-        >
-          <span>Done</span>
-        </v-btn>
-      </div>
-    </v-fade-transition>
-  </section>
+          <v-btn
+            large
+            color="primary"
+            id="done-button"
+            class="mt-8"
+            @click="$root.$emit('go-to-dashboard')"
+          >
+            <span>Done</span>
+          </v-btn>
+        </div>
+      </v-fade-transition>
+    </section>
+  </ViewWrapper>
 </template>
 
 <script lang="ts">
@@ -112,9 +114,11 @@ import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { BcRestorationResource, BenRestorationResource, CccRestorationResource, UlcRestorationResource }
   from '@/resources/Restoration/'
 import { FilingDataIF } from '@bcrs-shared-components/interfaces'
+import ViewWrapper from '@/components/ViewWrapper.vue'
 
 @Component({
   components: {
+    ViewWrapper,
     CertifySection,
     DocumentsDelivery,
     PeopleAndRoles,

--- a/src/views/SpecialResolution.vue
+++ b/src/views/SpecialResolution.vue
@@ -1,108 +1,110 @@
 <template>
-  <section class="pb-10" id="special-resolution-view">
-    <!-- Company Information page-->
-    <v-slide-x-transition hide-on-leave>
-      <div v-if="!isSummaryMode">
-        <header>
-          <h1>Business Information</h1>
-        </header>
+  <ViewWrapper>
+    <section class="pb-10" id="special-resolution-view">
+      <!-- Company Information page-->
+      <v-slide-x-transition hide-on-leave>
+        <div v-if="!isSummaryMode">
+          <header>
+            <h1>Business Information</h1>
+          </header>
 
-        <section class="mt-6">
-          You must keep your business information up to date. Some changes require a Special Resolution.
-          Necessary fees will be applied as updates are made.
-        </section>
+          <section class="mt-6">
+            You must keep your business information up to date. Some changes require a Special Resolution.
+            Necessary fees will be applied as updates are made.
+          </section>
 
-        <YourCompany class="mt-10" />
+          <YourCompany class="mt-10" />
 
-        <CurrentDirectors class="mt-10" />
+          <CurrentDirectors class="mt-10" />
 
-        <CreateSpecialResolution class="mt-10" v-if="showCreateSpecialResolution" />
-      </div>
-    </v-slide-x-transition>
+          <CreateSpecialResolution class="mt-10" v-if="showCreateSpecialResolution" />
+        </div>
+      </v-slide-x-transition>
 
-    <!-- Review and Certify page -->
-    <v-slide-x-reverse-transition hide-on-leave>
-      <div v-if="isSummaryMode && showFeeSummary">
-        <header>
-          <h1>Review and Certify</h1>
-        </header>
+      <!-- Review and Certify page -->
+      <v-slide-x-reverse-transition hide-on-leave>
+        <div v-if="isSummaryMode && showFeeSummary">
+          <header>
+            <h1>Review and Certify</h1>
+          </header>
 
-        <section class="mt-6">
-          <p id="intro-text">
-            Changes were made to your business information that require a filing.
-            Review and certify the changes you are about to make to your business.
-          </p>
-        </section>
+          <section class="mt-6">
+            <p id="intro-text">
+              Changes were made to your business information that require a filing.
+              Review and certify the changes you are about to make to your business.
+            </p>
+          </section>
 
-        <SpecialResolutionSummary
-          class="mt-10"
-          :validate="getAppValidate"
-          @haveChanges="onSpecialResolutionSummaryChanges($event)"
-        />
-
-        <DocumentsDelivery
-          class="mt-10"
-          sectionNumber="1."
-          :validate="getAppValidate"
-          @valid="setDocumentOptionalEmailValidity($event)"
-        />
-
-        <TransactionalFolioNumber
-          v-if="showTransactionalFolioNumber"
-          class="mt-10"
-          sectionNumber="2."
-          :validate="getAppValidate"
-        />
-
-        <CompletingParty
-          class="mt-10"
-          :sectionNumber="showTransactionalFolioNumber ? '3.' : '2.'"
-          :validate="getAppValidate"
-        />
-
-        <CertifySection
-          class="mt-10"
-          :sectionNumber="showTransactionalFolioNumber ? '4.' : '3.'"
-          :validate="getAppValidate"
-          :disableEdit="!isRoleStaff"
-        />
-
-        <template v-if="isRoleStaff">
-          <StaffPayment
+          <SpecialResolutionSummary
             class="mt-10"
-            sectionNumber="4."
-            @haveChanges="onStaffPaymentChanges()"
+            :validate="getAppValidate"
+            @haveChanges="onSpecialResolutionSummaryChanges($event)"
           />
-        </template>
 
-      </div>
-    </v-slide-x-reverse-transition>
+          <DocumentsDelivery
+            class="mt-10"
+            sectionNumber="1."
+            :validate="getAppValidate"
+            @valid="setDocumentOptionalEmailValidity($event)"
+          />
 
-    <!-- Done-->
-    <v-fade-transition>
-      <div v-if="isSummaryMode && !showFeeSummary">
-        <header>
-          <h1>Review and Certify</h1>
-        </header>
+          <TransactionalFolioNumber
+            v-if="showTransactionalFolioNumber"
+            class="mt-10"
+            sectionNumber="2."
+            :validate="getAppValidate"
+          />
 
-        <section class="mt-6">
-          You have deleted all fee-based changes and your company information has reverted to its
-          original state. If you made any non-fee changes such as updates to your Registered
-          Office Contact Information, please note that these changes have already been saved.
-        </section>
+          <CompletingParty
+            class="mt-10"
+            :sectionNumber="showTransactionalFolioNumber ? '3.' : '2.'"
+            :validate="getAppValidate"
+          />
 
-        <v-btn
-          large
-          color="primary"
-          id="done-button"
-          class="mt-8"
-          @click="$root.$emit('go-to-dashboard')"
-        >
-          <span>Done</span>
-        </v-btn>
-      </div>
-    </v-fade-transition>
-  </section>
+          <CertifySection
+            class="mt-10"
+            :sectionNumber="showTransactionalFolioNumber ? '4.' : '3.'"
+            :validate="getAppValidate"
+            :disableEdit="!isRoleStaff"
+          />
+
+          <template v-if="isRoleStaff">
+            <StaffPayment
+              class="mt-10"
+              sectionNumber="4."
+              @haveChanges="onStaffPaymentChanges()"
+            />
+          </template>
+
+        </div>
+      </v-slide-x-reverse-transition>
+
+      <!-- Done-->
+      <v-fade-transition>
+        <div v-if="isSummaryMode && !showFeeSummary">
+          <header>
+            <h1>Review and Certify</h1>
+          </header>
+
+          <section class="mt-6">
+            You have deleted all fee-based changes and your company information has reverted to its
+            original state. If you made any non-fee changes such as updates to your Registered
+            Office Contact Information, please note that these changes have already been saved.
+          </section>
+
+          <v-btn
+            large
+            color="primary"
+            id="done-button"
+            class="mt-8"
+            @click="$root.$emit('go-to-dashboard')"
+          >
+            <span>Done</span>
+          </v-btn>
+        </div>
+      </v-fade-transition>
+    </section>
+  </ViewWrapper>
 </template>
 
 <script lang="ts">
@@ -119,9 +121,11 @@ import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
 import { FilingCodes, FilingStatus } from '@/enums/'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { CpSpecialResolutionResource } from '@/resources/SpecialResolution/'
+import ViewWrapper from '@/components/ViewWrapper.vue'
 
 @Component({
   components: {
+    ViewWrapper,
     SpecialResolutionSummary,
     CertifySection,
     CurrentDirectors,

--- a/tests/unit/Alteration.spec.ts
+++ b/tests/unit/Alteration.spec.ts
@@ -8,6 +8,7 @@ import { shallowMount, createLocalVue } from '@vue/test-utils'
 import { AxiosInstance as axios } from '@/utils/'
 import Alteration from '@/views/Alteration.vue'
 import mockRouter from './MockRouter'
+import ViewWrapper from '@/components/ViewWrapper.vue'
 
 Vue.use(Vuetify)
 
@@ -280,6 +281,7 @@ describe('Alteration component', () => {
 
   it('renders Alteration view', () => {
     expect(wrapper.findComponent(Alteration).exists()).toBe(true)
+    expect(wrapper.findComponent(ViewWrapper).exists()).toBe(true)
   })
 
   it('loads the entity snapshot into the store', async () => {

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -651,20 +651,4 @@ describe('App component - other', () => {
     expect(vm.fileAndPayInvalidNameRequestDialog).toBe(false)
     expect(vm.confirmDeleteAllDialog).toBe(false)
   })
-
-  it('renders the fee summary properly following changes', async () => {
-    store.state.stateModel.tombstone.entityType = 'SP'
-    store.state.stateModel.tombstone.filingType = 'changeOfRegistration'
-    store.state.stateModel.entitySnapshot = mockEntitySnapshot
-    store.state.stateModel.officeAddresses = mockAddresses
-    store.state.stateModel.filingData = {
-      filingTypeCode: 'FMCHANGE',
-      entityType: 'SP',
-      priority: false,
-      waiveFees: false
-    }
-    await Vue.nextTick()
-
-    expect(wrapper.findComponent(FeeSummaryShared).exists()).toBe(true) // not displayed initially
-  })
 })

--- a/tests/unit/Conversion.spec.ts
+++ b/tests/unit/Conversion.spec.ts
@@ -4,10 +4,12 @@ import VueRouter from 'vue-router'
 import flushPromises from 'flush-promises'
 import sinon from 'sinon'
 import { getVuexStore } from '@/store/'
-import { shallowMount, createLocalVue } from '@vue/test-utils'
+import { shallowMount, createLocalVue, mount } from '@vue/test-utils'
 import { AxiosInstance as axios } from '@/utils/'
 import Conversion from '@/views/Conversion.vue'
+import ViewWrapper from '@/components/ViewWrapper.vue'
 import mockRouter from './MockRouter'
+import { FeeSummary as FeeSummaryShared } from '@bcrs-shared-components/fee-summary'
 
 Vue.use(Vuetify)
 
@@ -230,7 +232,7 @@ describe('Conversion component', () => {
     localVue.use(VueRouter)
     const router = mockRouter.mock()
     await router.push({ name: 'conversion' })
-    wrapper = shallowMount(Conversion, { localVue, store, router, vuetify })
+    wrapper = mount(Conversion, { localVue, store, router, vuetify })
 
     // wait for all queries to complete
     await flushPromises()
@@ -244,6 +246,7 @@ describe('Conversion component', () => {
 
   it('renders Conversion view', () => {
     expect(wrapper.findComponent(Conversion).exists()).toBe(true)
+    expect(wrapper.findComponent(ViewWrapper).exists()).toBe(true)
   })
 
   // FUTURE

--- a/tests/unit/Conversion.spec.ts
+++ b/tests/unit/Conversion.spec.ts
@@ -4,12 +4,11 @@ import VueRouter from 'vue-router'
 import flushPromises from 'flush-promises'
 import sinon from 'sinon'
 import { getVuexStore } from '@/store/'
-import { shallowMount, createLocalVue, mount } from '@vue/test-utils'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
 import { AxiosInstance as axios } from '@/utils/'
 import Conversion from '@/views/Conversion.vue'
 import ViewWrapper from '@/components/ViewWrapper.vue'
 import mockRouter from './MockRouter'
-import { FeeSummary as FeeSummaryShared } from '@bcrs-shared-components/fee-summary'
 
 Vue.use(Vuetify)
 
@@ -232,7 +231,7 @@ describe('Conversion component', () => {
     localVue.use(VueRouter)
     const router = mockRouter.mock()
     await router.push({ name: 'conversion' })
-    wrapper = mount(Conversion, { localVue, store, router, vuetify })
+    wrapper = shallowMount(Conversion, { localVue, store, router, vuetify })
 
     // wait for all queries to complete
     await flushPromises()

--- a/tests/unit/SpecialResolution.spec.ts
+++ b/tests/unit/SpecialResolution.spec.ts
@@ -8,6 +8,7 @@ import { shallowMount, createLocalVue } from '@vue/test-utils'
 import { AxiosInstance as axios } from '@/utils/'
 import SpecialResolution from '@/views/SpecialResolution.vue'
 import mockRouter from './MockRouter'
+import ViewWrapper from '@/components/ViewWrapper.vue'
 
 Vue.use(Vuetify)
 
@@ -193,6 +194,7 @@ describe('Special Resolution component', () => {
 
   it('renders Special Resolution view', () => {
     expect(wrapper.findComponent(SpecialResolution).exists()).toBe(true)
+    expect(wrapper.findComponent(ViewWrapper).exists()).toBe(true)
   })
 
   it.only('loads the entity snapshot into the store', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15092

This is an incremental PR as the changes are potentially disruptive.  The PR removes the fee summaries from App.vue and moves them to a ViewWrapper component that's added to the following views:

- Alteration.vue
- Change.vue
- Conversion.vue
- Correction.vue
- Restoration.vue
- SpecialResolution.vue

By removing the fee summary components from App.vue it gives us more flexibility to handle the actions from FeeSummaryShared differently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
