### PR TITLE
17435 Make resolution dates optional in a correction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.5.6",
+  "version": "4.5.6a",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.5.6",
+      "version": "4.5.6a",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.5.6",
+  "version": "4.5.6a",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Alteration/AlterationSummary.vue
+++ b/src/components/Alteration/AlterationSummary.vue
@@ -110,8 +110,8 @@
       <v-divider class="mx-4" />
       <div class="section-container new-resolution-dates-summary">
         <ResolutionDates
-          :added-dates="getNewResolutionDates"
-          :previous-dates="getOriginalResolutions"
+          :addedDates="getNewResolutionDates"
+          :originalResolutions="getOriginalResolutions"
           :isEditMode="false"
         />
       </div>

--- a/src/components/Alteration/Articles/Articles.vue
+++ b/src/components/Alteration/Articles/Articles.vue
@@ -76,14 +76,14 @@ export default class Articles extends Mixins(CommonMixin) {
   /** Emits Have Changes event. */
   @Emit('haveChanges')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected emitHaveChanges (haveChanges: boolean): void {}
+  emitHaveChanges (haveChanges: boolean): void {}
 
-  protected setEditingCompanyProvisions (editing: boolean) {
+  setEditingCompanyProvisions (editing: boolean) {
     this.isEditingCompanyProvisions = editing
     this.setValidComponent({ key: 'isValidCompanyProvisions', value: !editing })
   }
 
-  protected setIsAddingResolutionDate (addingResolutionDate: boolean) {
+  setIsAddingResolutionDate (addingResolutionDate: boolean) {
     this.isAddingResolutionDate = addingResolutionDate
   }
 

--- a/src/components/Alteration/Articles/Articles.vue
+++ b/src/components/Alteration/Articles/Articles.vue
@@ -29,7 +29,7 @@
     >
       <ResolutionDates
         :addedDates="getNewResolutionDates"
-        :previousDates="getOriginalResolutions"
+        :originalResolutions="getOriginalResolutions"
         :isEditMode="true"
         :hasRightsOrRestrictions="getHasRightsOrRestrictions"
         @addRemoveDate="setNewResolutionDates($event)"

--- a/src/components/Alteration/Articles/ResolutionDates.vue
+++ b/src/components/Alteration/Articles/ResolutionDates.vue
@@ -61,6 +61,7 @@
           <span>{{ addBtnLabel }}</span>
         </v-btn>
       </v-col>
+
       <v-col
         v-else-if="isAdding"
         cols="2"
@@ -175,7 +176,7 @@ import { Action, Getter } from 'pinia-class'
 import { CommonMixin, DateMixin } from '@/mixins/'
 import { DatePicker as DatePickerShared } from '@bcrs-shared-components/date-picker/'
 import { cloneDeep } from 'lodash'
-import { ActionKvIF } from '@/interfaces/'
+import { ActionKvIF, ResolutionsIF } from '@/interfaces/'
 import { useStore } from '@/store/store'
 
 @Component({
@@ -188,7 +189,7 @@ export default class ResolutionDates extends Mixins(CommonMixin, DateMixin) {
   @Prop({ default: () => [] }) readonly addedDates!: string[]
 
   /** Previously existing resolution dates. */
-  @Prop({ default: () => [] }) readonly previousDates!: string[]
+  @Prop({ default: () => [] }) readonly previousDates!: ResolutionsIF[]
 
   /** Whether this component should be in edit mode or review mode. */
   @Prop({ default: true }) readonly isEditMode!: boolean

--- a/src/components/Alteration/Articles/ResolutionDates.vue
+++ b/src/components/Alteration/Articles/ResolutionDates.vue
@@ -158,10 +158,10 @@
         <template v-if="displayPreviousDates">
           <ul class="resolution-date-list info-text pl-0 mt-3">
             <li
-              v-for="(resolutions, index) in previousDates"
+              v-for="(resolution, index) in originalResolutions"
               :key="`resolutionDate-${index}`"
             >
-              {{ resolutions.date }}
+              {{ resolution.date }}
             </li>
           </ul>
         </template>
@@ -188,8 +188,8 @@ export default class ResolutionDates extends Mixins(CommonMixin, DateMixin) {
   /** New resolution dates. */
   @Prop({ default: () => [] }) readonly addedDates!: string[]
 
-  /** Previously existing resolution dates. */
-  @Prop({ default: () => [] }) readonly previousDates!: ResolutionsIF[]
+  /** Previously existing resolutions (ie, dates). */
+  @Prop({ default: () => [] }) readonly originalResolutions!: ResolutionsIF[]
 
   /** Whether this component should be in edit mode or review mode. */
   @Prop({ default: true }) readonly isEditMode!: boolean
@@ -228,7 +228,7 @@ export default class ResolutionDates extends Mixins(CommonMixin, DateMixin) {
   }
 
   get havePreviousDates (): boolean {
-    return (this.previousDates?.length > 0)
+    return (this.originalResolutions?.length > 0)
   }
 
   get addBtnIcon (): string {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1114,6 +1114,7 @@ export const useStore = defineStore('store', {
     /** True if resolution dates are valid. */
     getIsResolutionDatesValid (): boolean {
       if (
+        this.isAlterationFiling &&
         this.hasShareStructureChanged &&
         (this.getHasOriginalRightsOrRestrictions || this.getHasRightsOrRestrictions)
       ) {

--- a/tests/unit/ResolutionDates.spec.ts
+++ b/tests/unit/ResolutionDates.spec.ts
@@ -16,7 +16,7 @@ const addedDates = [
   '2020-06-01'
 ]
 
-const previousDates = [
+const originalResolutions = [
   {
     'date': '2020-06-12'
   },
@@ -106,7 +106,7 @@ describe('Resolution Dates component - edit mode', () => {
   })
 
   it('displays previous dates', async () => {
-    const wrapper = wrapperFactory({ previousDates })
+    const wrapper = wrapperFactory({ originalResolutions })
     const vm = wrapper.vm
 
     // verify there is a second row
@@ -367,7 +367,7 @@ describe('Resolution Dates component - review mode', () => {
   })
 
   it('displays previous dates', async () => {
-    const wrapper = wrapperFactory({ previousDates })
+    const wrapper = wrapperFactory({ originalResolutions })
     const vm = wrapper.vm
 
     // verify there is a second row

--- a/tests/unit/ResolutionDates.spec.ts
+++ b/tests/unit/ResolutionDates.spec.ts
@@ -74,6 +74,7 @@ describe('Resolution Dates component - edit mode', () => {
   let wrapperFactory: any
 
   beforeAll(() => {
+    store.stateModel.tombstone.filingType = FilingTypes.ALTERATION
     store.stateModel.shareStructureStep.shareClasses = shareClasses as any
     wrapperFactory = (propsData: any) => {
       return mount(ResolutionDates, { propsData: { ...propsData, isEditMode: true }, vuetify })


### PR DESCRIPTION
*Issue #:* bcgov/entity#17435

*Description of changes:*
- app version = 4.5.6a
- removed some accessors
- fixed type of Previous Dates prop
- renamed `previousDates` -> `originalResolutions`
- made Resolution Dates Validity dependent on Alteration Filing
- fixed unit test suite

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).