### PR TITLE
22978 Fixed original filing date decoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.10.6",
+  "version": "4.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.10.6",
+      "version": "4.10.7",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.10.6",
+  "version": "4.10.7",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,6 @@
 export { default as AuthServices } from './auth-services'
 export { default as BusinessLookupServices } from './business-lookup-services'
+export { default as DateUtilities } from './date-utilities'
 export { default as LegalServices } from './legal-services'
 export { default as NaicsServices } from './naics-services'
 export { default as PayServices } from './pay-services'

--- a/src/views/Correction/CoopCorrection.vue
+++ b/src/views/Correction/CoopCorrection.vue
@@ -81,7 +81,7 @@ import { SpecialResolutionSummary, Resolution } from '@/components/SpecialResolu
 import { AssociationType, BusinessContactInfo, BusinessType, CertifySection, CompletingParty, CourtOrderPoa,
   CurrentDirectors, Detail, DocumentsDelivery, EntityName, FolioInformation, OfficeAddresses, PeopleAndRoles,
   RecognitionDateTime, StaffPayment, TransactionalFolioNumber, YourCompanyWrapper } from '@/components/common/'
-import { CommonMixin, DateMixin, FeeMixin, FilingTemplateMixin } from '@/mixins/'
+import { CommonMixin, FeeMixin, FilingTemplateMixin } from '@/mixins/'
 import ViewWrapper from '@/components/ViewWrapper.vue'
 import Rules from '@/components/SpecialResolution/Rules.vue'
 import Memorandum from '@/components/SpecialResolution/Memorandum.vue'
@@ -89,7 +89,7 @@ import { Action, Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
 import { CorrectionFilingIF, ResourceIF, EntitySnapshotIF } from '@/interfaces'
 import { CorrectionResourceCp } from '@/resources/Correction'
-import { LegalServices, AuthServices } from '@/services'
+import { DateUtilities, LegalServices, AuthServices } from '@/services'
 import { StaffPaymentOptions } from '@bcrs-shared-components/enums'
 import { CorrectionErrorTypes } from '@/enums'
 
@@ -119,7 +119,7 @@ import { CorrectionErrorTypes } from '@/enums'
     YourCompanyWrapper
   }
 })
-export default class CoopCorrection extends Mixins(CommonMixin, DateMixin, FeeMixin, FilingTemplateMixin) {
+export default class CoopCorrection extends Mixins(CommonMixin, FeeMixin, FilingTemplateMixin) {
   // Store getters
   @Getter(useStore) hasResolutionSection!: boolean
 
@@ -134,7 +134,7 @@ export default class CoopCorrection extends Mixins(CommonMixin, DateMixin, FeeMi
 
   /** The original filing date, in Pacific time. */
   get originalFilingDate (): string {
-    return this.apiToPacificDateLong(this.getCorrectedFilingDate)
+    return DateUtilities.yyyyMmDdToPacificDate(this.getCorrectedFilingDate, true)
   }
 
   /** The resource object for a firm correction filing. */

--- a/src/views/Correction/CorpCorrection.vue
+++ b/src/views/Correction/CorpCorrection.vue
@@ -68,8 +68,8 @@ import { Articles } from '@/components/Alteration/'
 import { BusinessContactInfo, CertifySection, CompletingParty, Detail, EntityName, FolioInformation,
   NameTranslation, OfficeAddresses, PeopleAndRoles, RecognitionDateTime, ShareStructures, StaffPayment,
   YourCompanyWrapper } from '@/components/common/'
-import { CommonMixin, DateMixin, FeeMixin, FilingTemplateMixin } from '@/mixins/'
-import { AuthServices, LegalServices } from '@/services/'
+import { CommonMixin, FeeMixin, FilingTemplateMixin } from '@/mixins/'
+import { AuthServices, DateUtilities, LegalServices } from '@/services/'
 import { StaffPaymentOptions } from '@bcrs-shared-components/enums/'
 import { CorrectionFilingIF, EntitySnapshotIF, ResourceIF } from '@/interfaces/'
 import * as Resources from '@/resources/Correction/'
@@ -95,7 +95,7 @@ import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
     YourCompanyWrapper
   }
 })
-export default class CorpCorrection extends Mixins(CommonMixin, DateMixin, FeeMixin, FilingTemplateMixin) {
+export default class CorpCorrection extends Mixins(CommonMixin, FeeMixin, FilingTemplateMixin) {
   // Store getters
   // @Getter(useStore) getEntityType!: CorpTypeCd
 
@@ -108,7 +108,7 @@ export default class CorpCorrection extends Mixins(CommonMixin, DateMixin, FeeMi
 
   /** The original filing date, in Pacific time. */
   get originalFilingDate (): string {
-    return this.apiToPacificDateLong(this.getCorrectedFilingDate)
+    return DateUtilities.yyyyMmDdToPacificDate(this.getCorrectedFilingDate, true)
   }
 
   /** The resource object for a correction filing. */


### PR DESCRIPTION
*Issue #:* bcgov/entity#22978

*Description of changes:*
- app version = 4.10.7
- replaced DateMixin with DateUtilities (coop correction and corp correction only)
- used correct date conversion for original filing date

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).