### PR TITLE
17347 - Add in appointmentDate for co-op corrections.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.7.3",
+      "version": "4.7.4",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -494,6 +494,7 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
   @Getter(useStore) getResource!: ResourceIF
   @Getter(useStore) isAlterationFiling!: boolean
   @Getter(useStore) isBenBcCccUlcCorrectionFiling!: boolean
+  @Getter(useStore) isCoopCorrectionFiling!: boolean
   @Getter(useStore) isFirmCorrectionFiling!: boolean
   @Getter(useStore) isFirm!: boolean
   @Getter(useStore) isFirmChangeFiling!: boolean
@@ -851,7 +852,9 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
       }
       person.deliveryAddress = { ...this.inProgressDeliveryAddress }
     }
-    if (this.isBenBcCccUlcCorrectionFiling) {
+    // Note: For corrections if the appointmentDate isn't included - you may run into some issues where adding a new
+    // director as it wont show up in the parties or directors call.
+    if (this.isBenBcCccUlcCorrectionFiling || this.isCoopCorrectionFiling) {
       person.roles = this.setPersonRoles(this.orgPerson)
     } else {
       person.roles = this.orgPerson.roles


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17347

*Description of changes:*
If the appointmentDate doesn't exist, it's not possible to add in new party members. They get created but don't actually show up.

Fixes this issue:

![image](https://github.com/bcgov/business-edit-ui/assets/3484109/ba5b1d34-8df4-4c9d-907e-6568616a20c5)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
