### PR TITLE
chore: upgrade packageManager to pnpm@11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,6 @@
   },
   "engines": {
     "node": ">=24"
-  }
+  },
+  "packageManager": "pnpm@11.9.0"
 }


### PR DESCRIPTION
Sets `packageManager` to `pnpm@11.9.0` in `package.json` as part of the pnpm v11 upgrade (ticket #33875).

The Cloud Build CI trigger has already been updated to use `pnpm@11.9.0`.