### PR TITLE
25394 - Corrections filing update date format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.16",
+  "version": "4.11.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.11.16",
+      "version": "4.11.17",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.16",
+  "version": "4.11.17",
   "private": true,
   "appName": "Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -15,6 +15,7 @@ import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
 import { StaffPaymentOptions } from '@bcrs-shared-components/enums/'
 import { FilingTypeToName } from '@/utils'
 import { useStore } from '@/store/store'
+import DateUtilities from '@/services/date-utilities'
 
 /**
  * Mixin that provides the integration with the Legal API.
@@ -1455,14 +1456,13 @@ export default class FilingTemplateMixin extends DateMixin {
   /** The default (hard-coded first line) correction detail comment. */
   public get defaultCorrectionDetailComment (): string {
     const correctedFilingName = FilingTypeToName(this.getCorrectedFilingType)
-    return `Correction for ${correctedFilingName} filed on ${this.getCorrectedFilingDate}`
+    return `Correction for ${correctedFilingName} filed on ${this.correctedFilingDate}`
   }
 
-  // FUTURE: probably don't need this becayse Corrected Filing Date is already YYYY-MM-DD
-  /** The corrected filing date as YYYY-MM-DD. */
-  // private get correctedFilingDate (): string {
-  //   return this.getCorrectedFilingDate
-  // }
+  /** The corrected filing date as (Month Day, Year). */
+  private get correctedFilingDate (): string {
+    return DateUtilities.yyyyMmDdToPacificDate(this.getCorrectedFilingDate, true)
+  }
 
   /** The Contact Point object. */
   private get getContactPoint (): ContactPointIF {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25394

*Description of changes:*
In the Register Correction Application output, the date is part of the comment field (i.e. entire text is saved as comment in Comments table). For this reason, the date format needs to be updated in Edit UI.

Date format before was **2025-01-17**

Register Corrections Application filing:
![image](https://github.com/user-attachments/assets/73bfdc6a-9ea8-4998-917f-2dedad2658f5)

Ledger:
![image](https://github.com/user-attachments/assets/51c6573a-ef03-4aa5-8db1-1246235509f8)

Output:
![image](https://github.com/user-attachments/assets/bb670f91-5570-4bba-b047-469095659efc)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
