### PR TITLE
30238 cleaned up some env keys and fixed breadcrumbs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,17 @@
-# Base Path
 VUE_APP_PATH="/"
 
-#vaults Shared
+# vaults canadapost
 VUE_APP_ADDRESS_COMPLETE_KEY=
 
-#vaults web-url
+# vaults web-url
 VUE_APP_REGISTRY_HOME_URL="https://dev.bcregistry.gov.bc.ca/"
 VUE_APP_AUTH_WEB_URL="https://dev.account.bcregistry.gov.bc.ca/"
-VUE_APP_BUSINESSES_URL="https://dev.account.bcregistry.gov.bc.ca/"
 VUE_APP_BUSINESS_DASH_URL="https://dev.business-dashboard.bcregistry.gov.bc.ca/"
+VUE_APP_BUSINESS_REGISTRY_URL="https://dev.business-registry-dashboard.bcregistry.gov.bc.ca/"
 VUE_APP_NAME_REQUEST_URL="https://dev.names.bcregistry.gov.bc.ca/"
 VUE_APP_SITEMINDER_LOGOUT_URL="https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi"
 
-#vaults API
+# vaults API
 # we still need VUE_APP_AUTH_API_URL for SbcHeader common component
 VUE_APP_AUTH_API_URL="https://auth-api-dev-142173140222.northamerica-northeast1.run.app"
 VUE_APP_AUTH_API_GW_URL="https://test.api.connect.gov.bc.ca/auth-dev"
@@ -36,16 +35,16 @@ VUE_APP_REGISTRIES_SEARCH_API_KEY=
 VUE_APP_STATUS_API_URL="https://status-api-dev.apps.gold.devops.gov.bc.ca"
 VUE_APP_STATUS_API_VERSION="/api/v1"
 
-#vaults launchdarkly
+# vaults launchdarkly
 VUE_APP_BUSINESS_EDIT_LD_CLIENT_ID="642af8daefad6f134479c602"
 
-#vaults keycloak
+# vaults keycloak
 VUE_APP_KEYCLOAK_AUTH_URL="https://dev.loginproxy.gov.bc.ca/auth"
 VUE_APP_KEYCLOAK_REALM="bcregistry"
 VUE_APP_KEYCLOAK_CLIENTID="entity-web"
 
-#vaults sentry
+# vaults sentry
 VUE_APP_SENTRY_DSN=
 
-#vaults hotjar
+# vaults hotjar
 VUE_APP_HOTJAR_ID=

--- a/devops/vaults.env
+++ b/devops/vaults.env
@@ -1,18 +1,17 @@
-# Base Path Openshift: /businesses/edit Firebase: /
 VUE_APP_PATH="/"
 
-#vaults Shared
+# vaults canadapost
 VUE_APP_ADDRESS_COMPLETE_KEY="op://canadapost/$APP_ENV/address-key/ADDRESS_COMPLETE_KEY"
 
-#vaults web-url
+# vaults web-url
 VUE_APP_REGISTRY_HOME_URL="op://web-url/$APP_ENV/registry/REGISTRY_HOME_URL"
 VUE_APP_AUTH_WEB_URL="op://web-url/$APP_ENV/auth-web/AUTH_WEB_URL"
-VUE_APP_BUSINESSES_URL="op://web-url/$APP_ENV/business/BUSINESSES_URL"
 VUE_APP_BUSINESS_DASH_URL="op://web-url/$APP_ENV/business-dash/BUSINESS_DASH_URL"
+VUE_APP_BUSINESS_REGISTRY_URL="op://web-url/$APP_ENV/business-registry-ui/BUSINESS_REGISTRY_URL"
 VUE_APP_NAME_REQUEST_URL="op://web-url/$APP_ENV/name-request/NAME_REQUEST_URL"
 VUE_APP_SITEMINDER_LOGOUT_URL="op://web-url/$APP_ENV/siteminder/SITEMINDER_LOGOUT_URL"
 
-#vaults API
+# vaults API
 # we still need VUE_APP_AUTH_API_URL for SbcHeader common component
 VUE_APP_AUTH_API_URL="op://API/$APP_ENV/auth-api/AUTH_API_URL"
 VUE_APP_AUTH_API_GW_URL="op://API/$APP_ENV/auth-api/AUTH_API_GW_URL"
@@ -36,16 +35,16 @@ VUE_APP_REGISTRIES_SEARCH_API_KEY="op://API/$APP_ENV/registries-search-api/REGIS
 VUE_APP_STATUS_API_URL="op://API/$APP_ENV/status-api/STATUS_API_URL"
 VUE_APP_STATUS_API_VERSION="op://API/$APP_ENV/status-api/STATUS_API_VERSION"
 
-#vaults launchdarkly
+# vaults launchdarkly
 VUE_APP_BUSINESS_EDIT_LD_CLIENT_ID="op://launchdarkly/$APP_ENV/business-edit/BUSINESS_EDIT_LD_CLIENT_ID"
 
-#vaults keycloak
+# vaults keycloak
 VUE_APP_KEYCLOAK_AUTH_URL="op://keycloak/$APP_ENV/base/KEYCLOAK_AUTH_BASE_URL"
 VUE_APP_KEYCLOAK_REALM="op://keycloak/$APP_ENV/base/KEYCLOAK_REALMNAME"
 VUE_APP_KEYCLOAK_CLIENTID="op://keycloak/$APP_ENV/entity-web/UI_KEYCLOAK_RESOURCE_NAME"
 
