### PR TITLE
33555 - Share structure name validation showing while field is focused

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.17.12",
+  "version": "4.17.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.17.12",
+      "version": "4.17.13",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.17.12",
+  "version": "4.17.13",
   "private": true,
   "appName": "Business Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/ShareStructure/EditShareStructure.vue
+++ b/src/components/common/ShareStructure/EditShareStructure.vue
@@ -44,6 +44,7 @@
                   :rules="nameRules"
                   suffix="Shares"
                   persistent-hint
+                  @focus="onNameFocus()"
                   @blur="onNameBlur()"
                 />
 
@@ -291,7 +292,7 @@ export default class EditShareStructure extends Mixins(CurrencyLookupMixin) {
   private hasSeriesShares = false
   private maxNumberOfShares = '' // v-model, which is converted to number before saving
   private parValue = '' // v-model, which is converted to number before saving
-  private nameTouched = false // tracks whether the name field has lost focus at least once
+  private nameTouched = false // true once the name field has settled (blurred); reset while it has focus
 
   private excludedWordsListForClass: string [] = ['share', 'shares', 'value']
   private excludedWordsListForSeries: string [] = ['share', 'shares']
@@ -547,6 +548,13 @@ export default class EditShareStructure extends Mixins(CurrencyLookupMixin) {
     }
   }
 
+  /** While the name field has focus, suppress space validation and clear any space error shown. */
+  protected onNameFocus (): void {
+    this.nameTouched = false
+    this.$nextTick(() => this.$refs.shareNameInput.validate())
+  }
+
+  /** Once the name field loses focus, enable space validation so any space error is shown. */
   protected onNameBlur (): void {
     this.nameTouched = true
     this.$nextTick(() => this.$refs.shareNameInput.validate())

--- a/tests/unit/EditShareStructure.spec.ts
+++ b/tests/unit/EditShareStructure.spec.ts
@@ -593,6 +593,27 @@ describe('Edit Share Structure component', () => {
     wrapper.destroy()
   })
 
+  it('Hides the invalid spaces error again when the name field is re-focused', async () => {
+    const shareClass = createShareStructure(null, 1, 'Class', 'Class A', true, 100, true, 0.5, 'CAD', true)
+    const wrapper = createComponent(shareClass, -1, 1, null, [])
+    const input = wrapper.find(nameSelector)
+
+    // first blur surfaces the trailing-space error
+    input.setValue('Class B ')
+    input.trigger('blur')
+    await Vue.nextTick()
+    await Vue.nextTick()
+    expect(wrapper.text()).toContain('Invalid spaces')
+
+    // re-focusing to edit clears it (the focus event does not propagate through Vuetify in jsdom,
+    // so invoke the handler directly to exercise the re-focus reset logic)
+    ;(wrapper.vm as any).onNameFocus()
+    await Vue.nextTick()
+    await Vue.nextTick()
+    expect(wrapper.text()).not.toContain('Invalid spaces')
+    wrapper.destroy()
+  })
+
   describe('OTHER currency handling', () => {
     it('shows the "Currency Update" alert when editing a class with OTHER currency', async () => {
       const shareClass: ShareClassIF = {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33555

*Description of changes:*

Fixed the name field showing space validation after you click out, and resume typing again when you click back in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).