### PR TITLE
24297 - Alteration Business Type & Change Name Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.7",
+  "version": "4.11.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.11.7",
+      "version": "4.11.8",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.7",
+  "version": "4.11.8",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/assets/styles/theme.scss
+++ b/src/assets/styles/theme.scss
@@ -61,6 +61,7 @@ $BCgovFontColorInverted: #ffffff;
 $app-blue: #1669bb; // same as the Vuetify theme primary
 $app-lt-blue: #e4edf7;
 $app-dk-blue: #38598a; // same as the Vuetify theme appDkBlue
+$app-lt-red: #fae9e9;
 $app-red: #d3272c; // same as the Vuetify theme error
 $app-green: #1a9031; // same as the Vuetify theme success
 

--- a/src/components/Alteration/AlterationSummary.vue
+++ b/src/components/Alteration/AlterationSummary.vue
@@ -197,6 +197,7 @@ export default class AlterationSummary extends Mixins(DateMixin, FeeMixin, Filin
   @Getter(useStore) getOriginalResolutions!: ResolutionsIF[]
   @Getter(useStore) haveNewResolutionDates!: boolean
   @Getter(useStore) isBusySaving!: boolean
+  @Getter(useStore) getUpdatedName!: string
 
   // Store actions
   @Action(useStore) setEffectiveDateValid!: (x: boolean) => void
@@ -220,7 +221,7 @@ export default class AlterationSummary extends Mixins(DateMixin, FeeMixin, Filin
   /** The company name (from NR, or incorporation number). */
   get companyName (): string {
     if (this.getNameRequestLegalName) return this.getNameRequestLegalName
-    return `${this.getBusinessNumber || '[Incorporation Number]'} B.C. Ltd.`
+    return `${this.getBusinessNumber || '[Incorporation Number]'} B.C. ${this.getUpdatedName}`
   }
 
   /** True if invalid class should be set for Alteration Date-Time container. */

--- a/src/components/common/MessageBox.vue
+++ b/src/components/common/MessageBox.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-card
+    outlined
+    class="rounded-0 ma-0"
+    :class="{
+      'message-box-gold': color === 'gold',
+      'message-box-red': color === 'red'
+    }"
+  >
+    <div class="mx-7 my-5 pa-0">
+      <slot />
+    </div>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+  @Component({})
+export default class MessageBox extends Vue {
+    @Prop({ required: true }) readonly color!: 'gold' | 'red'
+}
+</script>
+
+  <style lang="scss" scoped>
+  @import '@/assets/styles/theme.scss';
+
+  .v-card {
+    div {
+      font-size: $px-14;
+      letter-spacing: 0.01rem;
+      color: $gray7;
+    }
+  }
+  .message-box-gold {
+    background-color: $BCgovGold0 !important;
+    border-color: $BCgovGold5 !important;
+  }
+  .message-box-red {
+    background-color: $app-lt-red !important;
+    border-color: $app-red !important;
+  }
+  </style>

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -211,7 +211,7 @@
             large
             outlined
             color="primary"
-            @click="isEditingType = false, hasAttemptedSubmission = false"
+            @click="resetType()"
           >
             <span>Cancel</span>
           </v-btn>
@@ -346,6 +346,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
   @Action(useStore) setNameRequest!: (x: NameRequestIF) => void
   @Action(useStore) setNameRequestLegalName!: (x: string) => void
   @Action(useStore) setNameChangedByType!: (x: boolean) => void
+  @Action(useStore) setEntityTypeChangedByName!: (x: boolean) => void
 
   selectedEntityType = null as CorpTypeCd
   confirmArticles = false
@@ -455,6 +456,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
     } as any)
     this.setNameRequestLegalName(this.getOriginalLegalName)
     this.setNameChangedByType(false)
+    this.setEntityTypeChangedByName(false)
     this.isEditingType = false
     this.confirmArticles = false
   }

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -279,7 +279,7 @@
                 <v-list-item
                   id="btn-more-actions-edit"
                   class="v-list-item"
-                  @click="isEditingType = true; dropdown = false"
+                  @click="isEditingType = true; dropdown = false; hasAttemptedSubmission = false"
                 >
                   <v-list-item-subtitle>
                     <v-icon

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -423,8 +423,9 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
   }
 
   get nameRequestRequiredError (): boolean {
-    // Don't show the Error when the type is changed by name, or changed to a numbered company
-    if (this.isNumberedCompany || this.isEntityTypeChangedByName || this.isNameChangedToNumber) {
+    // Don't show the Error when the type is changed by name, or changed to a numbered company, or no change
+    if (this.isNumberedCompany || this.isEntityTypeChangedByName || this.isNameChangedToNumber ||
+       this.selectedEntityType === this.getOriginalLegalType) {
       return false
     }
     // Named companies to CC/CCC or ULC/CUL require a name request.

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -484,6 +484,8 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
       this.setNameRequestLegalName(updatedName)
       if (originalName !== updatedName) {
         this.setNameChangedByType(true)
+      } else {
+        this.setNameChangedByType(false)
       }
     }
   }

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -201,6 +201,7 @@
             id="done-btn"
             large
             color="primary"
