### PR TITLE
Fix dev tools - Update BreadCrumbResources.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/action-chip": "1.1.5",
@@ -24943,7 +24943,7 @@
         "@vue/cli-shared-utils": "^5.0.8",
         "babel-loader": "^8.2.2",
         "thread-loader": "^3.0.0",
-        "webpack": "^5.54.0"
+        "webpack": "5.78"
       }
     },
     "@vue/cli-plugin-eslint": {
@@ -24955,7 +24955,7 @@
         "@vue/cli-shared-utils": "^5.0.8",
         "eslint-webpack-plugin": "^3.1.0",
         "globby": "^11.0.2",
-        "webpack": "^5.54.0",
+        "webpack": "5.78",
         "yorkie": "^2.0.0"
       },
       "dependencies": {
@@ -25072,7 +25072,7 @@
         "globby": "^11.0.2",
         "thread-loader": "^3.0.0",
         "ts-loader": "^9.2.5",
-        "webpack": "^5.54.0"
+        "webpack": "5.78"
       },
       "dependencies": {
         "ansi-styles": {
@@ -25227,7 +25227,7 @@
         "thread-loader": "^3.0.0",
         "vue-loader": "^17.0.0",
         "vue-style-loader": "^4.1.3",
-        "webpack": "^5.54.0",
+        "webpack": "5.78",
         "webpack-bundle-analyzer": "^4.4.0",
         "webpack-chain": "^6.5.1",
         "webpack-dev-server": "^4.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/SpecialResolution/CreateSpecialResolution.vue
+++ b/src/components/SpecialResolution/CreateSpecialResolution.vue
@@ -62,7 +62,6 @@
           >
             <div class="d-flex flex-column flex-sm-row justify-center align-center">
               <img
-                slot-scope=""
                 src="@/assets/images/BCRegistries_CoopSpecialResolution-x2.png"
                 :alt="getSpecialResolutionResource.label"
                 class="preview-image"

--- a/src/resources/BreadCrumbResources.ts
+++ b/src/resources/BreadCrumbResources.ts
@@ -1,9 +1,5 @@
 import { BreadcrumbIF } from '@bcrs-shared-components/interfaces/'
-import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '@/store/store'
-
-setActivePinia(createPinia())
-const store = useStore()
 
 /** Returns URL param string with Account ID if present, else empty string. */
 function getParams (): string {
@@ -12,6 +8,7 @@ function getParams (): string {
 }
 
 export function getEntityDashboardBreadcrumb (): BreadcrumbIF {
+  const store = useStore()
   const getOriginalLegalName = store.getOriginalLegalName
   const getBusinessId = store.getBusinessId
   return {


### PR DESCRIPTION
Fix dev tools working intermittently - sometimes it would work when you first load the page, but not when you have the page already open and go into the Vue tools.

Fixes this error:

![image](https://user-images.githubusercontent.com/3484109/235058510-1e2acde7-471d-48bb-a257-00ff525b4e7f.png)

The Pinia store is being used before the Vue instance is initialized I believe

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
