### PR TITLE
20947 - Fix limited restoration to full filing saves or resumes with company Name change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.12",
+  "version": "4.11.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.11.12",
+      "version": "4.11.13",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.12",
+  "version": "4.11.13",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/YourCompany/EntityName.vue
+++ b/src/components/common/YourCompany/EntityName.vue
@@ -444,6 +444,9 @@ export default class EntityName extends Mixins(CommonMixin, NameRequestMixin) {
 
   /** Updates UI when correct name options are done.  */
   nameChangeHandler (isSaved = false): void {
+    // check if this is a numbered company case:
+    // 1. no Name Request legal name exists (indicating not using NR)
+    // 2. business number exists (needed for numbered company name)
     const isNumberedName = !this.getNameRequestLegalName && !!this.getBusinessNumber
     this.hasCompanyNameChanged = this.isNewName || isNumberedName
 

--- a/tests/unit/EntityName.spec.ts
+++ b/tests/unit/EntityName.spec.ts
@@ -441,12 +441,6 @@ describe('Name Changes for Limited Restoration to Full', () => {
     expect(companyName.exists()).toBe(true)
     expect(companyName.text()).toBe('Mock Original Name')
 
-    console.log('Initial state:', {
-      shouldShowUndoButton: wrapper.vm.shouldShowUndoButton,
-      hasBusinessNameChanged: wrapper.vm.hasBusinessNameChanged,
-      isLimitedRestorationToFull: wrapper.vm.isLimitedRestorationToFull
-    })
-
     // Simulate changing to numbered company
     store.stateModel.nameRequestLegalName = null
 

--- a/tests/unit/EntityName.spec.ts
+++ b/tests/unit/EntityName.spec.ts
@@ -21,6 +21,8 @@ import { CorrectionResourceGp } from '@/resources/Correction/GP'
 import { CorrectionResourceSp } from '@/resources/Correction/SP'
 import { CorrectionResourceUlc } from '@/resources/Correction/ULC'
 
+import { RestorationResourceBc } from '@/resources/LimitedRestorationToFull/BC'
+
 import { SpecialResolutionResourceCp } from '@/resources/SpecialResolution/CP'
 
 import { createPinia, setActivePinia } from 'pinia'
@@ -396,5 +398,65 @@ describe('Name Changes by Type change', () => {
     expect(wrapper.text()).toMatch(
       /We have changed your numbered company\s+name based on the business type you selected\./
     )
+  })
+})
+
+describe('Name Changes for Limited Restoration to Full', () => {
+  let wrapper: any
+
+  const entitySnapshot = {
+    businessInfo: {
+      legalName: 'Mock Original Name',
+      legalType: CorpTypeCd.BC_COMPANY,
+      identifier: 'BC0884805'
+    }
+  }
+
+  beforeEach(() => {
+    // Set original business Data
+    store.stateModel.summaryMode = false
+    store.stateModel.nameRequestLegalName = entitySnapshot.businessInfo.legalName
+    store.stateModel.entitySnapshot = entitySnapshot as any
+    store.stateModel.tombstone.filingType = FilingTypes.RESTORATION
+    store.stateModel.tombstone.entityType = entitySnapshot.businessInfo.legalType
+    store.stateModel.tombstone.businessId = entitySnapshot.businessInfo.identifier
+    store.resourceModel = RestorationResourceBc
+
+    wrapper = mount(EntityName, {
+      vuetify,
+      computed: {
+        isLimitedRestorationToFull: () => true,
+        isNameChangedByType: () => false
+      }
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('displays Undo button after changing to a numbered company and resuming draft', async () => {
+    // Initial state
+    const companyName = wrapper.find('.company-name')
+    expect(companyName.exists()).toBe(true)
+    expect(companyName.text()).toBe('Mock Original Name')
+
+    console.log('Initial state:', {
+      shouldShowUndoButton: wrapper.vm.shouldShowUndoButton,
+      hasBusinessNameChanged: wrapper.vm.hasBusinessNameChanged,
+      isLimitedRestorationToFull: wrapper.vm.isLimitedRestorationToFull
+    })
+
+    // Simulate changing to numbered company
+    store.stateModel.nameRequestLegalName = null
+
+    await wrapper.vm.nameChangeHandler(true)
+    await Vue.nextTick()
+
+    // Verify show the Undo button
+    const button = wrapper.find('#btn-undo-company-name')
+    expect(button.exists()).toBe(true)
+    expect(button.text()).toBe('Undo')
+    expect(wrapper.vm.shouldShowUndoButton).toBe(true)
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20947

*Description of changes:*
- Added `isLimitedRestorationToFull` condition to `shouldShowUndoButton` logic
- Enhanced `nameChangeHandler` to properly handle numbered company names
- Added logic to set legal name for numbered companies to satisfy Legal API requirement
- Updated `shouldShowEditedLabel` to include Limited Restoration to Full scenario

*Notes:*
- This is a temporary easy solution until we can implement the refractory long-term fix in ticket[ #20827](https://github.com/bcgov/entity/issues/20827)

*Test Screenshots:*
Test locally with these scenarios:
- [x] CC (Community Contribution Company) `BC0884776`
- [x] BC (Limited Company) `BC0884805`
- [x] BEN (Benefit Companies) `BC0884873`
- [x] ULC (Unlimited Liability Company) `BC0884875`

**Before Fix** (Using Limited Company as an example):
 - After using the incorporation number as the name and clicking "save and resume later"
 - Upon resuming, the button incorrectly shows as "Edit"
<img width="1683" alt="image" src="https://github.com/user-attachments/assets/90d23b00-f151-4d95-b73d-b697b064a46f" />

 **After Fix**:
 - Scenario 1: Numbered Name
     - After save and resume, button correctly shows as "Undo"
![image](https://github.com/user-attachments/assets/78fc7a94-8973-43dc-bc7e-17dce4c6ca22)
 
- Scenario 2: Non-Numbered Name
     - After save and resume, button correctly shows as "Undo"
![image](https://github.com/user-attachments/assets/bb3cc2af-1109-42fd-bbca-fe8b60988396)

Results:
* Submitted this filing successfully
![image](https://github.com/user-attachments/assets/fea40cf0-5647-46d9-9ab8-5df44ea027df)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
