### PR TITLE
29238 - Addresses for Extension of Restoration Should not be Editable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.13.1",
+  "version": "4.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.13.1",
+      "version": "4.13.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.13.1",
+  "version": "4.13.2",
   "private": true,
   "appName": "Business Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -12,12 +12,8 @@ export * from './state-interface'
 export * from './rules-memorandum-interfaces'
 
 // External interfaces
-// NB: importing EmptyAddress doesn't work in local components
 export type {
   BusinessLookupIF,
   BusinessLookupResultIF
 } from '@bcrs-shared-components/interfaces'
 
-export {
-  EmptyAddress
-} from '@bcrs-shared-components/interfaces'

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -12,7 +12,12 @@ export * from './state-interface'
 export * from './rules-memorandum-interfaces'
 
 // External interfaces
+// NB: importing EmptyAddress doesn't work in local components
 export type {
   BusinessLookupIF,
   BusinessLookupResultIF
+} from '@bcrs-shared-components/interfaces'
+
+export {
+  EmptyAddress
 } from '@bcrs-shared-components/interfaces'

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -16,4 +16,3 @@ export type {
   BusinessLookupIF,
   BusinessLookupResultIF
 } from '@bcrs-shared-components/interfaces'
-

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import { ConfirmDialogType } from '@/interfaces/'
+import { isEmpty } from 'lodash'
+import { AddressIF, ConfirmDialogType } from '@/interfaces/'
 
 /**
  * Mixin that provides some useful common utilities.
@@ -75,6 +76,22 @@ export default class CommonMixin extends Vue {
   /** Changes the specified prop to uppercase. */
   uppercase (prop: string): void {
     this[prop] = this[prop]?.toUpperCase()
+  }
+
+  /**
+   * Whether the address object is empty or with only with default input values.
+   * See also EmptyAddress.
+   */
+  isEmptyAddress (address: AddressIF): boolean {
+    return isEmpty(address) || (
+      !address.addressCity &&
+      (!address.addressCountry || address.addressCountry === 'CA') &&
+      (!address.addressRegion || address.addressRegion === 'BC') &&
+      !address.deliveryInstructions &&
+      !address.postalCode &&
+      !address.streetAddress &&
+      !address.streetAddressAdditional
+    )
   }
 
   /**

--- a/src/views/LimitedRestorationExtension.vue
+++ b/src/views/LimitedRestorationExtension.vue
@@ -387,7 +387,7 @@ export default class LimitedRestorationExtension extends Mixins(
     const registeredExists = officeAddresses.registeredOffice &&
       (!this.isEmptyAddress(officeAddresses.registeredOffice.mailingAddress) ||
       !this.isEmptyAddress(officeAddresses.registeredOffice.deliveryAddress))
-    console.log('hasOfficeAddresses', officeAddresses, registeredExists)
+
     const recordsExists = officeAddresses.recordsOffice &&
       (!this.isEmptyAddress(officeAddresses.recordsOffice.mailingAddress) ||
       !this.isEmptyAddress(officeAddresses.recordsOffice.deliveryAddress))

--- a/src/views/LimitedRestorationExtension.vue
+++ b/src/views/LimitedRestorationExtension.vue
@@ -36,7 +36,7 @@
               <NameTranslation />
             </div>
             <RecognitionDateTime />
-            <OfficeAddresses />
+            <OfficeAddresses :isSummaryView="hasOfficeAddresses" />
             <BusinessContactInfo />
             <FolioInformation />
           </YourCompanyWrapper>
@@ -380,6 +380,20 @@ export default class LimitedRestorationExtension extends Mixins(
     return currentApplicant[0]?.officer.email
   }
 
+  get hasOfficeAddresses (): boolean {
+    const officeAddresses = this.getOfficeAddresses
+    if (!officeAddresses) return false
+
+    const registeredExists = officeAddresses.registeredOffice &&
+      (!this.isEmptyAddress(officeAddresses.registeredOffice.mailingAddress) ||
+      !this.isEmptyAddress(officeAddresses.registeredOffice.deliveryAddress))
+    console.log('hasOfficeAddresses', officeAddresses, registeredExists)
+    const recordsExists = officeAddresses.recordsOffice &&
+      (!this.isEmptyAddress(officeAddresses.recordsOffice.mailingAddress) ||
+      !this.isEmptyAddress(officeAddresses.recordsOffice.deliveryAddress))
+
+    return registeredExists || recordsExists
+  }
   /** Emits Fetch Error event. */
   @Emit('fetchError')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tests/unit/OfficeAddresses.spec.ts
+++ b/tests/unit/OfficeAddresses.spec.ts
@@ -1125,6 +1125,16 @@ describe('For Special resolution', () => {
   })
 })
 
+// For Limited Restoration Extension
+it('does not display the edit button when isSummaryView is true', async () => {
+  const wrapper = mount(OfficeAddresses, { vuetify, propsData: { isSummaryView: false } })
+
+  const editBtn = wrapper.find('#btn-correct-office-addresses')
+
+  // The button should not exist
+  expect(editBtn.exists()).toBe(false)
+})
+
 describe('verify updateAddress()', () => {
   let wrapper: any
   let vm: any


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29238 

*Description of changes:*
- Make office addresses not editable if they already exist for Limited Restoration Extension

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
