### PR TITLE
validate NR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.3.3",
+      "version": "4.3.4",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/YourCompany/CompanyName/CorrectNameRequest.vue
+++ b/src/components/common/YourCompany/CompanyName/CorrectNameRequest.vue
@@ -166,8 +166,12 @@ export default class CorrectNameRequest extends Mixins(CommonMixin, NameRequestM
   }
 
   private isValidNrNumber (value: string): boolean {
-    const VALID_FORMAT = new RegExp(/^(NR )\d{7}$/)
-    return VALID_FORMAT.test(value)
+    const VALID_FORMAT = new RegExp(/^(NR)?\s*(\d{7})$/)
+    if (VALID_FORMAT.test(value)) {
+      this.nameRequestNumber = 'NR ' + value.match(VALID_FORMAT)[2]
+      return true
+    }
+    return false
   }
 
   private validateEmailFormat (value: string): boolean {

--- a/tests/unit/CorrectNameRequest.spec.ts
+++ b/tests/unit/CorrectNameRequest.spec.ts
@@ -142,7 +142,7 @@ describe('CorrectNameRequest', () => {
     expect(wrapper.vm.isFormValid).toBe(false)
   })
 
-  // the leading or tearing spaces of a NR are invalid
+  // the leading or trailing spaces of a NR are invalid
   it('verifies invalid NR', async () => {
     const wrapper = wrapperFactory()
 
@@ -158,7 +158,7 @@ describe('CorrectNameRequest', () => {
     expect(wrapper.vm.isFormValid).toBe(false)
   })
 
-  // the leading or tearing spaces are invalid
+  // the leading or trailing spaces are invalid
   it('verifies invalid NR', async () => {
     const wrapper = wrapperFactory()
 

--- a/tests/unit/CorrectNameRequest.spec.ts
+++ b/tests/unit/CorrectNameRequest.spec.ts
@@ -111,7 +111,7 @@ describe('CorrectNameRequest', () => {
     expect(wrapper.vm.nameRequestNumber).toEqual('NR 1234567')
   })
 
-  // the spaces between 'NR' and the numbers is ignored
+  // the spaces between 'NR' and the numbers are ignored
   it('verifies valid NR input', async () => {
     const wrapper = wrapperFactory()
 

--- a/tests/unit/CorrectNameRequest.spec.ts
+++ b/tests/unit/CorrectNameRequest.spec.ts
@@ -76,6 +76,39 @@ describe('CorrectNameRequest', () => {
     await flushPromises()
 
     expect(wrapper.vm.isFormValid).toBe(true)
+    expect(wrapper.vm.nameRequestNumber).toEqual('NR 1234567')
+  })
+
+  it('verifies inputs when valid', async () => {
+    const wrapper = wrapperFactory()
+
+    // Verify Invalid before input
+    expect(wrapper.vm.isFormValid).toBe(false)
+
+    wrapper.vm.nameRequestNumber = 'NR 1234567'
+    wrapper.vm.applicantPhone = '123 456 7890'
+    wrapper.vm.applicantEmail = 'mock@example.com'
+
+    await flushPromises()
+
+    expect(wrapper.vm.isFormValid).toBe(true)
+    expect(wrapper.vm.nameRequestNumber).toEqual('NR 1234567')
+  })
+
+  it('verifies inputs when valid', async () => {
+    const wrapper = wrapperFactory()
+
+    // Verify Invalid before input
+    expect(wrapper.vm.isFormValid).toBe(false)
+
+    wrapper.vm.nameRequestNumber = '1234567'
+    wrapper.vm.applicantPhone = '123 456 7890'
+    wrapper.vm.applicantEmail = 'mock@example.com'
+
+    await flushPromises()
+
+    expect(wrapper.vm.isFormValid).toBe(true)
+    expect(wrapper.vm.nameRequestNumber).toEqual('NR 1234567')
   })
 
   it('verifies invalid NR', async () => {

--- a/tests/unit/CorrectNameRequest.spec.ts
+++ b/tests/unit/CorrectNameRequest.spec.ts
@@ -111,6 +111,23 @@ describe('CorrectNameRequest', () => {
     expect(wrapper.vm.nameRequestNumber).toEqual('NR 1234567')
   })
 
+  // the spaces between 'NR' and the numbers is ignored
+  it('verifies valid NR input', async () => {
+    const wrapper = wrapperFactory()
+
+    // Verify Invalid before input
+    expect(wrapper.vm.isFormValid).toBe(false)
+
+    wrapper.vm.nameRequestNumber = 'NR   1234567'
+    wrapper.vm.applicantPhone = '123 456 7890'
+    wrapper.vm.applicantEmail = 'mock@example.com'
+
+    await flushPromises()
+
+    expect(wrapper.vm.isFormValid).toBe(true)
+    expect(wrapper.vm.nameRequestNumber).toEqual('NR 1234567')
+  })
+
   it('verifies invalid NR', async () => {
     const wrapper = wrapperFactory()
 
@@ -118,6 +135,38 @@ describe('CorrectNameRequest', () => {
     expect(wrapper.vm.isFormValid).toBe(false)
 
     wrapper.vm.nameRequestNumber = '123123NR'
+    wrapper.vm.applicantEmail = 'mock@example.com'
+
+    await flushPromises()
+
+    expect(wrapper.vm.isFormValid).toBe(false)
+  })
+
+  // the leading or tearing spaces of a NR are invalid
+  it('verifies invalid NR', async () => {
+    const wrapper = wrapperFactory()
+
+    // Verify Invalid before input
+    expect(wrapper.vm.isFormValid).toBe(false)
+
+    wrapper.vm.nameRequestNumber = '   NR 1234567'
+    wrapper.vm.applicantPhone = '123 456 7890'
+    wrapper.vm.applicantEmail = 'mock@example.com'
+
+    await flushPromises()
+
+    expect(wrapper.vm.isFormValid).toBe(false)
+  })
+
+  // the leading or tearing spaces are invalid
+  it('verifies invalid NR', async () => {
+    const wrapper = wrapperFactory()
+
+    // Verify Invalid before input
+    expect(wrapper.vm.isFormValid).toBe(false)
+
+    wrapper.vm.nameRequestNumber = 'NR 1234567    '
+    wrapper.vm.applicantPhone = '123 456 7890'
     wrapper.vm.applicantEmail = 'mock@example.com'
 
     await flushPromises()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14439

*Description of changes:*
Validate NR format. If the input NR number is valid, normalize the NR number and re-write the result to the input field
For example, input 1234567, it is a valid NR, the NR number input field shows 'NR 1234567'

The acceptable NR numbers are like:
NR 1234567
1234567
NR1234567
NR    1234567

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