-#vaults sentry
+# vaults sentry
 VUE_APP_SENTRY_DSN="op://sentry/$APP_ENV/entity/SENTRY_DSN"
 
-#vaults hotjar (hotjar id - ready to use)
+# vaults hotjar (hotjar id - ready to use)
 VUE_APP_HOTJAR_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.13.7",
+  "version": "4.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.13.7",
+      "version": "4.13.8",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.13.7",
+  "version": "4.13.8",
   "private": true,
   "appName": "Business Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,6 @@ start().catch(async (error) => {
   window.alert('There was an error starting this page. (See console for details.)\n' +
     'Please try again later.')
 
-  // try to navigate to Business Registry home page
-  Navigate(sessionStorage.getItem('BUSINESSES_URL'))
+  // try to navigate to Business Registry Dashboard
+  Navigate(sessionStorage.getItem('BUSINESS_REGISTRY_URL'))
 })

--- a/src/resources/BreadCrumbResources.ts
+++ b/src/resources/BreadCrumbResources.ts
@@ -33,7 +33,7 @@ export function getRegistryDashboardBreadcrumb (): BreadcrumbIF {
 export function getMyBusinessRegistryBreadcrumb (): BreadcrumbIF {
   return {
     text: 'My Business Registry',
-    href: `${sessionStorage.getItem('BUSINESSES_URL')}account/${store.getAccountId}/business`
+    href: `${sessionStorage.getItem('BUSINESS_REGISTRY_URL')}account/${store.getAccountId}`
   }
 }
 
@@ -41,6 +41,6 @@ export function getMyBusinessRegistryBreadcrumb (): BreadcrumbIF {
 export function getStaffDashboardBreadcrumb (): BreadcrumbIF {
   return {
     text: 'Staff Dashboard',
-    href: `${sessionStorage.getItem('BUSINESSES_URL')}staff/dashboard/active`
+    href: `${sessionStorage.getItem('AUTH_WEB_URL')}staff/dashboard/active`
   }
 }

--- a/src/utils/FetchConfig.ts
+++ b/src/utils/FetchConfig.ts
@@ -24,8 +24,8 @@ export function FetchConfig (): void {
   const nameRequestUrl: string = import.meta.env.VUE_APP_NAME_REQUEST_URL
   sessionStorage.setItem('NAME_REQUEST_URL', nameRequestUrl)
 
-  const businessesUrl: string = import.meta.env.VUE_APP_BUSINESSES_URL
-  sessionStorage.setItem('BUSINESSES_URL', businessesUrl)
+  const businessRegistryUrl: string = import.meta.env.VUE_APP_BUSINESS_REGISTRY_URL
+  sessionStorage.setItem('BUSINESS_REGISTRY_URL', businessRegistryUrl)
 
   const businessDashUrl: string = import.meta.env.VUE_APP_BUSINESS_DASH_URL
   sessionStorage.setItem('BUSINESS_DASH_URL', businessDashUrl)

--- a/tests/unit/FetchConfig.spec.ts
+++ b/tests/unit/FetchConfig.spec.ts
@@ -13,9 +13,9 @@ describe('Fetch Config', () => {
   import.meta.env.VUE_APP_AUTH_API_GW_URL = 'https://auth-api-gw.url'
   import.meta.env.VUE_APP_AUTH_API_VERSION = '/auth-api-version'
   import.meta.env.VUE_APP_AUTH_WEB_URL = 'https://auth-web.url'
-  import.meta.env.VUE_APP_BUSINESSES_URL = 'https://businesses.url'
   import.meta.env.VUE_APP_BUSINESS_EDIT_LD_CLIENT_ID = 'ld-client-id'
   import.meta.env.VUE_APP_BUSINESS_DASH_URL = 'https://business-dash.url'
+  import.meta.env.VUE_APP_BUSINESS_REGISTRY_URL = 'https://business-registry.url'
   import.meta.env.VUE_APP_LEGAL_API_URL = 'https://legal-api.url'
   import.meta.env.VUE_APP_LEGAL_API_VERSION_2 = '/legal-api-version-2'
   // import.meta.env.VUE_APP_BUSINESS_API_GW_URL = 'https://business-api-gw.url'
@@ -51,8 +51,8 @@ describe('Fetch Config', () => {
     // verify data
     expect(sessionStorage.getItem('AUTH_API_GW_URL')).toBe('https://auth-api-gw.url/auth-api-version/')
     expect(sessionStorage.getItem('AUTH_WEB_URL')).toBe('https://auth-web.url')
-    expect(sessionStorage.getItem('BUSINESSES_URL')).toBe('https://businesses.url')
     expect(sessionStorage.getItem('BUSINESS_DASH_URL')).toBe('https://business-dash.url')
+    expect(sessionStorage.getItem('BUSINESS_REGISTRY_URL')).toBe('https://business-registry.url')
     expect(sessionStorage.getItem('LEGAL_API_URL')).toBe('https://legal-api.url/legal-api-version-2/')
     // expect(sessionStorage.getItem('BUSINESS_API_GW_URL')).toBe('https://business-api-gw.url/business-api-version-2/')
     expect(sessionStorage.getItem('NAICS_URL')).toBe('https://naics-api.url/naics-api-version/')


### PR DESCRIPTION
*Issue #:* bcgov/entity#30238

*Description of changes:*
- deleted obsolete key VUE_APP_BUSINESSES_URL
- added key VUE_APP_BUSINESS_REGISTRY_URL
- app version = 4.13.8
- fixed MBR breadcrumb URL
- fixed staff dashboard breadcrumb URL
- updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).