### PR TITLE
Add missing 'of' in Benefit Company Articles alteration text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-edit-ui",
-  "version": "4.17.15",
+  "version": "4.17.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-edit-ui",
-      "version": "4.17.15",
+      "version": "4.17.16",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/action-chip": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-edit-ui",
-  "version": "4.17.15",
+  "version": "4.17.16",
   "private": true,
   "appName": "Business Edit UI",
   "sbcName": "SBC Common Components",

--- a/src/resources/Alteration/BEN.ts
+++ b/src/resources/Alteration/BEN.ts
@@ -40,7 +40,7 @@ export const AlterationResourceBen: ResourceIF = {
       }
     ],
     articleTitle: 'Benefit Company Articles',
-    articleInfo: `The company has completed a set Benefit Company Articles containing a benefit provision, 
+    articleInfo: `The company has completed a set of Benefit Company Articles containing a benefit provision,
       and a copy of these articles has been added to the company's record book.`
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +

--- a/src/resources/Alteration/CBEN.ts
+++ b/src/resources/Alteration/CBEN.ts
@@ -40,7 +40,7 @@ export const AlterationResourceCben: ResourceIF = {
       }
     ],
     articleTitle: 'Benefit Company Articles',
-    articleInfo: `The company has completed a set Benefit Company Articles containing a benefit provision, 
+    articleInfo: `The company has completed a set of Benefit Company Articles containing a benefit provision,
       and a copy of these articles has been added to the company's record book.`
   },
   certifyClause: 'Note: It is an offence to make a false or misleading statement in respect ' +


### PR DESCRIPTION
**Issue #:** bcgov/entity#34352

## Description
"has completed a set Benefit Company Articles" — missing "of". Now reads "has completed a set of Benefit Company Articles".

