### PR TITLE
24041 Fix alteration of company type issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.4",
+  "version": "4.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.11.4",
+      "version": "4.11.5",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.4",
+  "version": "4.11.5",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -459,7 +459,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
     }
     if (this.isCommunityContribution) {
       originalName = originalName.replace(' LTD.', '')
-      originalName += ' COMMUNITY CONTRIBUTION COMPANY'
+      originalName += ' COMMUNITY CONTRIBUTION COMPANY LTD.'
       return originalName
     }
     if (this.isBcLimited || this.isBenefitCompany) {

--- a/tests/unit/ChangeBusinessType.spec.ts
+++ b/tests/unit/ChangeBusinessType.spec.ts
@@ -152,7 +152,7 @@ describe('Change Business Type component', () => {
     wrapper.vm.selectedEntityType = CorpTypeCd.BC_CCC
     wrapper.vm.submitTypeChange()
 
-    expect(wrapper.vm.getNameRequestLegalName).toBe('1234567 COMMUNITY CONTRIBUTION COMPANY')
+    expect(wrapper.vm.getNameRequestLegalName).toBe('1234567 COMMUNITY CONTRIBUTION COMPANY LTD.')
 
     store.stateModel.entitySnapshot.businessInfo.legalType = CorpTypeCd.BC_ULC_COMPANY
     store.stateModel.entitySnapshot.businessInfo.legalName = '1234567 COMMUNITY CONTRIBUTION COMPANY'


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24041

*Description of changes:*
- Changed `getUpdatedName` for businesses altering their type to CC/CCC. Talked to Dylan and the preference is to use "COMMUNITY CONTRIBUTION COMPANY LTD." suffix for numbered companies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
