### PR TITLE
15882 fixes to dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -102,7 +102,7 @@ export default class FilingTemplateMixin extends DateMixin {
   @Action(useStore) mutateRestorationCourtOrder!: ActionBindingIF
   @Action(useStore) mutateRestorationExpiry!: ActionBindingIF
   @Action(useStore) mutateRestorationType!: ActionBindingIF
-  @Action(useStore) mutateRestorationRelationships!: ActionBindingIF
+  @Action(useStore) setRestorationRelationships!: ActionBindingIF
 
   /** The default (hard-coded first line) correction detail comment. */
   public get defaultCorrectionDetailComment (): string {
@@ -860,7 +860,7 @@ export default class FilingTemplateMixin extends DateMixin {
     ))
 
     if (filing.restoration.relationships) {
-      this.mutateRestorationRelationships(filing.restoration.relationships)
+      this.setRestorationRelationships(filing.restoration.relationships)
     }
 
     // store Name Translations

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -98,10 +98,6 @@ export default class FilingTemplateMixin extends DateMixin {
   @Action(useStore) setRestorationCourtOrder!: ActionBindingIF
   @Action(useStore) setRestorationExpiry!: ActionBindingIF
   @Action(useStore) setRestorationType!: ActionBindingIF
-  @Action(useStore) mutateRestorationApprovalType!: ActionBindingIF
-  @Action(useStore) mutateRestorationCourtOrder!: ActionBindingIF
-  @Action(useStore) mutateRestorationExpiry!: ActionBindingIF
-  @Action(useStore) mutateRestorationType!: ActionBindingIF
   @Action(useStore) setRestorationRelationships!: ActionBindingIF
 
   /** The default (hard-coded first line) correction detail comment. */
@@ -833,7 +829,7 @@ export default class FilingTemplateMixin extends DateMixin {
 
     // set restoration approval type
     if (filing.restoration.approvalType) {
-      this.mutateRestorationApprovalType(filing.restoration.approvalType)
+      this.setRestorationApprovalType(filing.restoration.approvalType)
     } else {
       this.setRestorationApprovalType(this.getStateFilingRestoration?.approvalType)
     }

--- a/src/views/LimitedRestorationToFull.vue
+++ b/src/views/LimitedRestorationToFull.vue
@@ -40,7 +40,7 @@
               :isCourtOrderOnly="isCourtOrderOnly"
               :isCourtOrderRadio="showCourtOrderRadio"
               :invalidSection="!getApprovalTypeValid"
-              @courtNumberChange="mutateRestorationCourtOrder({ 'fileNumber': $event })"
+              @courtNumberChange="setRestorationCourtOrder({ 'fileNumber': $event })"
               @valid="setValidComponent({ key: 'isValidApprovalType', value: $event })"
             />
           </QuestionWrapper>
@@ -182,6 +182,7 @@ export default class LimitedRestorationToFull extends Vue {
   @Getter(useStore) showFeeSummary!: boolean
   @Getter(useStore) getComponentValidate!: boolean
   @Getter(useStore) getCourtOrderNumberText!: string
+  @Getter(useStore) getApprovalTypeValid!: boolean
 
   // Global actions
   @Action(useStore) setDocumentOptionalEmailValidity!: ActionBindingIF
@@ -192,7 +193,7 @@ export default class LimitedRestorationToFull extends Vue {
   @Action(useStore) setRestorationRelationships!: ActionBindingIF
   @Action(useStore) setStateFilingRestoration!: ActionBindingIF
   @Action(useStore) setValidComponent!: ActionBindingIF
-  @Action(useStore) mutateRestorationCourtOrder!: ActionBindingIF
+  @Action(useStore) setRestorationCourtOrder!: ActionBindingIF
 
   /** Whether App is ready. */
   @Prop({ default: false }) readonly appReady!: boolean


### PR DESCRIPTION
*Issue #:* /bcgov/entity#15882

Add missing Pinia actions to resolve issues in DEV.  I didn't realize that Vuex mutations that started with "mutate.." had been renamed to "set..." during the upgrade to Pinia.  This PR removes the calls to "mutate..." and replaces them with calls to the equivalent "set..." instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
