### PR TITLE
Certify - uxa tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.17.5",
+  "version": "4.17.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.17.5",
+      "version": "4.17.6",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",
@@ -14,7 +14,7 @@
         "@bcrs-shared-components/base-address": "2.2.4",
         "@bcrs-shared-components/breadcrumb": "2.1.5",
         "@bcrs-shared-components/business-lookup": "1.3.15",
-        "@bcrs-shared-components/certify": "2.2.3",
+        "@bcrs-shared-components/certify": "2.2.4",
         "@bcrs-shared-components/completing-party": "2.1.100",
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
         "@bcrs-shared-components/contact-info": "1.2.76",
@@ -351,9 +351,9 @@
       "license": "MIT"
     },
     "node_modules/@bcrs-shared-components/certify": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/certify/-/certify-2.2.3.tgz",
-      "integrity": "sha512-HB7WS8Q8Qqq3YPeDYfa1E8BY6UAkCCzznkBFSOInkX3cg24+/vg1BB4FvPqMnQOGWSakXT8cRafmp8l6TEnXuA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/certify/-/certify-2.2.4.tgz",
+      "integrity": "sha512-Sp4OY2fFDkJQK5/tTJ1AQeO+AUMYQ9CGe8Pb2cLqdhVC778AISsjIOg55ZUClAqHWIyADObypMSTFYZXX2W3Kw==",
       "dependencies": {
         "@bcrs-shared-components/interfaces": "^1.1.41",
         "dompurify": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.17.5",
+  "version": "4.17.6",
   "private": true,
   "appName": "Business Edit UI",
   "sbcName": "SBC Common Components",
@@ -23,7 +23,7 @@
     "@bcrs-shared-components/base-address": "2.2.4",
     "@bcrs-shared-components/breadcrumb": "2.1.5",
     "@bcrs-shared-components/business-lookup": "1.3.15",
-    "@bcrs-shared-components/certify": "2.2.3",
+    "@bcrs-shared-components/certify": "2.2.4",
     "@bcrs-shared-components/completing-party": "2.1.100",
     "@bcrs-shared-components/confirm-dialog": "1.2.1",
     "@bcrs-shared-components/contact-info": "1.2.76",

--- a/src/components/common/CertifySection.vue
+++ b/src/components/common/CertifySection.vue
@@ -89,7 +89,7 @@ export default class CertifySection extends Mixins(DateMixin) {
 
   /** Get the entity type in readable format */
   get readableEntityType (): string {
-    return (this.getResource?.certifyText || GetCorpFullDescription(this.getEntityType))
+    return GetCorpFullDescription(this.getEntityType)
   }
 
   /** Get the certify resource message */

--- a/src/resources/Alteration/BC.ts
+++ b/src/resources/Alteration/BC.ts
@@ -56,6 +56,5 @@ export const AlterationResourceBc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Alteration/BEN.ts
+++ b/src/resources/Alteration/BEN.ts
@@ -45,6 +45,5 @@ export const AlterationResourceBen: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Alteration/C.ts
+++ b/src/resources/Alteration/C.ts
@@ -56,6 +56,5 @@ export const AlterationResourceC: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Alteration/CBEN.ts
+++ b/src/resources/Alteration/CBEN.ts
@@ -45,6 +45,5 @@ export const AlterationResourceCben: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Alteration/CC.ts
+++ b/src/resources/Alteration/CC.ts
@@ -28,6 +28,5 @@ export const AlterationResourceCc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Alteration/CCC.ts
+++ b/src/resources/Alteration/CCC.ts
@@ -28,6 +28,5 @@ export const AlterationResourceCcc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Alteration/CUL.ts
+++ b/src/resources/Alteration/CUL.ts
@@ -45,6 +45,5 @@ export const AlterationResourceCul: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Alteration/ULC.ts
+++ b/src/resources/Alteration/ULC.ts
@@ -45,6 +45,5 @@ export const AlterationResourceUlc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Correction/BC.ts
+++ b/src/resources/Correction/BC.ts
@@ -30,6 +30,5 @@ export const CorrectionResourceBc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Correction/BEN.ts
+++ b/src/resources/Correction/BEN.ts
@@ -30,6 +30,5 @@ export const CorrectionResourceBen: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Correction/C.ts
+++ b/src/resources/Correction/C.ts
@@ -30,6 +30,5 @@ export const CorrectionResourceC: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Correction/CBEN.ts
+++ b/src/resources/Correction/CBEN.ts
@@ -30,6 +30,5 @@ export const CorrectionResourceCben: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Correction/CC.ts
+++ b/src/resources/Correction/CC.ts
@@ -30,6 +30,5 @@ export const CorrectionResourceCc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Correction/CCC.ts
+++ b/src/resources/Correction/CCC.ts
@@ -30,6 +30,5 @@ export const CorrectionResourceCcc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Correction/CUL.ts
+++ b/src/resources/Correction/CUL.ts
@@ -30,6 +30,5 @@ export const CorrectionResourceCul: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/Correction/ULC.ts
+++ b/src/resources/Correction/ULC.ts
@@ -30,6 +30,5 @@ export const CorrectionResourceUlc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationExtension/BC.ts
+++ b/src/resources/LimitedRestorationExtension/BC.ts
@@ -25,6 +25,5 @@ export const RestorationResourceBc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationExtension/BEN.ts
+++ b/src/resources/LimitedRestorationExtension/BEN.ts
@@ -25,6 +25,5 @@ export const RestorationResourceBen: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationExtension/C.ts
+++ b/src/resources/LimitedRestorationExtension/C.ts
@@ -25,6 +25,5 @@ export const RestorationResourceC: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationExtension/CBEN.ts
+++ b/src/resources/LimitedRestorationExtension/CBEN.ts
@@ -25,6 +25,5 @@ export const RestorationResourceCben: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationExtension/CC.ts
+++ b/src/resources/LimitedRestorationExtension/CC.ts
@@ -25,6 +25,5 @@ export const RestorationResourceCc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationExtension/CCC.ts
+++ b/src/resources/LimitedRestorationExtension/CCC.ts
@@ -25,6 +25,5 @@ export const RestorationResourceCcc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationExtension/CUL.ts
+++ b/src/resources/LimitedRestorationExtension/CUL.ts
@@ -25,6 +25,5 @@ export const RestorationResourceCul: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationExtension/ULC.ts
+++ b/src/resources/LimitedRestorationExtension/ULC.ts
@@ -25,6 +25,5 @@ export const RestorationResourceUlc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationToFull/BC.ts
+++ b/src/resources/LimitedRestorationToFull/BC.ts
@@ -33,6 +33,5 @@ export const RestorationResourceBc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationToFull/BEN.ts
+++ b/src/resources/LimitedRestorationToFull/BEN.ts
@@ -33,6 +33,5 @@ export const RestorationResourceBen: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationToFull/C.ts
+++ b/src/resources/LimitedRestorationToFull/C.ts
@@ -33,6 +33,5 @@ export const RestorationResourceC: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationToFull/CBEN.ts
+++ b/src/resources/LimitedRestorationToFull/CBEN.ts
@@ -33,6 +33,5 @@ export const RestorationResourceCben: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationToFull/CC.ts
+++ b/src/resources/LimitedRestorationToFull/CC.ts
@@ -33,6 +33,5 @@ export const RestorationResourceCc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationToFull/CCC.ts
+++ b/src/resources/LimitedRestorationToFull/CCC.ts
@@ -33,6 +33,5 @@ export const RestorationResourceCcc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationToFull/CUL.ts
+++ b/src/resources/LimitedRestorationToFull/CUL.ts
@@ -33,6 +33,5 @@ export const RestorationResourceCul: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }

--- a/src/resources/LimitedRestorationToFull/ULC.ts
+++ b/src/resources/LimitedRestorationToFull/ULC.ts
@@ -33,6 +33,5 @@ export const RestorationResourceUlc: ResourceIF = {
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +
     'of a material fact in a record submitted to the Corporate Registry for filing. ' +
-    'See section 427 of the Business Corporations Act.',
-  certifyText: 'business'
+    'See section 427 of the <em>Business Corporations Act.</em>'
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31842

*Description of changes:*
- pass in corp desc instead of 'business' to certify component for corps filings
- add emphasis on act name in certify stmt
- pull in newer version of common certify with correct text font-size

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