+            :disabled="disableDoneButton"
             @click="submitTypeChange()"
           >
             <span>Done</span>
@@ -536,7 +537,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
   }
 
   get disableDoneButton (): boolean {
-    return !this.confirmArticles || this.minimumThreeDirectorError || this.nameRequestRequiredError
+    return !this.confirmArticles
   }
 
   @Watch('isEditingType')

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -139,19 +139,23 @@
           class="mt-6"
           color="red"
         >
-          <p>
-            <v-icon
-              color="red"
-              class="error-icon"
-            >
-              mdi-alert
-            </v-icon>
-            <strong class="pl-2 pt-6">Update directors</strong>
-          </p>
-          <p class="pl-8">
-            A BC Community Contribution Company requires at least three directors.
-            File a director change and then come back and update the business type.
-          </p>
+          <header>
+            <p>
+              <v-icon
+                color="red"
+                class="error-icon"
+              >
+                mdi-alert
+              </v-icon>
+              <strong class="pl-2 pt-6">Update directors</strong>
+            </p>
+          </header>
+          <article>
+            <p class="pl-8">
+              A BC Community Contribution Company requires at least three directors.
+              File a director change and then come back and update the business type.
+            </p>
+          </article>
         </MessageBox>
 
         <MessageBox
@@ -160,19 +164,23 @@
           class="mt-6"
           color="red"
         >
-          <p>
-            <v-icon
-              color="red"
-              class="error-icon"
-            >
-              mdi-alert
-            </v-icon>
-            <strong class="pl-2 pt-6">Change company name</strong>
-          </p>
-          <p class="pl-8">
-            To change to a {{ GetCorpFullDescription(selectedEntityType) }}, you must change the company
-            name using an approved name request or change it to a numbered company.
-          </p>
+          <header>
+            <p>
+              <v-icon
+                color="red"
+                class="error-icon"
+              >
+                mdi-alert
+              </v-icon>
+              <strong class="pl-2 pt-6">Change company name</strong>
+            </p>
+          </header>
+          <article>
+            <p class="pl-8">
+              To change to a {{ GetCorpFullDescription(selectedEntityType) }}, you must change the company
+              name using an approved name request or change it to a numbered company.
+            </p>
+          </article>
         </MessageBox>
 
         <div class="my-6">

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -374,6 +374,10 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
   @Watch('selectedEntityType')
   private clearConfirmArticles (): void {
     this.confirmArticles = false
+    // Ensure when selected type changes by NR, show the error message and Articles
+    if (this.selectedEntityType !== this.getOriginalLegalType) {
+      this.isEditingType = true
+    }
   }
 
   /** Display the edit, so the user has to reconfirm articles. */

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -140,21 +140,17 @@
           color="red"
         >
           <header>
-            <p>
-              <v-icon
-                color="red"
-                class="error-icon"
-              >
-                mdi-alert
-              </v-icon>
-              <strong class="pl-2 pt-6">Update directors</strong>
-            </p>
+            <v-icon
+              color="red"
+              class="error-icon"
+            >
+              mdi-alert
+            </v-icon>
+            <strong class="pl-2 gray9--text text-small-text">Update directors</strong>
           </header>
-          <article>
-            <p class="pl-8">
-              A BC Community Contribution Company requires at least three directors.
-              File a director change and then come back and update the business type.
-            </p>
+          <article class="pl-8 pt-1 small-text">
+            A BC Community Contribution Company requires at least three directors.
+            File a director change and then come back and update the business type.
           </article>
         </MessageBox>
 
@@ -165,21 +161,17 @@
           color="red"
         >
           <header>
-            <p>
-              <v-icon
-                color="red"
-                class="error-icon"
-              >
-                mdi-alert
-              </v-icon>
-              <strong class="pl-2 pt-6">Change company name</strong>
-            </p>
+            <v-icon
+              color="red"
+              class="error-icon"
+            >
+              mdi-alert
+            </v-icon>
+            <strong class="pl-2 gray9--text text-small-text">Change company name</strong>
           </header>
-          <article>
-            <p class="pl-8">
-              To change to a {{ GetCorpFullDescription(selectedEntityType) }}, you must change the company
-              name using an approved name request or change it to a numbered company.
-            </p>
+          <article class="pl-8 pt-1 small-text">
+            To change to a {{ GetCorpFullDescription(selectedEntityType) }}, you must change the company
+            name using an approved name request or change it to a numbered company.
           </article>
         </MessageBox>
 

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -134,7 +134,7 @@
         </template>
 
         <div
-          v-if="minimumThreeDirectorError"
+          v-if="hasAttemptedSubmission && minimumThreeDirectorError"
           id="minimum-three-director-error"
           class="my-6"
         >
@@ -144,7 +144,7 @@
         </div>
 
         <div
-          v-if="nameRequestRequiredError"
+          v-if="hasAttemptedSubmission && nameRequestRequiredError"
           id="name-request-required-error"
           class="my-6"
         >
@@ -180,7 +180,6 @@
             id="done-btn"
             large
             color="primary"
