### PR TITLE
23971 - allow editable certify legal name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.11.1",
+      "version": "4.11.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -75,7 +75,6 @@
             class="mt-10"
             :sectionNumber="showTransactionalFolioNumber ? '3.' : '2.'"
             :validate="getAppValidate"
-            :disableEdit="!isRoleStaff"
           />
 
           <!-- STAFF ONLY: Court Order/Plan of Arrangement and Staff Payment -->

--- a/src/views/SpecialResolution.vue
+++ b/src/views/SpecialResolution.vue
@@ -97,7 +97,6 @@
             class="mt-10"
             :sectionNumber="showTransactionalFolioNumber ? '4.' : '3.'"
             :validate="getAppValidate"
-            :disableEdit="!isRoleStaff"
           />
 
           <template v-if="isRoleStaff">

--- a/tests/unit/Alteration.spec.ts
+++ b/tests/unit/Alteration.spec.ts
@@ -413,7 +413,7 @@ describe('Alteration component', () => {
     expect(store.stateModel.filingData[0].filingTypeCode).toBe(FilingCodes.ALTERATION_BC_TO_ULC)
   })
 
-  it('certify text is not prefilled/editable for staff user', async () => {
+  it('certify text is not prefilled for staff user', async () => {
     store.stateModel.tombstone.keycloakRoles = ['staff']
     store.stateModel.tombstone.userInfo = {
       firstname: 'Jon',
@@ -425,7 +425,7 @@ describe('Alteration component', () => {
     expect(store.stateModel.certifyState.certifiedBy).toBe('undefined undefined')
   })
 
-  it('certify text is prefilled/uneditable for non-staff user', async () => {
+  it('certify text is prefilled for non-staff user', async () => {
     store.stateModel.tombstone.keycloakRoles = []
     store.stateModel.tombstone.userInfo = {
       firstname: 'Jon',

--- a/tests/unit/SpecialResolution.spec.ts
+++ b/tests/unit/SpecialResolution.spec.ts
@@ -278,7 +278,7 @@ describe('Special Resolution component', () => {
     expect(store.stateModel.currentFees[0].filingFees).toBe(70)
   })
 
-  it('certify text is not prefilled/editable for staff user', async () => {
+  it('certify text is not prefilled for staff user', async () => {
     store.stateModel.tombstone.keycloakRoles = ['staff']
     store.stateModel.tombstone.userInfo = {
       firstname: 'Jon',
@@ -290,7 +290,7 @@ describe('Special Resolution component', () => {
     expect(store.stateModel.certifyState.certifiedBy).toBe('undefined undefined')
   })
 
-  it('certify text is prefilled/uneditable for non-staff user', async () => {
+  it('certify text is prefilled for non-staff user', async () => {
     store.stateModel.tombstone.keycloakRoles = []
     store.stateModel.tombstone.userInfo = {
       firstname: 'Jon',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23971

*Description of changes:*
Allow Certify Legal Name section to be editable for regular users. _As per discussion with Mihai, firms and coops are not considered in this ticket._
| Filing Type | is Editable Before | is Editable Now | Notes |
| --- | --- | --- | --- |
| alteration | ❌ | ✔️ |  |
| limitedRestorationExtension | ✔️ | ✔️ |  |
| limitedRestorationToFull | ✔️ | ✔️ |  |
| specialResolution | ❌ | ✔️ |  |
| CorpCorrection | ✔️ | ✔️ |  |
| CoopCorrection | ✔️ | ✔️ | Not considering Coops and Firms at this moment |
| change | ❌ | ❌ | Not considering Coops and Firms at this moment |
| FirmCorrection | ✔️ | ✔️ | Not considering Coops and Firms at this moment |


#### Change Example - Alteration for a corp as a regular user 
##### Before
![Pasted image 20241031100156](https://github.com/user-attachments/assets/024b4f5a-ba30-4fcb-a024-6798e289a953)
##### Now
![Pasted image 20241031100325](https://github.com/user-attachments/assets/d2bd986c-9c3f-4035-856a-853b8da938d9)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
