### PR TITLE
27529 - Update Name Change Text for Firms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.11.30",
+  "version": "4.11.31",
   "private": true,
   "appName": "Business Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/PeopleAndRoles/OrgPerson.vue
+++ b/src/components/common/PeopleAndRoles/OrgPerson.vue
@@ -36,13 +36,13 @@
                   <label class="sub-header">Person's Name</label>
 
                   <p
-                    v-if="(isExisting && isProprietor)"
+                    v-if="(isExisting && isProprietor && !isRoleStaff)"
                     class="info-text mb-0"
                   >
                     If the proprietor has changed their legal name, enter their new legal name.
                   </p>
                   <p
-                    v-if="(isExisting && isPartner)"
+                    v-if="(isExisting && isPartner && !isRoleStaff)"
                     class="info-text mb-0"
                   >
                     If the partner has changed their legal name, enter their new legal name.
@@ -80,7 +80,7 @@
                 <!-- Confirm name change -->
                 <v-expand-transition>
                   <article
-                    v-if="hasNameChanged(orgPerson)"
+                    v-if="hasNameChanged(orgPerson) && !isRoleStaff"
                     class="confirm-name-change mt-6"
                   >
                     <v-checkbox
@@ -273,7 +273,7 @@
                     <!-- Confirm name change -->
                     <v-expand-transition>
                       <v-checkbox
-                        v-if="hasNameChanged(orgPerson)"
+                        v-if="hasNameChanged(orgPerson) && !isRoleStaff"
                         id="confirm-name-change-checkbox"
                         v-model="orgPerson.confirmNameChange"
                         class="mt-6 pt-0"

--- a/src/resources/Change/SP.ts
+++ b/src/resources/Change/SP.ts
@@ -22,9 +22,8 @@ export const ChangeResourceSp: ResourceIF = {
     orgPersonInfo: {
       orgPersonLabel: 'Proprietor',
       orgTypesLabel: 'Business or Corporation',
-      subtitle: 'You can change the legal name, mailing and delivery addresses and the email address of the ' +
-        'individual proprietor. To change to a different proprietor, you must form a new business with that ' +
-        'proprietor and dissolve this registration.',
+      subtitle: 'You can update the proprietor\'s information below. If ownership of the business has changed, ' +
+      'a new registration is required.',
       helpSection: {
         header: 'Need Help? Contact Us',
         helpText: [

--- a/src/resources/Conversion/SP.ts
+++ b/src/resources/Conversion/SP.ts
@@ -22,9 +22,8 @@ export const ConversionResourceSp: ResourceIF = {
     orgPersonInfo: {
       orgPersonLabel: 'Proprietor',
       orgTypesLabel: 'Business or Corporation',
-      subtitle: 'You can change the legal name, mailing and delivery addresses and the email address of the ' +
-        'individual proprietor. To change to a different proprietor, you must form a new business with that ' +
-        'proprietor and dissolve this registration.'
+      subtitle: 'You can update the proprietor\'s information below. If ownership of the business has changed, ' +
+      'a new registration is required.'
     }
   },
   certifyClause: null // not used

--- a/src/resources/Correction/SP.ts
+++ b/src/resources/Correction/SP.ts
@@ -23,9 +23,8 @@ export const CorrectionResourceSp: ResourceIF = {
     orgPersonInfo: {
       orgPersonLabel: 'Proprietor',
       orgTypesLabel: 'Business or Corporation',
-      subtitle: 'You can change the legal name, mailing and delivery addresses and the email address of the ' +
-        'individual proprietor. To change to a different proprietor, you must form a new business with that ' +
-        'proprietor and dissolve this registration.'
+      subtitle: 'You can update the proprietor\'s information below. If ownership of the business has changed, ' +
+      'a new registration is required.'
     },
     nameRequestTypes: [
       NrRequestActionCodes.CHANGE_NAME

--- a/tests/unit/Change.spec.ts
+++ b/tests/unit/Change.spec.ts
@@ -275,7 +275,8 @@ describe('Change component', () => {
     const wrapper = shallowMount(Change, { vuetify })
 
     expect((wrapper.vm as any).firmChangeResource.changeData.orgPersonInfo.subtitle)
-      .toContain('You can change the legal name, mailing and delivery')
+      .toContain('You can update the proprietor\'s information below. ' +
+        'If ownership of the business has changed, a new registration is required.')
 
     wrapper.destroy()
   })

--- a/tests/unit/Change.spec.ts
+++ b/tests/unit/Change.spec.ts
@@ -275,8 +275,8 @@ describe('Change component', () => {
     const wrapper = shallowMount(Change, { vuetify })
 
     expect((wrapper.vm as any).firmChangeResource.changeData.orgPersonInfo.subtitle)
-      .toContain('You can update the proprietor\'s information below. ' +
-        'If ownership of the business has changed, a new registration is required.')
+      .toContain('You can update the proprietor\'s information below. If ownership of the business has changed, ' +
+        'a new registration is required.')
 
     wrapper.destroy()
   })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#27519

*Description of changes:*
- Update intro text for SP (change, conversion and correction)
Before:
![image](https://github.com/user-attachments/assets/89398d27-1c37-4690-b9b7-72354c9ea92f)

After:
![image](https://github.com/user-attachments/assets/b030210d-9909-430a-a26a-d305c3eeb283)
- Remove legal text above name fields, checkbox under name fields and name change validation for **staff**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
