### PR TITLE
22564 Do not show Confirm Name Change checkbox for firm corrections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.10.2",
+  "version": "4.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.10.2",
+      "version": "4.10.3",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.10.2",
+  "version": "4.10.3",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -818,10 +818,14 @@ export default class OrgPerson extends Mixins(CommonMixin, OrgPersonMixin) {
 
   /** Returns True if person name or org name has changed from its original properties. */
   hasNameChanged (orgPerson: OrgPersonIF): boolean {
-    /** This check is only for firm corrections, change, conversion, Corp extension and Corp conversion filings.
-    Does not apply to corps corrections */
-    const showConfirmNameChange = this.isFirmCorrectionFiling || this.isFirmChangeFiling ||
-      this.isFirmConversionFiling || this.isLimitedRestorationExtension || this.isLimitedRestorationToFull
+    // This check is only for firm change, firm conversion, corp extension and corp conversion filings.
+    // This does not apply to firm, coop or corp corrections.
+    const showConfirmNameChange = (
+      this.isFirmChangeFiling ||
+      this.isFirmConversionFiling ||
+      this.isLimitedRestorationExtension ||
+      this.isLimitedRestorationToFull
+    )
 
     // check showConfirmNameChange and is this a pre-existing person?
     if (showConfirmNameChange && this.isPreExisting && this.isPerson) {


### PR DESCRIPTION
*Issue #:* bcgov/entity#22564

*Description of changes:*
- app version = 4.10.3
- do not show Confirm Name Change checkbox for firm corrections

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).