### PR TITLE
15880 Fixed bug - saving expiry date in limited restoration conversions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -300,7 +300,6 @@ export default class FilingTemplateMixin extends DateMixin {
       },
       restoration: {
         approvalType: this.getStateFilingRestoration?.approvalType,
-        expiry: this.getRestoration.expiry,
         type: this.getRestoration.type,
         business: {
           identifier: this.getBusinessId,
@@ -311,6 +310,11 @@ export default class FilingTemplateMixin extends DateMixin {
         contactPoint: this.getContactPoint,
         relationships: this.getRestoration.relationships
       }
+    }
+
+    // Set expiry date property if it's not null
+    if (this.getRestoration.expiry) {
+      filing.restoration.expiry = this.getRestoration.expiry
     }
 
     // Apply NR / business name / business type change to filing
@@ -834,8 +838,6 @@ export default class FilingTemplateMixin extends DateMixin {
     } else if (filing.restoration.type === RestorationTypes.LTD_EXTEND) {
       // Reset radio button to 2 years
       this.mutateRestorationExpiry(DateUtilities.addMonthsToDate(24, this.getStateFilingRestoration?.expiry))
-    } else {
-      this.mutateRestorationExpiry(undefined)
     }
 
     // store Name Request data

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -12,7 +12,7 @@ import { CompletingPartyIF, ContactPointIF, NaicsIF, ShareClassIF, SpecialResolu
 import { ActionTypes, CoopTypes, CorrectionErrorTypes, EffectOfOrders, FilingTypes, PartyTypes,
   RoleTypes } from '@/enums/'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
-import { StaffPaymentOptions } from '@bcrs-shared-components/enums/'
+import { RestorationTypes, StaffPaymentOptions } from '@bcrs-shared-components/enums/'
 import { FilingTypeToName } from '@/utils'
 
 /**
@@ -831,9 +831,11 @@ export default class FilingTemplateMixin extends DateMixin {
     this.mutateRestorationType(filing.restoration.type)
     if (filing.restoration.expiry) {
       this.mutateRestorationExpiry(filing.restoration.expiry)
-    } else {
+    } else if (filing.restoration.type === RestorationTypes.LTD_EXTEND) {
       // Reset radio button to 2 years
       this.mutateRestorationExpiry(DateUtilities.addMonthsToDate(24, this.getStateFilingRestoration?.expiry))
+    } else {
+      this.mutateRestorationExpiry(undefined)
     }
 
     // store Name Request data


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15880

*Description of changes:*
- No longer saving expiry date when doing limited restoration conversion to full

![no longer saving expiry](https://user-images.githubusercontent.com/122301442/230218917-7032b6c6-1dae-4303-8508-6377a814bebf.PNG)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
