### PR TITLE
16444 Use Keycloak roles for LaunchDarkly update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.4.1",
+      "version": "4.4.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -20,7 +20,8 @@ export const routes = [
     meta: {
       requiresAuth: true,
       isStaffOnly: false,
-      filingType: FilingTypes.ALTERATION
+      filingType: FilingTypes.ALTERATION,
+      title: 'Company Information page'
     }
   },
   {
@@ -30,7 +31,8 @@ export const routes = [
     meta: {
       requiresAuth: true,
       isStaffOnly: false,
-      filingType: FilingTypes.CHANGE_OF_REGISTRATION
+      filingType: FilingTypes.CHANGE_OF_REGISTRATION,
+      title: 'Business Information'
     }
   },
   {
@@ -40,7 +42,8 @@ export const routes = [
     meta: {
       requiresAuth: true,
       isStaffOnly: true,
-      filingType: FilingTypes.CONVERSION
+      filingType: FilingTypes.CONVERSION,
+      title: 'Record Conversion'
     }
   },
   {
@@ -50,7 +53,8 @@ export const routes = [
     meta: {
       requiresAuth: true,
       isStaffOnly: true,
-      filingType: FilingTypes.CORRECTION
+      filingType: FilingTypes.CORRECTION,
+      title: 'Register Correction'
     }
   },
   {
@@ -63,7 +67,8 @@ export const routes = [
     meta: {
       requiresAuth: true,
       isStaffOnly: true,
-      filingType: FilingTypes.RESTORATION
+      filingType: FilingTypes.RESTORATION,
+      title: 'Limited Restoration Extension'
     }
   },
   {
@@ -76,7 +81,8 @@ export const routes = [
     meta: {
       requiresAuth: true,
       isStaffOnly: true,
-      filingType: FilingTypes.RESTORATION
+      filingType: FilingTypes.RESTORATION,
+      title: 'Conversion to Full Restoration'
     }
   },
   {
@@ -86,7 +92,8 @@ export const routes = [
     meta: {
       requiresAuth: true,
       isStaffOnly: false,
-      filingType: FilingTypes.SPECIAL_RESOLUTION
+      filingType: FilingTypes.SPECIAL_RESOLUTION,
+      title: 'Special Resolution'
     }
   },
   {

--- a/src/services/auth-services.ts
+++ b/src/services/auth-services.ts
@@ -10,15 +10,18 @@ export default class AuthServices {
   /**
    * Fetches authorizations.
    * @param businessIdentifier the business identifier (eg, BC1219948)
-   * @returns a promise to return the authorizations object
+   * @returns a promise to return the roles object
    */
-  static async fetchAuthorizations (businessIdentifier: string): Promise<any> {
+  static async fetchAuthorizations (businessIdentifier: string): Promise<Array<string>> {
     if (!businessIdentifier) throw new Error('Invalid parameter \'businessIdentifier\'')
 
     const authApiUrl = sessionStorage.getItem('AUTH_API_URL')
     const url = `${authApiUrl}entities/${businessIdentifier}/authorizations`
 
-    return axios.get(url)
+    return axios.get(url).then(response => {
+      if (response?.data?.roles) return response.data.roles
+      throw new Error('Invalid response data ')
+    })
   }
 
   /**

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -58,7 +58,7 @@ export const useStore = defineStore('store', {
   // convert to a function
   state: (): StateIF => ({ resourceModel, stateModel }),
   getters: {
-    /** Whether the user has "staff" keycloak role. */
+    /** Whether the user has "staff" Keycloak role. */
     isRoleStaff (): boolean {
       return this.stateModel.tombstone.keycloakRoles.includes('staff')
     },
@@ -66,16 +66,6 @@ export const useStore = defineStore('store', {
     /** Whether the current account is SBC Staff. */
     isSbcStaff (): boolean {
       return this.stateModel.accountInformation?.accountType === AccountTypes.SBC_STAFF
-    },
-
-    /** Whether the user is authorized to edit. */
-    isAuthEdit (): boolean {
-      return this.stateModel.tombstone.authRoles.includes('edit')
-    },
-
-    /** Whether the user is authorized to view. */
-    isAuthView (): boolean {
-      return this.stateModel.tombstone.authRoles.includes('view')
     },
 
     /** Whether the current filing is a Correction. */
@@ -364,6 +354,11 @@ export const useStore = defineStore('store', {
       return this.stateModel.tombstone.userInfo
     },
 
+    /** The current user's keycloak roles. */
+    getKeycloakRoles (): Array<string> {
+      return this.stateModel.tombstone.keycloakRoles
+    },
+
     /** The org info. (May be null.) */
     getOrgInfo (): any {
       return this.stateModel.tombstone.orgInfo
@@ -391,11 +386,6 @@ export const useStore = defineStore('store', {
     /** The current user's last name. (May be undefined.) */
     getUserLastName (): string {
       return this.getUserInfo?.lastname
-    },
-
-    /** The current user's roles. (May be undefined.) */
-    getUserRoles (): any {
-      return this.getUserInfo?.roles
     },
 
     /** The current user's username. (May be undefined.) */
@@ -1253,9 +1243,6 @@ export const useStore = defineStore('store', {
     },
     setKeycloakRoles (keycloakRoles) {
       this.stateModel.tombstone.keycloakRoles = keycloakRoles
-    },
-    setAuthRoles (authRoles) {
-      this.stateModel.tombstone.authRoles = authRoles
     },
     setUserInfo (userInfo) {
       this.stateModel.tombstone.userInfo = userInfo

--- a/src/utils/GetKeycloakRoles.ts
+++ b/src/utils/GetKeycloakRoles.ts
@@ -1,33 +1,27 @@
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 
-/** Gets Keycloak JWT and parses it. */
-function getJWT (): any {
-  const token = sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)
-  if (token) {
-    return parseToken(token)
-  }
-  throw new Error('Error getting Keycloak token')
-}
-
-/** Decodes and parses Keycloak token. */
-function parseToken (token: string): any {
-  try {
-    const base64Url = token.split('.')[1]
-    const base64 = decodeURIComponent(window.atob(base64Url).split('').map(function (c) {
-      return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-    }).join(''))
-    return JSON.parse(base64)
-  } catch (err) {
-    throw new Error('Error parsing Keycloak token - ' + err)
-  }
-}
-
-/** Gets Keycloak roles from JWT. */
+/** Gets Keycloak roles and returns them. */
 export function GetKeycloakRoles (): Array<string> {
   const jwt = getJWT()
-  const keycloakRoles = jwt.roles
-  if (keycloakRoles && keycloakRoles.length > 0) {
-    return keycloakRoles
+  const keycloakRoles = (jwt.roles || []) as Array<string>
+  if (keycloakRoles.length < 1) throw new Error('Invalid Keycloak roles')
+  return keycloakRoles
+
+  /** Gets Keycloak JWT and parses it. */
+  function getJWT (): any {
+    // get KC token (JWT) from session storage
+    const keycloakToken = sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)
+    if (!keycloakToken) throw new Error('Error getting Keycloak token')
+
+    // decode and parse the JWT
+    try {
+      const base64Url = keycloakToken.split('.')[1]
+      const base64 = decodeURIComponent(window.atob(base64Url).split('').map(function (c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+      }).join(''))
+      return JSON.parse(base64)
+    } catch (error) {
+      throw new Error('Error parsing JWT - ' + error)
+    }
   }
-  throw new Error('Error getting Keycloak roles')
 }

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -476,9 +476,7 @@ describe.skip('App component', () => {
     wrapper.destroy()
   })
 
-  it('gets auth and user info properly', () => {
-    expect(store.isAuthEdit).toBe(true)
-    expect(store.isAuthView).toBe(true)
+  it('gets user info properly', () => {
     expect(store.stateModel.tombstone.userEmail).toBe('completing-party@example.com')
   })
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#16444

*Description of changes:*
- app version = 4.4.2
- moved entity titles from a computed to the routes array
- stop saving auth roles (not used)
- reduced current account retry duration to match other UIs
- used Keycloak roles in LaunchDarkly update
- added titles to routes array
- updated fetchAuthorizations to return roles array
- deleted unused getters and setter
- added getKeycloakRoles
- refactored GetKeycloakRoles (same as in Create UI)
- updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).