### PR TITLE
25243 - Disable Allowing Empty Articles Input in filing correction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.15",
+  "version": "4.11.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.11.15",
+      "version": "4.11.16",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.15",
+  "version": "4.11.16",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -721,6 +721,7 @@ export const useStore = defineStore('store', {
             this.getFlagsCompanyInfo.isValidOrgPersons &&
             this.getFlagsCompanyInfo.isValidAddress &&
             this.getFlagsCompanyInfo.isValidShareStructure &&
+            this.getFlagsCompanyInfo.isValidResolutionDate &&
             this.getFlagsReviewCertify.isValidDetailComment &&
             // don't check certify for staff correction
             this.getFlagsReviewCertify.isValidStaffPayment

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -710,6 +710,7 @@ export const useStore = defineStore('store', {
             this.getFlagsCompanyInfo.isValidAddress &&
             this.getFlagsCompanyInfo.isValidOrgPersons &&
             this.getFlagsCompanyInfo.isValidShareStructure &&
+            this.getFlagsCompanyInfo.isValidResolutionDate &&
             this.getFlagsReviewCertify.isValidDetailComment &&
             this.getFlagsReviewCertify.isValidCertify &&
             this.getFlagsReviewCertify.isValidStaffPayment

--- a/tests/unit/CoopCorrection.spec.ts
+++ b/tests/unit/CoopCorrection.spec.ts
@@ -465,6 +465,7 @@ describe('Coop Correction component', () => {
     expect(store.getFlagsCompanyInfo.isValidMemorandum).toBe(true)
     expect(store.getFlagsCompanyInfo.isValidSpecialResolution).toBe(true)
     expect(store.getFlagsCompanyInfo.isValidSpecialResolutionSignature).toBe(true)
+    expect(store.getFlagsCompanyInfo.isValidResolutionDate).toBe(true)
 
     // Non edit fields.
     expect(store.getFlagsReviewCertify.isValidDetailComment).toBe(false)

--- a/tests/unit/state-getters.spec.ts
+++ b/tests/unit/state-getters.spec.ts
@@ -125,6 +125,7 @@ describe('State Getters', () => {
     store.setValidComponent({ key: 'isValidAddress', value: true })
     store.setValidComponent({ key: 'isValidOrgPersons', value: true })
     store.setValidComponent({ key: 'isValidShareStructure', value: true })
+    store.setValidComponent({ key: 'isValidResolutionDate', value: true })
     store.setDetailValidity(true)
     store.setCertifyStateValidity(true)
     store.setStaffPaymentValidity(true)
@@ -171,6 +172,11 @@ describe('State Getters', () => {
     store.setStaffPaymentValidity(false)
     expect(vm.isCorrectionValid).toBe(false)
     store.setStaffPaymentValidity(true)
+
+    //check for resolution date flag alone affects validity
+    store.setValidComponent({ key: 'isValidResolutionDate', value: false })
+    expect(vm.isCorrectionValid).toBe(false)
+    store.setValidComponent({ key: 'isValidResolutionDate', value: true })
 
     // this getter should be true again
     expect(vm.isCorrectionValid).toBe(true)

--- a/tests/unit/state-getters.spec.ts
+++ b/tests/unit/state-getters.spec.ts
@@ -173,7 +173,7 @@ describe('State Getters', () => {
     expect(vm.isCorrectionValid).toBe(false)
     store.setStaffPaymentValidity(true)
 
-    //check for resolution date flag alone affects validity
+    // check for resolution date flag alone affects validity
     store.setValidComponent({ key: 'isValidResolutionDate', value: false })
     expect(vm.isCorrectionValid).toBe(false)
     store.setValidComponent({ key: 'isValidResolutionDate', value: true })


### PR DESCRIPTION
*Issue #:* bcgov/entity#25243

*Description of changes:* Disable Allowing Empty Articles Input in filing correction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
