### PR TITLE
16500 - Fixed Restoration People Section Bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.10.10",
+  "version": "4.10.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.10.10",
+      "version": "4.10.11",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.10.10",
+  "version": "4.10.11",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
@@ -730,24 +730,14 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
         if (deleted) delete deleted.actions
       }
     } else {
-      // get ID of original officer to undo
-      const id = this.originalParties[0]?.officer?.id
-
-      let thisPerson
-      if (isNaN(+id)) {
-        // to check assigned UUID
-        thisPerson = cloneDeep(this.originalParties.find(x => x.officer.id === id))
-      } else {
-        // get a copy of original person from original IA
-        thisPerson = cloneDeep(this.originalParties.find(x => +x.officer.id === +id))
-      }
+      // copy the original person
+      let thisPerson = cloneDeep(this.originalParties[0])
 
       // safety check
-      if (!thisPerson) throw new Error(`Failed to find original person with id = ${id}`)
+      if (!thisPerson) throw new Error(`Failed to find original person`)
 
       // splice in the original person
       tempList.splice(index, 1, thisPerson)
-      console.log(tempList)
     }
 
     // set updated list

--- a/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
@@ -730,8 +730,8 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
         if (deleted) delete deleted.actions
       }
     } else {
-      // get ID of edited person to undo
-      const id = person?.officer?.id
+      // get ID of original officer to undo
+      const id = this.originalParties[0]?.officer?.id
 
       let thisPerson
       if (isNaN(+id)) {
@@ -747,6 +747,7 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
 
       // splice in the original person
       tempList.splice(index, 1, thisPerson)
+      console.log(tempList)
     }
 
     // set updated list

--- a/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles/PeopleAndRoles.vue
@@ -730,11 +730,20 @@ export default class PeopleAndRoles extends Mixins(CommonMixin, DateMixin, OrgPe
         if (deleted) delete deleted.actions
       }
     } else {
-      // copy the original person
-      let thisPerson = cloneDeep(this.originalParties[0])
+      // get ID of edited person to undo
+      const id = person?.officer?.id
+
+      let thisPerson
+      if (isNaN(+id)) {
+        // to check assigned UUID
+        thisPerson = cloneDeep(this.originalParties.find(x => x.officer.id === id))
+      } else {
+        // get a copy of original person from original IA
+        thisPerson = cloneDeep(this.originalParties.find(x => +x.officer.id === +id))
+      }
 
       // safety check
-      if (!thisPerson) throw new Error(`Failed to find original person`)
+      if (!thisPerson) throw new Error(`Failed to find original person with id = ${id}`)
 
       // splice in the original person
       tempList.splice(index, 1, thisPerson)

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -1518,12 +1518,7 @@ export default class FilingTemplateMixin extends DateMixin {
         if (!party.mailingAddress.streetAddressAdditional) delete party.mailingAddress.streetAddressAdditional
         if (!party.mailingAddress.deliveryInstructions) delete party.mailingAddress.deliveryInstructions
       }
-      // If the partyType is organization, remove firstName, middleName and lastName
-      if (party.officer.partyType === PartyTypes.ORGANIZATION) {
-        delete party.officer.firstName
-        delete party.officer.lastName
-        delete party.officer.middleName
-      }
+
       // NB: at this time, do not convert party from "middleName" to "middleInitial"
 
       return party

--- a/src/views/LimitedRestorationExtension.vue
+++ b/src/views/LimitedRestorationExtension.vue
@@ -112,7 +112,6 @@
 <script lang="ts">
 import { Component, Emit, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
-import { v4 as uuidv4 } from 'uuid'
 import { cloneDeep } from 'lodash'
 import { GetFeatureFlag } from '@/utils/'
 import RestorationSummary from '@/components/Restoration/RestorationSummary.vue'
@@ -337,7 +336,6 @@ export default class LimitedRestorationExtension extends Mixins(
 
     // make a copy of the original object
     const copy = cloneDeep(applicant)
-
     return copy
   }
 

--- a/src/views/LimitedRestorationExtension.vue
+++ b/src/views/LimitedRestorationExtension.vue
@@ -335,9 +335,8 @@ export default class LimitedRestorationExtension extends Mixins(
       throw new Error(`Applicant not found for ${this.getBusinessId}`)
     }
 
-    // make a copy of the original object and assign a new id (for UI use only)
+    // make a copy of the original object
     const copy = cloneDeep(applicant)
-    copy.officer.id = uuidv4()
 
     return copy
   }

--- a/src/views/LimitedRestorationToFull.vue
+++ b/src/views/LimitedRestorationToFull.vue
@@ -364,9 +364,8 @@ export default class LimitedRestorationToFull extends Mixins(
       throw new Error(`Applicant not found for ${this.getBusinessId}`)
     }
 
-    // make a copy of the original object and assign a new id (for UI use only)
+    // make a copy of the original object
     const copy = cloneDeep(applicant)
-    copy.officer.id = uuidv4()
 
     return copy
   }

--- a/src/views/LimitedRestorationToFull.vue
+++ b/src/views/LimitedRestorationToFull.vue
@@ -139,7 +139,6 @@
 <script lang="ts">
 import { Component, Emit, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
-import { v4 as uuidv4 } from 'uuid'
 import { cloneDeep } from 'lodash'
 import { GetFeatureFlag } from '@/utils/'
 import RestorationSummary from '@/components/Restoration/RestorationSummary.vue'
@@ -366,7 +365,6 @@ export default class LimitedRestorationToFull extends Mixins(
 
     // make a copy of the original object
     const copy = cloneDeep(applicant)
-
     return copy
   }
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#16500

*Description of changes:*
- Conversion to Full Restoration or Limited Restoration Extension page, when we edited the Applicant Person's information, click "Save and Resume", then go back - the "Undo" function doesn't work anymore
- Fixed this bug by removing the re-assign officer ID.
- Fixed the bug that removed and added person are not updated, previously in ticket
 https://app.zenhub.com/workspaces/entities---olga-65af15f59e89f5043c2911f7/issues/gh/bcgov/entity/23277
(verify this ticket)
- Fixed the bug when the person is a business/corporation, the file and pay fails (fixed the party schema)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
