### PR TITLE
24040 Fix Alteration of Company Type Options for BEN/CBEN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.11.0",
+      "version": "4.11.1",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/resources/Alteration/BEN.ts
+++ b/src/resources/Alteration/BEN.ts
@@ -28,11 +28,6 @@ export const AlterationResourceBen: ResourceIF = {
         shortDesc: 'BC Limited Company',
         text: 'BC Limited Company'
       },
-      {
-        value: CorpTypeCd.BC_CCC,
-        shortDesc: 'BC Community Contribution Company',
-        text: 'BC Community Contribution Company'
-      }
     ],
     articleTitle: 'Benefit Company Articles',
     articleInfo: `The company has completed a set Benefit Company Articles containing a benefit provision, 

--- a/src/resources/Alteration/BEN.ts
+++ b/src/resources/Alteration/BEN.ts
@@ -27,7 +27,7 @@ export const AlterationResourceBen: ResourceIF = {
         value: CorpTypeCd.BC_COMPANY,
         shortDesc: 'BC Limited Company',
         text: 'BC Limited Company'
-      },
+      }
     ],
     articleTitle: 'Benefit Company Articles',
     articleInfo: `The company has completed a set Benefit Company Articles containing a benefit provision, 

--- a/src/resources/Alteration/CBEN.ts
+++ b/src/resources/Alteration/CBEN.ts
@@ -28,11 +28,6 @@ export const AlterationResourceCben: ResourceIF = {
         shortDesc: 'BC Limited Company',
         text: 'BC Limited Company'
       },
-      {
-        value: CorpTypeCd.CCC_CONTINUE_IN,
-        shortDesc: 'BC Community Contribution Company',
-        text: 'BC Community Contribution Company'
-      }
     ],
     articleTitle: 'Benefit Company Articles',
     articleInfo: `The company has completed a set Benefit Company Articles containing a benefit provision, 

--- a/src/resources/Alteration/CBEN.ts
+++ b/src/resources/Alteration/CBEN.ts
@@ -27,7 +27,7 @@ export const AlterationResourceCben: ResourceIF = {
         value: CorpTypeCd.CONTINUE_IN,
         shortDesc: 'BC Limited Company',
         text: 'BC Limited Company'
-      },
+      }
     ],
     articleTitle: 'Benefit Company Articles',
     articleInfo: `The company has completed a set Benefit Company Articles containing a benefit provision, 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24040

*Description of changes:*
- remove CC option from allowed business alteration types for BEN businesses
- remove CCC option from allowed business alteration types for CBEN businesses
- update patch version


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