-            :disabled="disableDoneButton"
             @click="submitTypeChange()"
           >
             <span>Done</span>
@@ -191,7 +190,7 @@
             large
             outlined
             color="primary"
-            @click="isEditingType = false"
+            @click="isEditingType = false, hasAttemptedSubmission = false"
           >
             <span>Cancel</span>
           </v-btn>
@@ -330,6 +329,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
   isEditingType = false
   dropdown = null as boolean
   supportedEntityTypes = [] as Array<string>
+  hasAttemptedSubmission = false
 
   /** Called when component is mounted. */
   mounted (): void {
@@ -423,6 +423,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
 
   /** Reset company type values to original. */
   resetType () {
+    this.hasAttemptedSubmission = false
     this.setEntityType(this.getOriginalLegalType || null)
     // reset name request
     this.setNameRequest({
@@ -437,6 +438,8 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
 
   /** Submit new company type. */
   submitTypeChange () {
+    this.hasAttemptedSubmission = true // Mark that submission was attempted
+    if (this.minimumThreeDirectorError || this.nameRequestRequiredError) { return }
     this.setEntityType(this.selectedEntityType)
     this.isEditingType = false
     if (this.isNumberedCompany && !this.hasNewNr) {

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -487,6 +487,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
   getUpdatedName (originalName: string): string {
     if (this.isUnlimitedLiability) {
       originalName = originalName.replace(' LTD.', '')
+      originalName = originalName.replace(' UNLIMITED LIABILITY COMPANY', '').replace(' ULC', '')
       originalName += ' UNLIMITED LIABILITY COMPANY'
       return originalName
     }

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -133,26 +133,47 @@
           </v-row>
         </template>
 
-        <div
+        <MessageBox
           v-if="hasAttemptedSubmission && minimumThreeDirectorError"
           id="minimum-three-director-error"
-          class="my-6"
+          class="mt-6"
+          color="red"
         >
-          <p class="error-text">
-            The business type cannot be changed. A Community Contribution Company requires a minimum of three directors.
+          <p>
+            <v-icon
+              color="red"
+              class="error-icon"
+            >
+              mdi-alert
+            </v-icon>
+            <strong class="pl-2 pt-6">Update directors</strong>
           </p>
-        </div>
+          <p class="pl-8">
+            A BC Community Contribution Company requires at least three directors.
+            File a director change and then come back and update the business type.
+          </p>
+        </MessageBox>
 
-        <div
+        <MessageBox
           v-if="hasAttemptedSubmission && nameRequestRequiredError"
           id="name-request-required-error"
-          class="my-6"
+          class="mt-6"
+          color="red"
         >
-          <p class="error-text">
-            An alteration of business type Name Request is required to make this change. After the name is approved,
-            you can then select 'change' beside the company name to update it.
+          <p>
+            <v-icon
+              color="red"
+              class="error-icon"
+            >
+              mdi-alert
+            </v-icon>
+            <strong class="pl-2 pt-6">Change company name</strong>
           </p>
-        </div>
+          <p class="pl-8">
+            To change to a BC Community Contribution Company, you must change the company
+            name using an approved name request or change it to a numbered company.
+          </p>
+        </MessageBox>
 
         <div class="my-6">
           <p class="info-text">
@@ -287,11 +308,13 @@ import { EntityTypeOption, ResourceIF } from '@/interfaces/'
 import { NameRequestIF } from '@bcrs-shared-components/interfaces'
 import { GetFeatureFlag, ResourceUtilities } from '@/utils'
 import { useStore } from '@/store/store'
+import MessageBox from '@/components/common/MessageBox.vue'
 
 @Component({
   components: {
     BcRegContacts,
-    BcRegEntityDetails
+    BcRegEntityDetails,
+    MessageBox
   }
 })
 export default class ChangeBusinessType extends Mixins(CommonMixin) {

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -341,6 +341,7 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
   @Getter(useStore) isEntityTypeChangedByName!: boolean
   @Getter(useStore) isNameChangedByType!: boolean
   @Getter(useStore) isNumberedCompany!: boolean
+  @Getter(useStore) isNameChangedToNumber!: boolean
 
   @Action(useStore) setEntityType!: (x: CorpTypeCd) => void
   @Action(useStore) setNameRequest!: (x: NameRequestIF) => void
@@ -413,8 +414,8 @@ export default class ChangeBusinessType extends Mixins(CommonMixin) {
   }
 
   get nameRequestRequiredError (): boolean {
-    // Don't show the Error when the type is changed by name
-    if (this.isNumberedCompany || this.isEntityTypeChangedByName) {
+    // Don't show the Error when the type is changed by name, or changed to a numbered company
+    if (this.isNumberedCompany || this.isEntityTypeChangedByName || this.isNameChangedToNumber) {
       return false
     }
     // Named companies to CC/CCC or ULC/CUL require a name request.

--- a/src/components/common/YourCompany/ChangeBusinessType.vue
+++ b/src/components/common/YourCompany/ChangeBusinessType.vue
@@ -170,7 +170,7 @@
             <strong class="pl-2 pt-6">Change company name</strong>
           </p>
           <p class="pl-8">
-            To change to a BC Community Contribution Company, you must change the company
+            To change to a {{ GetCorpFullDescription(selectedEntityType) }}, you must change the company
             name using an approved name request or change it to a numbered company.
           </p>
         </MessageBox>

--- a/src/components/common/YourCompany/CorrectName/CorrectName.vue
+++ b/src/components/common/YourCompany/CorrectName/CorrectName.vue
@@ -78,14 +78,12 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Emit, Prop } from 'vue-property-decorator'
-import { Action } from 'pinia-class'
 import { CorrectNameOptionIF } from '@/interfaces/'
 import { CorrectNameOptions } from '@/enums/'
 // These imports below are touchy, please don't change them - they can possibly break tests.
 import CorrectCompanyName from './CorrectCompanyName.vue'
 import CorrectNameRequest from './CorrectNameRequest.vue'
 import CorrectNameToNumber from './CorrectNameToNumber.vue'
-import { useStore } from '@/store/store'
 
 /**
  * Operation:

--- a/src/components/common/YourCompany/CorrectName/CorrectName.vue
+++ b/src/components/common/YourCompany/CorrectName/CorrectName.vue
@@ -78,12 +78,14 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Emit, Prop } from 'vue-property-decorator'
+import { Action } from 'pinia-class'
 import { CorrectNameOptionIF } from '@/interfaces/'
 import { CorrectNameOptions } from '@/enums/'
 // These imports below are touchy, please don't change them - they can possibly break tests.
 import CorrectCompanyName from './CorrectCompanyName.vue'
 import CorrectNameRequest from './CorrectNameRequest.vue'
 import CorrectNameToNumber from './CorrectNameToNumber.vue'
+import { useStore } from '@/store/store'
 
 /**
  * Operation:
@@ -102,6 +104,8 @@ import CorrectNameToNumber from './CorrectNameToNumber.vue'
 export default class CorrectName extends Vue {
   /** The options to display */
   @Prop() readonly correctNameChoices!: Array<string>
+
+  @Action(useStore) setNameChangedToNumber!: (x: boolean) => void
 
   // local properties
   displayedOptions: Array<CorrectNameOptionIF> = []
@@ -157,6 +161,9 @@ export default class CorrectName extends Vue {
     if (this.isFormValid) {
       this.isLoading = true
       this.formType = this.currentFormType
+      if (this.currentFormType === 'correct-name-to-number') {
+        this.setNameChangedToNumber(true)
+      }
     } else this.validateNameChange = true
   }
 

--- a/src/components/common/YourCompany/CorrectName/CorrectName.vue
+++ b/src/components/common/YourCompany/CorrectName/CorrectName.vue
@@ -105,8 +105,6 @@ export default class CorrectName extends Vue {
   /** The options to display */
   @Prop() readonly correctNameChoices!: Array<string>
 
-  @Action(useStore) setNameChangedToNumber!: (x: boolean) => void
-
   // local properties
   displayedOptions: Array<CorrectNameOptionIF> = []
   panel: number = null
@@ -161,9 +159,6 @@ export default class CorrectName extends Vue {
     if (this.isFormValid) {
       this.isLoading = true
       this.formType = this.currentFormType
-      if (this.currentFormType === 'correct-name-to-number') {
-        this.setNameChangedToNumber(true)
-      }
     } else this.validateNameChange = true
   }
 

--- a/src/components/common/YourCompany/CorrectName/CorrectNameToNumber.vue
+++ b/src/components/common/YourCompany/CorrectName/CorrectNameToNumber.vue
@@ -9,7 +9,7 @@
           id="correct-name-to-number-checkbox"
           v-model="correctToNumbered"
           class="mb-n5"
-          :label="`Change the company name to ${businessId} B.C. Ltd.`"
+          :label="`Change the company name to ${businessId} B.C. ${getUpdatedName()}`"
         />
       </v-col>
     </v-row>
@@ -20,6 +20,7 @@
 // Libraries
 import Vue from 'vue'
 import { Component, Prop, Watch, Emit } from 'vue-property-decorator'
+import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
 import { Action, Getter } from 'pinia-class'
 import { NameRequestIF } from '@bcrs-shared-components/interfaces'
 import { CorrectNameOptions } from '@/enums/'
@@ -35,12 +36,32 @@ export default class CorrectNameToNumber extends Vue {
 
   @Getter(useStore) getNameRequest!: NameRequestIF
   @Getter(useStore) getBusinessId!: string
+  @Getter(useStore) getOriginalLegalType!: CorpTypeCd
 
   // Local properties
   correctToNumbered = false
 
   get businessId (): string {
     return this.getBusinessId && this.getBusinessId.substring(2)
+  }
+
+  /** Get the numbered name, after changing from named company */
+  getUpdatedName (): string {
+    if (this.getOriginalLegalType === CorpTypeCd.BC_ULC_COMPANY ||
+    this.getOriginalLegalType === CorpTypeCd.ULC_CONTINUE_IN) {
+      return 'UNLIMITED LIABILITY COMPANY'
+    }
+    if (this.getOriginalLegalType === CorpTypeCd.BC_CCC ||
+    this.getOriginalLegalType === CorpTypeCd.CCC_CONTINUE_IN) {
+      return 'COMMUNITY CONTRIBUTION COMPANY LTD.'
+    }
+    if (this.getOriginalLegalType === CorpTypeCd.BC_COMPANY ||
+    this.getOriginalLegalType === CorpTypeCd.CONTINUE_IN ||
+    this.getOriginalLegalType === CorpTypeCd.BENEFIT_COMPANY ||
+    this.getOriginalLegalType === CorpTypeCd.BEN_CONTINUE_IN) {
+      return 'LTD.'
+    }
+    return 'LTD.' // should never happen
   }
 
   /** Watch for form submission and emit results. */

--- a/src/components/common/YourCompany/CorrectName/CorrectNameToNumber.vue
+++ b/src/components/common/YourCompany/CorrectName/CorrectNameToNumber.vue
@@ -9,7 +9,7 @@
           id="correct-name-to-number-checkbox"
           v-model="correctToNumbered"
           class="mb-n5"
-          :label="`Change the company name to ${businessId} B.C. ${getUpdatedName()}`"
+          :label="`Change the company name to ${businessId} B.C. ${getUpdatedName}`"
         />
       </v-col>
     </v-row>
@@ -37,31 +37,13 @@ export default class CorrectNameToNumber extends Vue {
   @Getter(useStore) getNameRequest!: NameRequestIF
   @Getter(useStore) getBusinessId!: string
   @Getter(useStore) getOriginalLegalType!: CorpTypeCd
+  @Getter(useStore) getUpdatedName!: string
 
   // Local properties
   correctToNumbered = false
 
   get businessId (): string {
     return this.getBusinessId && this.getBusinessId.substring(2)
-  }
-
-  /** Get the numbered name, after changing from named company */
-  getUpdatedName (): string {
-    if (this.getOriginalLegalType === CorpTypeCd.BC_ULC_COMPANY ||
-    this.getOriginalLegalType === CorpTypeCd.ULC_CONTINUE_IN) {
-      return 'UNLIMITED LIABILITY COMPANY'
-    }
-    if (this.getOriginalLegalType === CorpTypeCd.BC_CCC ||
-    this.getOriginalLegalType === CorpTypeCd.CCC_CONTINUE_IN) {
-      return 'COMMUNITY CONTRIBUTION COMPANY LTD.'
-    }
-    if (this.getOriginalLegalType === CorpTypeCd.BC_COMPANY ||
-    this.getOriginalLegalType === CorpTypeCd.CONTINUE_IN ||
-    this.getOriginalLegalType === CorpTypeCd.BENEFIT_COMPANY ||
-    this.getOriginalLegalType === CorpTypeCd.BEN_CONTINUE_IN) {
-      return 'LTD.'
-    }
-    return 'LTD.' // should never happen
   }
 
   /** Watch for form submission and emit results. */

--- a/src/components/common/YourCompany/EntityName.vue
+++ b/src/components/common/YourCompany/EntityName.vue
@@ -52,7 +52,8 @@
               <span class="info-text">{{ GetCorpFullDescription(getEntityType) }}</span>
             </div>
             <div class="info-text pt-3">
-              <span>The name of this business will be the current Incorporation Number followed by "B.C. Ltd."</span>
+              <span>The name of this business will be the current Incorporation Number followed
+                by "B.C. {{ getUpdatedName() }}"</span>
             </div>
           </template>
           <template v-if="isNameChangedByType && hasCompanyNameChanged">
@@ -301,6 +302,7 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
   @Action(useStore) setValidComponent!: (x: ActionKvIF) => void
   @Action(useStore) setEntityType!: (x: CorpTypeCd) => void
   @Action(useStore) setEntityTypeChangedByName!: (x: boolean) => void
+  @Action(useStore) setNameChangedToNumber!: (x: boolean) => void
 
   // local properties
   dropdown = false // v-model for dropdown menu
@@ -321,6 +323,25 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
         (this.isAlterationFiling || this.isFirmChangeFiling || this.isSpecialResolutionFiling)
       )
     )
+  }
+
+  /** Get the numbered name, after changing from named company */
+  getUpdatedName (): string {
+    if (this.getOriginalLegalType === CorpTypeCd.BC_ULC_COMPANY ||
+    this.getOriginalLegalType === CorpTypeCd.ULC_CONTINUE_IN) {
+      return 'UNLIMITED LIABILITY COMPANY'
+    }
+    if (this.getOriginalLegalType === CorpTypeCd.BC_CCC ||
+    this.getOriginalLegalType === CorpTypeCd.CCC_CONTINUE_IN) {
+      return 'COMMUNITY CONTRIBUTION COMPANY LTD.'
+    }
+    if (this.getOriginalLegalType === CorpTypeCd.BC_COMPANY ||
+    this.getOriginalLegalType === CorpTypeCd.CONTINUE_IN ||
+    this.getOriginalLegalType === CorpTypeCd.BENEFIT_COMPANY ||
+    this.getOriginalLegalType === CorpTypeCd.BEN_CONTINUE_IN) {
+      return 'LTD.'
+    }
+    return 'LTD.' // should never happen
   }
 
   /**
@@ -360,7 +381,7 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
   /** The company name (from NR, or incorporation number). */
   get companyName (): string {
     if (this.getNameRequestLegalName) return this.getNameRequestLegalName
-    return `${this.getBusinessNumber || '[Incorporation Number]'} B.C. Ltd.`
+    return `${this.getBusinessNumber || '[Incorporation Number]'} B.C. ${this.getUpdatedName()}`
   }
 
   /** True if a new NR number has been entered. */
@@ -455,6 +476,8 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
     if (this.isEntityTypeChangedByName) {
       this.setEntityTypeChangedByName(false)
     }
+
+    this.setNameChangedToNumber(false)
 
     // reset flag
     this.hasCompanyNameChanged = false

--- a/src/components/common/YourCompany/EntityName.vue
+++ b/src/components/common/YourCompany/EntityName.vue
@@ -53,7 +53,7 @@
             </div>
             <div class="info-text pt-3">
               <span>The name of this business will be the current Incorporation Number followed
-                by "B.C. {{ getUpdatedName() }}"</span>
+                by "B.C. {{ getUpdatedName }}"</span>
             </div>
           </template>
           <template v-if="isNameChangedByType && hasCompanyNameChanged">
@@ -283,6 +283,7 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
   @Getter(useStore) getOriginalLegalName!: string
   @Getter(useStore) getOriginalLegalType!: CorpTypeCd
   @Getter(useStore) getOriginalNrNumber!: string
+  @Getter(useStore) getUpdatedName!: string
   @Getter(useStore) hasBusinessNameChanged!: boolean
   @Getter(useStore) isAlterationFiling!: boolean
   @Getter(useStore) isConflictingLegalType!: boolean
@@ -325,25 +326,6 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
     )
   }
 
-  /** Get the numbered name, after changing from named company */
-  getUpdatedName (): string {
-    if (this.getEntityType === CorpTypeCd.BC_ULC_COMPANY ||
-    this.getEntityType === CorpTypeCd.ULC_CONTINUE_IN) {
-      return 'UNLIMITED LIABILITY COMPANY'
-    }
-    if (this.getEntityType === CorpTypeCd.BC_CCC ||
-    this.getEntityType === CorpTypeCd.CCC_CONTINUE_IN) {
-      return 'COMMUNITY CONTRIBUTION COMPANY LTD.'
-    }
-    if (this.getEntityType === CorpTypeCd.BC_COMPANY ||
-    this.getEntityType === CorpTypeCd.CONTINUE_IN ||
-    this.getEntityType === CorpTypeCd.BENEFIT_COMPANY ||
-    this.getEntityType === CorpTypeCd.BEN_CONTINUE_IN) {
-      return 'LTD.'
-    }
-    return 'LTD.' // should never happen
-  }
-
   /**
    * Whether the undo button should be displayed. This is the case when the company name has changed,
    * or the business name has changed during an alteration, firm change, or special resolution filing,
@@ -384,7 +366,7 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
   /** The company name (from NR, or incorporation number). */
   get companyName (): string {
     if (this.getNameRequestLegalName) return this.getNameRequestLegalName
-    return `${this.getBusinessNumber || '[Incorporation Number]'} B.C. ${this.getUpdatedName()}`
+    return `${this.getBusinessNumber || '[Incorporation Number]'} B.C. ${this.getUpdatedName}`
   }
 
   /** True if a new NR number has been entered. */

--- a/src/components/common/YourCompany/EntityName.vue
+++ b/src/components/common/YourCompany/EntityName.vue
@@ -327,18 +327,18 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
 
   /** Get the numbered name, after changing from named company */
   getUpdatedName (): string {
-    if (this.getOriginalLegalType === CorpTypeCd.BC_ULC_COMPANY ||
-    this.getOriginalLegalType === CorpTypeCd.ULC_CONTINUE_IN) {
+    if (this.getEntityType === CorpTypeCd.BC_ULC_COMPANY ||
+    this.getEntityType === CorpTypeCd.ULC_CONTINUE_IN) {
       return 'UNLIMITED LIABILITY COMPANY'
     }
-    if (this.getOriginalLegalType === CorpTypeCd.BC_CCC ||
-    this.getOriginalLegalType === CorpTypeCd.CCC_CONTINUE_IN) {
+    if (this.getEntityType === CorpTypeCd.BC_CCC ||
+    this.getEntityType === CorpTypeCd.CCC_CONTINUE_IN) {
       return 'COMMUNITY CONTRIBUTION COMPANY LTD.'
     }
-    if (this.getOriginalLegalType === CorpTypeCd.BC_COMPANY ||
-    this.getOriginalLegalType === CorpTypeCd.CONTINUE_IN ||
-    this.getOriginalLegalType === CorpTypeCd.BENEFIT_COMPANY ||
-    this.getOriginalLegalType === CorpTypeCd.BEN_CONTINUE_IN) {
+    if (this.getEntityType === CorpTypeCd.BC_COMPANY ||
+    this.getEntityType === CorpTypeCd.CONTINUE_IN ||
+    this.getEntityType === CorpTypeCd.BENEFIT_COMPANY ||
+    this.getEntityType === CorpTypeCd.BEN_CONTINUE_IN) {
       return 'LTD.'
     }
     return 'LTD.' // should never happen

--- a/src/components/common/YourCompany/EntityName.vue
+++ b/src/components/common/YourCompany/EntityName.vue
@@ -368,14 +368,17 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
    * - the business name has changed, and
    * - the filing is an alteration or firm change filing, and
    * - the name has not been changed by type
+   * - this is when a named business is changed to a numbered business
    */
   get shouldShowTypeDetail (): boolean {
-    return (
+    const result = (
       !this.hasNewNr &&
       this.hasBusinessNameChanged &&
       (this.isAlterationFiling || this.isFirmChangeFiling) &&
       !this.isNameChangedByType
     )
+    this.setNameChangedToNumber(result)
+    return result
   }
 
   /** The company name (from NR, or incorporation number). */

--- a/src/interfaces/store-interfaces/state-interfaces/tombstone-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/tombstone-interface.ts
@@ -21,5 +21,6 @@ export interface TombStoneIF {
   transactionalFolioNumber: string
   userEmail?: string
   nameChangedByType: boolean
+  nameChangedToNumber: boolean
   entityTypeChangedByName: boolean
 }

--- a/src/resources/Alteration/C.ts
+++ b/src/resources/Alteration/C.ts
@@ -12,7 +12,7 @@ export const AlterationResourceC: ResourceIF = {
     entityType: CorpTypeCd.CONTINUE_IN,
     priority: false
   },
-  // Conditionally used in place of filingData when switching from or C to CUL:
+  // Conditionally used in place of filingData when switching from C to CUL:
   additionalFilingData: {
     filingTypeCode: FilingCodes.ALTERATION_BC_TO_ULC,
     entityType: CorpTypeCd.CONTINUE_IN,

--- a/src/resources/Alteration/C.ts
+++ b/src/resources/Alteration/C.ts
@@ -12,10 +12,10 @@ export const AlterationResourceC: ResourceIF = {
     entityType: CorpTypeCd.CONTINUE_IN,
     priority: false
   },
-  // Conditionally used in place of filingData when switching from BC (or C) to ULC:
+  // Conditionally used in place of filingData when switching from or C to CUL:
   additionalFilingData: {
     filingTypeCode: FilingCodes.ALTERATION_BC_TO_ULC,
-    entityType: CorpTypeCd.BC_COMPANY,
+    entityType: CorpTypeCd.CONTINUE_IN,
     priority: false
   },
   changeData: {

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -23,6 +23,7 @@ export const stateModel: StateModelIF = {
     folioNumber: '',
     transactionalFolioNumber: '',
     nameChangedByType: false,
+    nameChangedToNumber: false,
     entityTypeChangedByName: false
   },
   completingParty: null,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -875,6 +875,25 @@ export const useStore = defineStore('store', {
       return this.stateModel.tombstone.nameChangedToNumber
     },
 
+    /** Get the numbered name, after changing from named company */
+    getUpdatedName (): string {
+      if (this.getEntityType === CorpTypeCd.BC_ULC_COMPANY ||
+          this.getEntityType === CorpTypeCd.ULC_CONTINUE_IN) {
+        return 'UNLIMITED LIABILITY COMPANY'
+      }
+      if (this.getEntityType === CorpTypeCd.BC_CCC ||
+          this.getEntityType === CorpTypeCd.CCC_CONTINUE_IN) {
+        return 'COMMUNITY CONTRIBUTION COMPANY LTD.'
+      }
+      if (this.getEntityType === CorpTypeCd.BC_COMPANY ||
+          this.getEntityType === CorpTypeCd.CONTINUE_IN ||
+          this.getEntityType === CorpTypeCd.BENEFIT_COMPANY ||
+          this.getEntityType === CorpTypeCd.BEN_CONTINUE_IN) {
+        return 'LTD.'
+      }
+      return 'LTD.' // should never happen
+    },
+
     /** Whether business name has changed by type change. */
     isNameChangedByType (): boolean {
       return this.stateModel.tombstone.nameChangedByType

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -870,6 +870,11 @@ export const useStore = defineStore('store', {
       return (currentLegalName !== originalLegalName)
     },
 
+    /** Whether named business has changed to numbered. */
+    isNameChangedToNumber (): boolean {
+      return this.stateModel.tombstone.nameChangedToNumber
+    },
+
     /** Whether business name has changed by type change. */
     isNameChangedByType (): boolean {
       return this.stateModel.tombstone.nameChangedByType
@@ -1477,6 +1482,9 @@ export const useStore = defineStore('store', {
     },
     setNameRequestLegalName (legalName: string) {
       this.stateModel.nameRequestLegalName = legalName
+    },
+    setNameChangedToNumber (changedToNumber: boolean) {
+      this.stateModel.tombstone.nameChangedToNumber = changedToNumber
     },
     setNameChangedByType (changedByType: boolean) {
       this.stateModel.tombstone.nameChangedByType = changedByType

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -216,6 +216,8 @@ export default class Alteration extends Mixins(CommonMixin, FeeMixin, FilingTemp
 
   @Watch('hasBusinessNameChanged')
   @Watch('hasBusinessTypeChanged')
+  @Watch('getNameRequestLegalName')
+  @Watch('getEntityType')
   onBusinessTypeChanged () {
     const filingData = this.getFilingData
     // when altering from BC (or C) to ULC, use specific filing data

--- a/src/views/Alteration.vue
+++ b/src/views/Alteration.vue
@@ -220,13 +220,16 @@ export default class Alteration extends Mixins(CommonMixin, FeeMixin, FilingTemp
   @Watch('getEntityType')
   onBusinessTypeChanged () {
     const filingData = this.getFilingData
-    // when altering from BC (or C) to ULC, use specific filing data
+    // when altering from BC (or C) to ULC/CUL, use specific filing data
     if (
       (
         this.getOriginalLegalType === CorpTypeCd.BC_COMPANY ||
         this.getOriginalLegalType === CorpTypeCd.CONTINUE_IN
       ) &&
-      this.getEntityType === CorpTypeCd.BC_ULC_COMPANY
+      (
+        this.getEntityType === CorpTypeCd.BC_ULC_COMPANY ||
+        this.getEntityType === CorpTypeCd.ULC_CONTINUE_IN
+      )
     ) {
       this.setFilingData([{
         filingTypeCode: Resources.AlterationResourceBc.additionalFilingData.filingTypeCode,

--- a/tests/unit/ChangeBusinessType.spec.ts
+++ b/tests/unit/ChangeBusinessType.spec.ts
@@ -152,7 +152,8 @@ describe('Change Business Type component', () => {
     wrapper.vm.selectedEntityType = CorpTypeCd.BC_CCC
     wrapper.vm.submitTypeChange()
 
-    expect(wrapper.vm.getNameRequestLegalName).toBe('1234567 COMMUNITY CONTRIBUTION COMPANY LTD.')
+    // Less than 3 directors, fail to change legal type
+    expect(wrapper.vm.getNameRequestLegalName).toBe('1234567 LTD.')
 
     store.stateModel.entitySnapshot.businessInfo.legalType = CorpTypeCd.BC_ULC_COMPANY
     store.stateModel.entitySnapshot.businessInfo.legalName = '1234567 COMMUNITY CONTRIBUTION COMPANY'
@@ -183,6 +184,7 @@ describe('Change Business Type component', () => {
 
     const wrapper: any = mount(ChangeBusinessType, { vuetify })
     wrapper.vm.isEditingType = true
+    wrapper.vm.hasAttemptedSubmission = true
     await Vue.nextTick()
 
     expect(wrapper.find('#name-request-required-error').exists()).toBe(true)
@@ -216,6 +218,7 @@ describe('Change Business Type component', () => {
 
     const wrapper = mount(ChangeBusinessType, { vuetify })
     wrapper.setData({ isEditingType: true })
+    wrapper.setData({ hasAttemptedSubmission: true })
 
     await Vue.nextTick()
 

--- a/tests/unit/CorrectBusinessType.spec.ts
+++ b/tests/unit/CorrectBusinessType.spec.ts
@@ -89,9 +89,8 @@ describe('ChangeBusinessType in an Alteration', () => {
     // Click edit btn and open edit mode
     await wrapper.find('#btn-correct-business-type').trigger('click')
 
-    // Verify checkbox is displayed in edit mode and DONE btn is disabled
+    // Verify checkbox is displayed in edit mode
     expect(wrapper.find('#confirm-articles-checkbox').exists()).toBe(true)
-    expect(wrapper.find('#done-btn').attributes('disabled')).toBeTruthy()
 
     // Select the Confirm Articles checkbox
     await wrapper.find('#confirm-articles-checkbox').trigger('click')

--- a/tests/unit/EntityName.spec.ts
+++ b/tests/unit/EntityName.spec.ts
@@ -334,7 +334,7 @@ describe('Name Changes for a SP alteration', () => {
     expect(wrapper.find('.company-name').text()).toBe('My Benefit Company')
     expect(companyInfo.at(0).text()).toBe('BC Benefit Company')
     expect(companyInfo.at(1).text()).toBe('The name of this business will be the current Incorporation ' +
-      'Number followed by "B.C. Ltd."')
+      'Number followed by "B.C. LTD."')
   })
 
   it('displays the Name Request information when NR data changes', async () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24297

*Description of changes:*
- update error showing logic - now show error message after user clicks "Done" button in Type Change section
- update error message format - in a message box, red outline
- When there is an error, mark this section invalid
- update wording and language in the error message
- now enable change a named business to numbered, and change its legal type in one filing (Case 7)
- fixed a bug in the "Cancel" button in type change section: it'a BC, 1 director -> enter the NR to change to a CC -> show error: less than 3 director-> click Cancel -> the name change and type change were incorrectly accepted
- fixed the error: change Named business to Numbered -> showing wrong numbered name, always showed "B.C. Ltd". 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
